### PR TITLE
feat: finish the app — forms + pages

### DIFF
--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,0 +1,53 @@
+import { prisma } from "@/lib/db"
+import { get2WeekBlockStart, formatWeekLabel } from "@/lib/weekUtils"
+import { createBossBattle } from "@/app/actions/createBossBattle"
+import BossBattleForm from "@/components/BossBattleForm"
+
+export const dynamic = "force-dynamic"
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+export default async function BossBattlesPage() {
+  const blockStart = get2WeekBlockStart(utcMidnight(new Date()))
+
+  const lanes = await prisma.lane.findMany({
+    where: { isActive: true },
+    orderBy: { sortOrder: "asc" },
+    include: { bossBattles: { where: { weekStarting: blockStart } } },
+  })
+
+  return (
+    <main className="max-w-2xl mx-auto space-y-8 p-6">
+      <h1 className="text-2xl font-bold">
+        Boss Battles — {formatWeekLabel(blockStart)}
+      </h1>
+      {lanes.length === 0 && (
+        <p className="text-zinc-500">No active lanes yet.</p>
+      )}
+      {lanes.map((lane) => {
+        const existing = lane.bossBattles[0]
+        return (
+          <section key={lane.id} className="space-y-3 rounded-lg border p-4">
+            <h2 className="text-lg font-semibold">
+              {lane.emoji} {lane.name}
+            </h2>
+            <BossBattleForm
+              laneId={lane.id}
+              laneName={lane.name}
+              weekStarting={blockStart}
+              existingReport={existing?.selfReport}
+              existingCoachNote={existing?.coachNote ?? undefined}
+              createBossBattle={async (data) => {
+                "use server"
+                await createBossBattle(data)
+                return {}
+              }}
+            />
+          </section>
+        )
+      })}
+    </main>
+  )
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,67 @@
+import { prisma } from "@/lib/db"
+import { computeStreak } from "@/lib/streak"
+
+export const dynamic = "force-dynamic"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+export default async function HistoryPage() {
+  const today = utcMidnight(new Date())
+  const start = new Date(today.getTime() - 29 * DAY_MS)
+
+  const lanes = await prisma.lane.findMany({
+    where: { isActive: true },
+    orderBy: { sortOrder: "asc" },
+    include: {
+      checkIns: {
+        where: { date: { gte: start } },
+        orderBy: { date: "asc" },
+      },
+    },
+  })
+
+  const days = Array.from({ length: 30 }, (_, i) => new Date(start.getTime() + i * DAY_MS))
+
+  return (
+    <main className="max-w-3xl mx-auto space-y-8 p-6">
+      <h1 className="text-2xl font-bold">History</h1>
+      {lanes.map((lane) => {
+        const streak = computeStreak(
+          lane.checkIns.map((c) => ({ date: c.date, isRest: c.isRest })),
+          today
+        )
+        const byDay = new Map(
+          lane.checkIns.map((c) => [utcMidnight(c.date).getTime(), c])
+        )
+        return (
+          <section key={lane.id} className="space-y-2">
+            <h2 className="text-lg font-semibold">
+              {lane.emoji} {lane.name} — {streak}🔥
+            </h2>
+            <div className="grid grid-cols-10 gap-1">
+              {days.map((d) => {
+                const c = byDay.get(d.getTime())
+                const cls = c
+                  ? c.isRest
+                    ? "bg-blue-300"
+                    : "bg-green-400"
+                  : "bg-zinc-200"
+                return (
+                  <div
+                    key={d.getTime()}
+                    className={`h-6 w-6 rounded ${cls}`}
+                    title={d.toISOString().slice(0, 10)}
+                  />
+                )
+              })}
+            </div>
+          </section>
+        )
+      })}
+    </main>
+  )
+}

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -1,0 +1,28 @@
+import { prisma } from "@/lib/db"
+import { createLane } from "@/app/actions/createLane"
+import LaneList from "@/components/LaneList"
+import LaneForm from "@/components/LaneForm"
+
+export const dynamic = "force-dynamic"
+
+export default async function LanesPage() {
+  const lanes = await prisma.lane.findMany({
+    orderBy: [{ isActive: "desc" }, { sortOrder: "asc" }],
+  })
+
+  return (
+    <main className="max-w-2xl mx-auto space-y-6 p-6">
+      <h1 className="text-2xl font-bold">Lanes</h1>
+      <LaneList lanes={lanes} />
+      <div className="border-t pt-6">
+        <h2 className="mb-3 text-lg font-semibold">Add a lane</h2>
+        <LaneForm
+          createLane={async (data) => {
+            "use server"
+            return createLane(data)
+          }}
+        />
+      </div>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,65 @@
-import Image from "next/image";
+import { prisma } from "@/lib/db"
+import { computeStreak } from "@/lib/streak"
+import { getWeekStart } from "@/lib/weekUtils"
+import { createCheckIn } from "@/app/actions/createCheckIn"
+import { deleteCheckIn } from "@/app/actions/deleteCheckIn"
+import CheckInCard from "@/components/CheckInCard"
+import { WeeklyProgress } from "@/components/WeeklyProgress"
 
-export default function Home() {
+export const dynamic = "force-dynamic"
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+export default async function DashboardPage() {
+  const today = utcMidnight(new Date())
+  const weekStart = getWeekStart(today)
+
+  const lanes = await prisma.lane.findMany({
+    where: { isActive: true },
+    orderBy: { sortOrder: "asc" },
+    include: {
+      checkIns: { where: { date: { gte: weekStart } }, orderBy: { date: "asc" } },
+    },
+  })
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
+    <main className="max-w-2xl mx-auto space-y-6 p-6">
+      <h1 className="text-2xl font-bold">Today</h1>
+      {lanes.length === 0 && (
+        <p className="text-zinc-500">No lanes yet — add one on the Lanes page.</p>
+      )}
+      {lanes.map((lane) => {
+        const todayCheckIn = lane.checkIns.find(
+          (c) => c.date.getTime() === today.getTime()
+        )
+        const weeklyHits = lane.checkIns.length
+        const streak = computeStreak(
+          lane.checkIns.map((c) => ({ date: c.date, isRest: c.isRest })),
+          today
+        )
+        return (
+          <div key={lane.id} className="space-y-2 rounded-lg border p-4">
+            <CheckInCard
+              lane={{ id: lane.id, name: lane.name, emoji: lane.emoji }}
+              streak={streak}
+              checkedIn={!!todayCheckIn}
+              isRest={todayCheckIn?.isRest ?? false}
+              today={today.toISOString()}
+              createCheckIn={async (params) => {
+                "use server"
+                await createCheckIn(params)
+              }}
+              deleteCheckIn={async (laneId, date) => {
+                "use server"
+                await deleteCheckIn(laneId, date)
+              }}
             />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
-  );
+            <WeeklyProgress hits={weeklyHits} target={lane.targetPerWeek} />
+          </div>
+        )
+      })}
+    </main>
+  )
 }

--- a/src/app/reflection/page.tsx
+++ b/src/app/reflection/page.tsx
@@ -1,0 +1,33 @@
+import { prisma } from "@/lib/db"
+import { getWeekStart } from "@/lib/weekUtils"
+import { createReflection } from "@/app/actions/createReflection"
+import ReflectionForm from "@/components/ReflectionForm"
+
+export const dynamic = "force-dynamic"
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+export default async function ReflectionPage() {
+  const weekStart = getWeekStart(utcMidnight(new Date()))
+  const reflection = await prisma.weeklyReflection.findUnique({
+    where: { weekStarting: weekStart },
+  })
+
+  return (
+    <main className="max-w-2xl mx-auto space-y-6 p-6">
+      <h1 className="text-2xl font-bold">Weekly Reflection</h1>
+      <ReflectionForm
+        weekStarting={weekStart}
+        existingNote={reflection?.playerNote}
+        existingCoachSummary={reflection?.coachSummary ?? undefined}
+        createReflection={async (data) => {
+          "use server"
+          await createReflection(data)
+          return {}
+        }}
+      />
+    </main>
+  )
+}

--- a/src/components/BossBattleForm.test.tsx
+++ b/src/components/BossBattleForm.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import BossBattleForm from './BossBattleForm'
+
+const baseProps = {
+  laneId: 'lane-1',
+  laneName: 'Shooting',
+  weekStarting: new Date(Date.UTC(2026, 0, 5)),
+}
+
+describe('BossBattleForm', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders textarea and submit button', () => {
+    render(<BossBattleForm {...baseProps} createBossBattle={vi.fn()} />)
+    expect(screen.getByTestId('self-report-input')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Submit Battle Report' })).toBeInTheDocument()
+  })
+
+  it('empty submit shows validation message without calling action', async () => {
+    const user = userEvent.setup()
+    const createBossBattle = vi.fn()
+    render(<BossBattleForm {...baseProps} createBossBattle={createBossBattle} />)
+
+    await user.click(screen.getByRole('button', { name: 'Submit Battle Report' }))
+
+    expect(screen.getByText('Tell me how it went first')).toBeInTheDocument()
+    expect(createBossBattle).not.toHaveBeenCalled()
+  })
+
+  it('valid submit calls createBossBattle and shows coach note', async () => {
+    const user = userEvent.setup()
+    const createBossBattle = vi.fn().mockResolvedValue({ coachNote: 'Keep showing up.' })
+    render(<BossBattleForm {...baseProps} createBossBattle={createBossBattle} />)
+
+    await user.type(screen.getByTestId('self-report-input'), 'Worked my off-hand.')
+    await user.click(screen.getByRole('button', { name: 'Submit Battle Report' }))
+
+    await waitFor(() =>
+      expect(createBossBattle).toHaveBeenCalledWith({
+        laneId: 'lane-1',
+        weekStarting: baseProps.weekStarting,
+        selfReport: 'Worked my off-hand.',
+      })
+    )
+    expect(await screen.findByTestId('coach-note')).toHaveTextContent('Keep showing up.')
+  })
+})

--- a/src/components/BossBattleForm.tsx
+++ b/src/components/BossBattleForm.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+interface BossBattleFormProps {
+  laneId: string
+  laneName: string
+  weekStarting: Date
+  existingReport?: string
+  existingCoachNote?: string
+  createBossBattle: (data: {
+    laneId: string
+    weekStarting: Date
+    selfReport: string
+  }) => Promise<{ coachNote?: string }>
+}
+
+export default function BossBattleForm({
+  laneId,
+  laneName,
+  weekStarting,
+  existingReport,
+  existingCoachNote,
+  createBossBattle,
+}: BossBattleFormProps) {
+  const [selfReport, setSelfReport] = useState(existingReport ?? "")
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [coachNote, setCoachNote] = useState<string | undefined>(existingCoachNote)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!selfReport.trim()) {
+      setError("Tell me how it went first")
+      return
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await createBossBattle({
+          laneId,
+          weekStarting,
+          selfReport: selfReport.trim(),
+        })
+        if (result.coachNote) {
+          setCoachNote(result.coachNote)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to submit report")
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="self-report-input" className="text-sm font-medium">
+          {laneName} — Battle Report
+        </label>
+        <textarea
+          id="self-report-input"
+          data-testid="self-report-input"
+          value={selfReport}
+          onChange={(e) => setSelfReport(e.target.value)}
+          className="min-h-[150px] p-2 border rounded-md text-black"
+          placeholder="How did the battle go?"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+
+      {coachNote && (
+        <div
+          data-testid="coach-note"
+          className="p-3 bg-blue-50 border border-blue-200 rounded-md text-blue-800"
+        >
+          🧠 Coach says: {coachNote}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+      >
+        {isPending ? "Sending..." : "Submit Battle Report"}
+      </button>
+    </form>
+  )
+}

--- a/src/components/LaneForm.test.tsx
+++ b/src/components/LaneForm.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import LaneForm from './LaneForm'
+
+describe('LaneForm', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders name input', () => {
+    render(<LaneForm createLane={vi.fn()} />)
+    expect(screen.getByTestId('lane-name-input')).toBeInTheDocument()
+  })
+
+  it('empty name submit shows validation error without calling action', async () => {
+    const user = userEvent.setup()
+    const createLane = vi.fn()
+    render(<LaneForm createLane={createLane} />)
+
+    await user.click(screen.getByRole('button', { name: 'Add Lane' }))
+
+    expect(screen.getByText('Name is required')).toBeInTheDocument()
+    expect(createLane).not.toHaveBeenCalled()
+  })
+
+  it('valid submit calls createLane and clears form', async () => {
+    const user = userEvent.setup()
+    const createLane = vi.fn().mockResolvedValue({ ok: true, id: 'lane-1' })
+    render(<LaneForm createLane={createLane} />)
+
+    const nameInput = screen.getByTestId('lane-name-input') as HTMLInputElement
+    await user.type(nameInput, 'Stick Skills')
+    await user.click(screen.getByRole('button', { name: 'Add Lane' }))
+
+    expect(createLane).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Stick Skills', targetPerWeek: 5 })
+    )
+    await waitFor(() => expect(nameInput.value).toBe(''))
+  })
+})

--- a/src/components/LaneForm.tsx
+++ b/src/components/LaneForm.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+interface LaneFormProps {
+  createLane: (data: {
+    name: string
+    emoji: string
+    targetPerWeek: number
+  }) => Promise<unknown>
+  onSubmit?: () => void
+}
+
+const DEFAULT_EMOJI = "🥍"
+
+export default function LaneForm({ createLane, onSubmit }: LaneFormProps) {
+  const [name, setName] = useState("")
+  const [emoji, setEmoji] = useState(DEFAULT_EMOJI)
+  const [targetPerWeek, setTargetPerWeek] = useState(5)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!name.trim()) {
+      setError("Name is required")
+      return
+    }
+
+    startTransition(async () => {
+      await createLane({ name: name.trim(), emoji, targetPerWeek })
+      setName("")
+      setEmoji(DEFAULT_EMOJI)
+      setTargetPerWeek(5)
+      onSubmit?.()
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="lane-name" className="text-sm font-medium">
+          Lane name
+        </label>
+        <input
+          id="lane-name"
+          data-testid="lane-name-input"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="p-2 border rounded-md text-black"
+          placeholder="e.g. Stick Skills"
+        />
+      </div>
+
+      <div className="flex gap-4">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="lane-emoji" className="text-sm font-medium">
+            Emoji
+          </label>
+          <input
+            id="lane-emoji"
+            data-testid="lane-emoji-input"
+            type="text"
+            value={emoji}
+            onChange={(e) => setEmoji(e.target.value)}
+            maxLength={2}
+            className="w-16 p-2 border rounded-md text-black"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="lane-target" className="text-sm font-medium">
+            Target / week
+          </label>
+          <input
+            id="lane-target"
+            data-testid="lane-target-input"
+            type="number"
+            min={1}
+            max={7}
+            value={targetPerWeek}
+            onChange={(e) => setTargetPerWeek(Number(e.target.value))}
+            className="w-20 p-2 border rounded-md text-black"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+      >
+        {isPending ? "Adding..." : "Add Lane"}
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
Hand-written finish of the UI layer Spike couldn't cross.

**2 form components:** BossBattleForm, LaneForm (action-as-prop, RTL tests).
**5 pages** (force-dynamic Server Components, Prisma per spec, forms wired via inline `use server` wrappers): `/`, `/lanes`, `/boss-battles`, `/reflection`, `/history`.

App feature-complete: schema · 8 actions · 5 components · 5 pages.
Gates: tsc clean · lint 0 errors · 65 tests · build clean (all 5 routes dynamic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)