### PR TITLE
feat(#5): Story 1.4 — Zod Validation Schemas

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema } from './validation'
+
+describe('validation', () => {
+  it('laneSchema valid input passes', () => {
+    const validData = {
+      name: 'Lacrosse',
+      emoji: '🥍',
+      targetPerWeek: 5
+    }
+    const result = laneSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.name).toBe('Lacrosse')
+    }
+  })
+
+  it('laneSchema empty name fails', () => {
+    const invalidData = {
+      name: '   ',
+      emoji: '🥍',
+      targetPerWeek: 5
+    }
+    const result = laneSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('laneSchema name too long fails', () => {
+    const invalidData = {
+      name: 'A'.repeat(41),
+      emoji: '🥍',
+      targetPerWeek: 5
+    }
+    const result = laneSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('checkInSchema valid input passes', () => {
+    const date = new Date(Date.UTC(2023, 10, 1, 12, 0, 0))
+    const validData = {
+      laneId: 'clp1234567890abcdefghij',
+      date: date,
+      isRest: true,
+      note: 'Feeling good'
+    }
+    const result = checkInSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.date.getUTCMonth()).toBe(10)
+      expect(result.data.laneId).toBe('clp1234567890abcdefghij')
+    }
+  })
+
+  it('checkInSchema missing laneId fails', () => {
+    const invalidData = {
+      date: new Date(Date.UTC(2023, 10, 1)),
+      isRest: false
+    }
+    const result = checkInSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('bossBattleSchema empty selfReport fails', () => {
+    const invalidData = {
+      laneId: 'clp1234567890abcdefghij',
+      weekStarting: new Date(Date.UTC(2023, 10, 1)),
+      selfReport: '   '
+    }
+    const resultParse = bossBattleSchema.safeParse(invalidData)
+    expect(resultParse.success).toBe(false)
+  })
+
+  it('reflectionSchema too long playerNote fails', () => {
+    const invalidData = {
+      weekStarting: new Date(Date.UTC(2023, 10, 1)),
+      playerNote: 'A'.repeat(501)
+    }
+    const result = reflectionSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+export const laneSchema = z.object({
+  name: z.string().trim().min(1).max(40),
+  emoji: z.string().trim().min(1).max(2).default("🥍"),
+  targetPerWeek: z.number().int().min(1).max(7).default(5),
+})
+
+export const checkInSchema = z.object({
+  laneId: z.string(), // cuid
+  date: z.date(),
+  isRest: z.boolean().default(false),
+  note: z.string().max(200).optional().nullable(),
+})
+
+export const bossBattleSchema = z.object({
+  laneId: z.string(), // cuid
+  weekStarting: z.date(),
+  selfReport: z.string().trim().min(1).max(1000),
+})
+
+export const reflectionSchema = z.object({
+  weekStarting: z.date(),
+  playerNote: z.string().trim().min(1).max(500),
+})
+
+export type LaneInput = z.infer<typeof laneSchema>
+export type CheckInInput = z.infer<typeof checkInSchema>
+export type BossBattleInput = z.infer<typeof bossBattleSchema>
+export type ReflectionInput = z.infer<typeof reflectionSchema>


### PR DESCRIPTION
## Summary

Implements story #5: Story 1.4 — Zod Validation Schemas

## Verified gates (auto-captured by dag-poc)

- `lint` exit 0
- `build` exit 0
- `test` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 16451
- Output tokens: 2370

Closes #5