### PR TITLE
fix(LaneList): add missing 'use server' to the toggle action

### DIFF
--- a/src/components/LaneList.tsx
+++ b/src/components/LaneList.tsx
@@ -18,6 +18,7 @@ interface LaneListProps {
  * This is defined within the component file as a server action.
  */
 async function updateLaneAction(formData: FormData) {
+  'use server';
   const laneId = formData.get('laneId') as string;
   const isActive = formData.get('isActive') === 'true';
 


### PR DESCRIPTION
`updateLaneAction` is a `<form action>` but lacked `'use server'`, so `/lanes` 500'd at SSR. Passed all gates (only fails at request-time serialization). One-line fix, verified live (/lanes now 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)