### PR TITLE
feat: server-action spine + domain-schema fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Copy to .env.local and fill in real values (.env.local is gitignored).
 # DATABASE_URL matches the Postgres service in docker-compose.yml.
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/lacrosse_grind?schema=public"
+DATABASE_URL=""
+LLM_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=gemma4:26b
+# ANTHROPIC_API_KEY=""
+# ANTHROPIC_MODEL=claude-3-5-haiku-20241022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,57 +7,69 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// Lane — a skill domain Eddie trains (e.g. "Stick Skills", "Shooting", "Conditioning")
 model Lane {
-  id                String             @id
-  name              String
-  checkIns          CheckIn[]
-  bossBattles       BossBattle[]
-  weeklyReflections WeeklyReflection[]
-  streakFreezes     StreakFreeze[]
-  createdAt         DateTime           @default(now())
-  updatedAt         DateTime           @updatedAt
+  id            String   @id @default(cuid())
+  name          String
+  emoji         String   @default("🥍")
+  targetPerWeek Int      @default(5) // days/week target frequency
+  isActive      Boolean  @default(true)
+  sortOrder     Int      @default(0)
+  createdAt     DateTime @default(now())
+
+  checkIns    CheckIn[]
+  bossBattles BossBattle[]
+
+  @@index([isActive])
 }
 
+// CheckIn — Eddie's daily self-report for a lane session
 model CheckIn {
-  id        String   @id
+  id        String   @id @default(cuid())
   laneId    String
   lane      Lane     @relation(fields: [laneId], references: [id])
-  userId    String
-  timestamp DateTime @default(now())
-  metadata  Json?
+  date      DateTime // UTC midnight of the check-in day
+  isRest    Boolean  @default(false) // true = rest/sleep entry (counts as a hit)
+  note      String? // optional free-text (effort note, not a grade)
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+
+  @@unique([laneId, date])
+  @@index([date])
+  @@index([laneId, date])
 }
 
+// BossBattle — every 2-week skill test for a lane
 model BossBattle {
-  id          String   @id
-  laneId      String
-  lane        Lane     @relation(fields: [laneId], references: [id])
-  difficulty  Int
-  description String
-  isCompleted Boolean  @default(false)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id           String   @id @default(cuid())
+  laneId       String
+  lane         Lane     @relation(fields: [laneId], references: [id])
+  weekStarting DateTime // UTC midnight of the Monday starting the 2-week block
+  selfReport   String // Eddie's free-text description of how it went
+  coachNote    String? // AI-generated coach note (process-framed, never graded)
+  createdAt    DateTime @default(now())
+
+  @@unique([laneId, weekStarting])
+  @@index([weekStarting])
 }
 
+// WeeklyReflection — Eddie's weekly free-text entry + AI summary
 model WeeklyReflection {
-  id        String   @id
-  laneId    String
-  lane      Lane     @relation(fields: [laneId], references: [id])
-  content   String
-  rating    Int
-  week      Int
-  year      Int
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id           String   @id @default(cuid())
+  weekStarting DateTime // UTC midnight of the Monday
+  playerNote   String // Eddie's reflection
+  coachSummary String? // AI-generated summary (effort-framed)
+  createdAt    DateTime @default(now())
+
+  @@unique([weekStarting])
+  @@index([weekStarting])
 }
 
+// StreakFreeze — banked freeze tokens (one guilt-free miss per token)
 model StreakFreeze {
-  id        String   @id
+  id        String    @id @default(cuid())
   laneId    String
-  lane      Lane     @relation(fields: [laneId], references: [id])
-  userId    String
-  usedAt    DateTime @default(now())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  usedDate  DateTime? // null = still available
+  createdAt DateTime  @default(now())
+
+  @@index([laneId])
 }

--- a/src/app/actions/awardFreeze.test.ts
+++ b/src/app/actions/awardFreeze.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { awardFreeze } from './awardFreeze'
+
+vi.mock('@/lib/db', () => ({ prisma: { streakFreeze: { create: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('awardFreeze', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('valid laneId creates freeze and returns ok', async () => {
+    vi.mocked(prisma.streakFreeze.create).mockResolvedValue({ id: 'fz-1' } as never)
+
+    const result = await awardFreeze('lane-1')
+
+    expect(result).toEqual({ ok: true, id: 'fz-1' })
+    expect(prisma.streakFreeze.create).toHaveBeenCalledWith({ data: { laneId: 'lane-1' } })
+    expect(revalidatePath).toHaveBeenCalledWith('/')
+  })
+
+  it('empty laneId returns error without db call', async () => {
+    const result = await awardFreeze('   ')
+
+    expect(result).toEqual({ ok: false, error: 'missing-laneId' })
+    expect(prisma.streakFreeze.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/awardFreeze.ts
+++ b/src/app/actions/awardFreeze.ts
@@ -1,0 +1,15 @@
+import { prisma } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+
+export async function awardFreeze(
+  laneId: string
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  if (!laneId || !laneId.trim()) {
+    return { ok: false, error: "missing-laneId" };
+  }
+
+  const freeze = await prisma.streakFreeze.create({ data: { laneId } });
+
+  revalidatePath("/");
+  return { ok: true, id: freeze.id };
+}

--- a/src/app/actions/createBossBattle.test.ts
+++ b/src/app/actions/createBossBattle.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/llm'
+import { revalidatePath } from 'next/cache'
+import { createBossBattle } from './createBossBattle'
+
+vi.mock('@/lib/db', () => ({ prisma: { bossBattle: { upsert: vi.fn() } } }))
+vi.mock('@/lib/llm', () => ({ generate: vi.fn() }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const weekStarting = new Date(Date.UTC(2026, 0, 5))
+
+describe('createBossBattle', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('valid input calls generate and upserts with coachNote', async () => {
+    vi.mocked(generate).mockResolvedValue('Keep showing up — the reps are the win.')
+    vi.mocked(prisma.bossBattle.upsert).mockResolvedValue({ id: 'bb-1' } as never)
+
+    const result = await createBossBattle({
+      laneId: 'lane-1',
+      weekStarting,
+      selfReport: 'Worked my off-hand cradle for 20 minutes.',
+    })
+
+    expect(result).toEqual({ ok: true, id: 'bb-1' })
+    expect(generate).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.bossBattle.upsert).mock.calls[0][0]
+    expect(arg.where).toEqual({ laneId_weekStarting: { laneId: 'lane-1', weekStarting } })
+    expect(arg.create).toMatchObject({ coachNote: 'Keep showing up — the reps are the win.' })
+    expect(revalidatePath).toHaveBeenCalledWith('/boss-battles')
+  })
+
+  it('invalid input returns validation error without generate or db', async () => {
+    const result = await createBossBattle({ laneId: 'lane-1', weekStarting, selfReport: '' })
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(generate).not.toHaveBeenCalled()
+    expect(prisma.bossBattle.upsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/createBossBattle.ts
+++ b/src/app/actions/createBossBattle.ts
@@ -1,0 +1,27 @@
+import { prisma } from "@/lib/db";
+import { bossBattleSchema } from "@/lib/validation";
+import { generate } from "@/lib/llm";
+import { revalidatePath } from "next/cache";
+
+export async function createBossBattle(
+  input: unknown
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const parsed = bossBattleSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "validation" };
+  }
+
+  const { laneId, weekStarting, selfReport } = parsed.data;
+  const prompt = `You are an effort-focused lacrosse coach. Eddie just described his boss battle: "${selfReport}". Write a 2-3 sentence coach note that is process-focused, never mentions performance grades, and encourages consistency. No 'great job' filler.`;
+  // If generate() throws, let it propagate — the caller handles it.
+  const coachNote = await generate(prompt);
+
+  const battle = await prisma.bossBattle.upsert({
+    where: { laneId_weekStarting: { laneId, weekStarting } },
+    update: { selfReport, coachNote },
+    create: { laneId, weekStarting, selfReport, coachNote },
+  });
+
+  revalidatePath("/boss-battles");
+  return { ok: true, id: battle.id };
+}

--- a/src/app/actions/createCheckIn.test.ts
+++ b/src/app/actions/createCheckIn.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { createCheckIn } from './createCheckIn'
+
+vi.mock('@/lib/db', () => ({ prisma: { checkIn: { upsert: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const date = new Date(Date.UTC(2026, 0, 5))
+
+describe('createCheckIn', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('valid check-in upserts and returns ok', async () => {
+    vi.mocked(prisma.checkIn.upsert).mockResolvedValue({ id: 'ci-1' } as never)
+
+    const result = await createCheckIn({ laneId: 'lane-1', date, isRest: false })
+
+    expect(result).toEqual({ ok: true, id: 'ci-1' })
+    expect(prisma.checkIn.upsert).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.checkIn.upsert).mock.calls[0][0]
+    expect(arg.where).toEqual({ laneId_date: { laneId: 'lane-1', date } })
+    expect(arg.create).toMatchObject({ laneId: 'lane-1', date, isRest: false })
+    expect(revalidatePath).toHaveBeenCalledWith('/')
+  })
+
+  it('missing laneId returns validation error without db call', async () => {
+    const result = await createCheckIn({ date, isRest: false })
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(prisma.checkIn.upsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/createCheckIn.ts
+++ b/src/app/actions/createCheckIn.ts
@@ -1,0 +1,22 @@
+import { prisma } from "@/lib/db";
+import { checkInSchema } from "@/lib/validation";
+import { revalidatePath } from "next/cache";
+
+export async function createCheckIn(
+  input: unknown
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const parsed = checkInSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "validation" };
+  }
+
+  const { laneId, date, isRest, note } = parsed.data;
+  const checkIn = await prisma.checkIn.upsert({
+    where: { laneId_date: { laneId, date } },
+    update: { isRest, note },
+    create: { laneId, date, isRest, note },
+  });
+
+  revalidatePath("/");
+  return { ok: true, id: checkIn.id };
+}

--- a/src/app/actions/createLane.test.ts
+++ b/src/app/actions/createLane.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { createLane } from './createLane'
+
+vi.mock('@/lib/db', () => ({ prisma: { lane: { create: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('createLane', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('valid input creates lane and returns ok', async () => {
+    vi.mocked(prisma.lane.create).mockResolvedValue({ id: 'lane-1' } as never)
+
+    const result = await createLane({ name: 'Shooting' })
+
+    expect(result).toEqual({ ok: true, id: 'lane-1' })
+    expect(prisma.lane.create).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.lane.create).mock.calls[0][0]
+    expect(arg.data).toMatchObject({ name: 'Shooting', sortOrder: 0 })
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('empty name returns validation error without db call', async () => {
+    const result = await createLane({ name: '' })
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(prisma.lane.create).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/createLane.ts
+++ b/src/app/actions/createLane.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/db";
+import { laneSchema } from "@/lib/validation";
+import { revalidatePath } from "next/cache";
+
+export async function createLane(
+  input: unknown
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const parsed = laneSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "validation" };
+  }
+
+  const lane = await prisma.lane.create({
+    data: { ...parsed.data, sortOrder: 0 },
+  });
+
+  revalidatePath("/lanes");
+  return { ok: true, id: lane.id };
+}

--- a/src/app/actions/createReflection.test.ts
+++ b/src/app/actions/createReflection.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/llm'
+import { revalidatePath } from 'next/cache'
+import { createReflection } from './createReflection'
+
+vi.mock('@/lib/db', () => ({ prisma: { weeklyReflection: { upsert: vi.fn() } } }))
+vi.mock('@/lib/llm', () => ({ generate: vi.fn() }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const weekStarting = new Date(Date.UTC(2026, 0, 5))
+
+describe('createReflection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('valid input calls generate and upserts with coachSummary', async () => {
+    vi.mocked(generate).mockResolvedValue('You stayed consistent all week — that is the habit taking hold.')
+    vi.mocked(prisma.weeklyReflection.upsert).mockResolvedValue({ id: 'wr-1' } as never)
+
+    const result = await createReflection({
+      weekStarting,
+      playerNote: 'Trained four days, rested two, felt strong.',
+    })
+
+    expect(result).toEqual({ ok: true, id: 'wr-1' })
+    expect(generate).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.weeklyReflection.upsert).mock.calls[0][0]
+    expect(arg.where).toEqual({ weekStarting })
+    expect(arg.create).toMatchObject({ coachSummary: 'You stayed consistent all week — that is the habit taking hold.' })
+    expect(revalidatePath).toHaveBeenCalledWith('/reflection')
+  })
+
+  it('invalid input returns validation error without generate or db', async () => {
+    const result = await createReflection({ weekStarting, playerNote: '' })
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(generate).not.toHaveBeenCalled()
+    expect(prisma.weeklyReflection.upsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/createReflection.ts
+++ b/src/app/actions/createReflection.ts
@@ -1,0 +1,27 @@
+import { prisma } from "@/lib/db";
+import { reflectionSchema } from "@/lib/validation";
+import { generate } from "@/lib/llm";
+import { revalidatePath } from "next/cache";
+
+export async function createReflection(
+  input: unknown
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const parsed = reflectionSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: "validation" };
+  }
+
+  const { weekStarting, playerNote } = parsed.data;
+  const prompt = `You are an effort-focused coach. Summarize Eddie's weekly reflection in 2-3 encouraging, process-framed sentences — never grades, never 'great job' filler: "${playerNote}".`;
+  // If generate() throws, let it propagate — the caller handles it.
+  const coachSummary = await generate(prompt);
+
+  const reflection = await prisma.weeklyReflection.upsert({
+    where: { weekStarting },
+    update: { playerNote, coachSummary },
+    create: { weekStarting, playerNote, coachSummary },
+  });
+
+  revalidatePath("/reflection");
+  return { ok: true, id: reflection.id };
+}

--- a/src/app/actions/deleteCheckIn.test.ts
+++ b/src/app/actions/deleteCheckIn.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { deleteCheckIn } from './deleteCheckIn'
+
+vi.mock('@/lib/db', () => ({ prisma: { checkIn: { delete: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const date = new Date(Date.UTC(2026, 0, 5))
+
+describe('deleteCheckIn', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('valid laneId and date deletes and returns ok', async () => {
+    vi.mocked(prisma.checkIn.delete).mockResolvedValue({ id: 'ci-1' } as never)
+
+    const result = await deleteCheckIn('lane-1', date)
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.checkIn.delete).toHaveBeenCalledWith({
+      where: { laneId_date: { laneId: 'lane-1', date } },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/')
+  })
+
+  it('prisma not-found error returns not-found error', async () => {
+    vi.mocked(prisma.checkIn.delete).mockRejectedValue(new Error('Record to delete does not exist.'))
+
+    const result = await deleteCheckIn('lane-1', date)
+
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/deleteCheckIn.ts
+++ b/src/app/actions/deleteCheckIn.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+
+export async function deleteCheckIn(
+  laneId: string,
+  date: Date
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await prisma.checkIn.delete({
+      where: { laneId_date: { laneId, date } },
+    });
+  } catch {
+    // Prisma throws when the record doesn't exist.
+    return { ok: false, error: "not-found" };
+  }
+
+  revalidatePath("/");
+  return { ok: true };
+}

--- a/src/app/actions/updateLane.test.ts
+++ b/src/app/actions/updateLane.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma as db } from '@/lib/db'
+import type { Lane } from '@prisma/client'
+import { updateLane } from './updateLane'
+import { revalidatePath } from 'next/cache'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+    checkIn: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+    bossBattle: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+    weeklyReflection: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+    streakFreeze: {
+      create: vi.fn(),
+      createMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+// Mocking the validation schema to prevent global state leakage from the real schema
+// which might contain default values that interfere with the 'empty object' test.
+vi.mock('@/lib/validation', () => ({
+  laneSchema: {
+    partial: () => ({
+      safeParse: (data: any) => {
+        // Simulate Zod behavior: if name is a number, it's a failure
+        if (typeof data?.name === 'number') {
+          return { success: false };
+        }
+        // If data is an empty object, return success with empty data
+        // If data has fields, return success with those fields
+        return { success: true, data: data };
+      }
+    })
+  }
+}))
+
+const makeLane = (overrides: Partial<Lane> = {}): Lane =>
+  ({
+    id: '',
+    name: '',
+    createdAt: new Date(Date.UTC(2024, 0, 1)),
+    updatedAt: new Date(Date.UTC(2024, 0, 1)),
+    ...overrides,
+  } as unknown as Lane)
+
+describe('updateLane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('valid patch updates lane and returns ok', async () => {
+    const id = 'lane-123'
+    const patch = { name: 'New Lane Name' }
+    vi.mocked(db.lane.update).mockResolvedValue(makeLane({ id, name: 'New Lane Name' }))
+
+    const result = await updateLane(id, patch)
+
+    expect(result).toEqual({ ok: true })
+    expect(db.lane.update).toHaveBeenCalledWith({
+      where: { id },
+      data: patch,
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('empty object patch is valid and returns ok', async () => {
+    const id = 'lane-123'
+    const patch = {}
+    vi.mocked(db.lane.update).mockResolvedValue(makeLane({ id }))
+
+    const result = await updateLane(id, patch)
+
+    expect(result).toEqual({ ok: true })
+    expect(db.lane.update).toHaveBeenCalledWith({
+      where: { id },
+      data: {},
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('invalid field value returns validation error', async () => {
+    const id = 'lane-123'
+    const patch = { name: 123 as unknown as string }
+
+    const result = await updateLane(id, patch)
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(db.lane.update).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('db error propagates as thrown error', async () => {
+    const id = 'lane-123'
+    const patch = { name: 'New Name' }
+    const dbError = new Error('Database connection failed')
+    vi.mocked(db.lane.update).mockRejectedValue(dbError)
+
+    await expect(updateLane(id, patch)).rejects.toThrow('Database connection failed')
+  })
+})

--- a/src/app/actions/updateLane.ts
+++ b/src/app/actions/updateLane.ts
@@ -1,0 +1,35 @@
+import { prisma as db } from "@/lib/db";
+import { laneSchema } from "@/lib/validation";
+import { revalidatePath } from "next/cache";
+
+/**
+ * Updates a lane with a partial patch.
+ * Validates the patch using laneSchema.partial().
+ */
+export async function updateLane(id: string, patch: unknown): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    // Validate the patch using the partial schema
+    const parsed = laneSchema.partial().safeParse(patch);
+
+    if (!parsed.success) {
+      return { ok: false, error: "validation" };
+    }
+
+    // Perform the update in the database
+    await db.lane.update({
+      where: { id },
+      data: parsed.data,
+    });
+
+    // Revalidate the lanes path to ensure the UI reflects the change
+    revalidatePath("/lanes");
+
+    return { ok: true };
+  } catch (err) {
+    // If it's a database error or other error, we let it propagate or handle it
+    // The AC specifies returning error: 'validation' for Zod failure.
+    // For other errors (like Prisma throwing), we re-throw to satisfy the test requirement
+    // that db errors propagate as thrown errors.
+    throw err;
+  }
+}

--- a/src/app/actions/useFreeze.test.ts
+++ b/src/app/actions/useFreeze.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { useFreeze } from './useFreeze'
+
+vi.mock('@/lib/db', () => ({
+  prisma: { streakFreeze: { findFirst: vi.fn(), update: vi.fn() } },
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+const date = new Date(Date.UTC(2026, 0, 5))
+
+describe('useFreeze', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('available freeze is consumed and returns ok', async () => {
+    vi.mocked(prisma.streakFreeze.findFirst).mockResolvedValue({ id: 'fz-1' } as never)
+    vi.mocked(prisma.streakFreeze.update).mockResolvedValue({ id: 'fz-1' } as never)
+
+    const result = await useFreeze('lane-1', date)
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.streakFreeze.findFirst).toHaveBeenCalledWith({
+      where: { laneId: 'lane-1', usedDate: null },
+    })
+    expect(prisma.streakFreeze.update).toHaveBeenCalledWith({
+      where: { id: 'fz-1' },
+      data: { usedDate: date },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/')
+  })
+
+  it('no available freeze returns no-freeze-available error', async () => {
+    vi.mocked(prisma.streakFreeze.findFirst).mockResolvedValue(null)
+
+    const result = await useFreeze('lane-1', date)
+
+    expect(result).toEqual({ ok: false, error: 'no-freeze-available' })
+    expect(prisma.streakFreeze.update).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/useFreeze.ts
+++ b/src/app/actions/useFreeze.ts
@@ -1,0 +1,23 @@
+import { prisma } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+
+export async function useFreeze(
+  laneId: string,
+  date: Date
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const freeze = await prisma.streakFreeze.findFirst({
+    where: { laneId, usedDate: null },
+  });
+
+  if (!freeze) {
+    return { ok: false, error: "no-freeze-available" };
+  }
+
+  await prisma.streakFreeze.update({
+    where: { id: freeze.id },
+    data: { usedDate: date },
+  });
+
+  revalidatePath("/");
+  return { ok: true };
+}

--- a/src/lib/llm.test.ts
+++ b/src/lib/llm.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { generate } from './llm'
+
+describe('llm', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.restoreAllMocks()
+  })
+
+  it('ollama provider returns response field', async () => {
+    process.env.LLM_PROVIDER = 'ollama'
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.OLLlama_MODEL = 'gemma4:26b'
+
+    const mockResponse = { response: 'hello from ollama' }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    const result = await generate('hi')
+
+    expect(result).toBe('hello from ollama')
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:11434/api/generate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'gemma4:26b',
+          prompt: 'hi',
+          stream: false,
+        }),
+      })
+    )
+  })
+
+  it('anthropic provider returns content text', async () => {
+    process.env.LLM_PROVIDER = 'anthropic'
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-123'
+    process.env.ANTHROPIC_MODEL = 'claude-3-mock'
+
+    const mockResponse = {
+      content: [{ text: 'hello from anthropic' }],
+    }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response)
+
+    const result = await generate('hi')
+
+    expect(result).toBe('hello from anthropic')
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-api-key': 'sk-ant-123',
+          'anthropic-version': '2023-06-01',
+        }),
+        body: JSON.stringify({
+          model: 'claude-3-mock',
+          max_tokens: 512,
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      })
+    )
+  })
+
+  it('ollama fetch throws on non-ok response', async () => {
+    process.env.LLM_PROVIDER = 'ollama'
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Not Found',
+    } as Response)
+
+    await expect(generate('hi')).rejects.toThrow('Ollama request failed: Not Found')
+  })
+
+  it('anthropic fetch throws on non-ok response', async () => {
+    process.env.LLM_PROVIDER = 'anthropic'
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Unauthorized',
+    } as Response)
+
+    await expect(generate('hi')).rejects.toThrow('Anthropic request failed: Unauthorized')
+  })
+})

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,53 @@
+export async function generate(prompt: string): Promise<string> {
+  const provider = process.env.LLM_PROVIDER || 'ollama';
+
+  if (provider === 'ollama') {
+    const baseUrl = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+    const model = process.env.OLLAMA_MODEL || 'gemma4:26b';
+
+    const res = await fetch(`${baseUrl}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        prompt,
+        stream: false,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Ollama request failed: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    return data.response;
+  }
+
+  if (provider === 'anthropic') {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    const model = process.env.ANTHROPIC_MODEL || 'claude-3-5-haiku-20241022';
+
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey || '',
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 512,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Anthropic request failed: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    return data.content[0].text;
+  }
+
+  throw new Error(`Unsupported LLM provider: ${provider}`);
+}

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema } from './validation'
+
+describe('validation', () => {
+  it('laneSchema valid input passes', () => {
+    const validData = {
+      name: 'Lacrosse',
+      emoji: '🥍',
+      targetPerWeek: 5
+    }
+    const result = laneSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.name).toBe('Lacrosse')
+    }
+  })
+
+  it('laneSchema empty name fails', () => {
+    const invalidData = {
+      name: '   ',
+      emoji: '🥍',
+      targetPerWeek: 5
+    }
+    const result = laneSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('laneSchema name too long fails', () => {
+    const invalidData = {
+      name: 'A'.repeat(41),
+      emoji: '🥍',
+      targetPerWeek: 5
+    }
+    const result = laneSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('checkInSchema valid input passes', () => {
+    const date = new Date(Date.UTC(2023, 10, 1, 12, 0, 0))
+    const validData = {
+      laneId: 'clp1234567890abcdefghij',
+      date: date,
+      isRest: true,
+      note: 'Feeling good'
+    }
+    const result = checkInSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.date.getUTCMonth()).toBe(10)
+      expect(result.data.laneId).toBe('clp1234567890abcdefghij')
+    }
+  })
+
+  it('checkInSchema missing laneId fails', () => {
+    const invalidData = {
+      date: new Date(Date.UTC(2023, 10, 1)),
+      isRest: false
+    }
+    const result = checkInSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('bossBattleSchema empty selfReport fails', () => {
+    const invalidData = {
+      laneId: 'clp1234567890abcdefghij',
+      weekStarting: new Date(Date.UTC(2023, 10, 1)),
+      selfReport: '   '
+    }
+    const resultParse = bossBattleSchema.safeParse(invalidData)
+    expect(resultParse.success).toBe(false)
+  })
+
+  it('reflectionSchema too long playerNote fails', () => {
+    const invalidData = {
+      weekStarting: new Date(Date.UTC(2023, 10, 1)),
+      playerNote: 'A'.repeat(501)
+    }
+    const result = reflectionSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+export const laneSchema = z.object({
+  name: z.string().trim().min(1).max(40),
+  emoji: z.string().trim().min(1).max(2).default("🥍"),
+  targetPerWeek: z.number().int().min(1).max(7).default(5),
+})
+
+export const checkInSchema = z.object({
+  laneId: z.string(), // cuid
+  date: z.date(),
+  isRest: z.boolean().default(false),
+  note: z.string().max(200).optional().nullable(),
+})
+
+export const bossBattleSchema = z.object({
+  laneId: z.string(), // cuid
+  weekStarting: z.date(),
+  selfReport: z.string().trim().min(1).max(1000),
+})
+
+export const reflectionSchema = z.object({
+  weekStarting: z.date(),
+  playerNote: z.string().trim().min(1).max(500),
+})
+
+export type LaneInput = z.infer<typeof laneSchema>
+export type CheckInInput = z.infer<typeof checkInSchema>
+export type BossBattleInput = z.infer<typeof bossBattleSchema>
+export type ReflectionInput = z.infer<typeof reflectionSchema>


### PR DESCRIPTION
Hand-written by Thomas + Claude (the layer Spike stalled on).

**Root cause fixed:** `prisma/schema.prisma` was hallucinated (right model names, wrong fields) and never matched the Zod schemas / architecture.md §2 — so no create-action could compile. Corrected to the canonical domain.

**7 actions + mocked-Prisma tests:** createLane, createCheckIn, deleteCheckIn, createBossBattle, createReflection, awardFreeze, useFreeze — matching the landed `updateLane` convention.

**Gates:** tsc clean · lint 0 errors · 48 tests pass · `next build` clean.

Supersedes the pending integration PRs (includes their Zod/db/llm/updateLane content plus the schema fix + actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)