### PR TITLE
fix: bottom-nav clearance (cut-off cards) + History nav link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col relative">
-        <main className="flex-1">
+        <main className="flex-1 pb-24">
           {children}
         </main>
 
@@ -65,6 +65,14 @@ export default function RootLayout({
                 className="flex flex-col items-center text-xs font-medium text-gray-600 hover:text-black"
               >
                 <span>Reflect</span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/history"
+                className="flex flex-col items-center text-xs font-medium text-gray-600 hover:text-black"
+              >
+                <span>History</span>
               </Link>
             </li>
           </ul>


### PR DESCRIPTION
The fixed bottom nav clipped the last card on every page (no bottom padding on main). Add pb-24 clearance, and add the missing History nav link. Verified live + gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)