### PR TITLE
fix: show coach note instantly (no refresh)

### DIFF
--- a/src/app/actions/createBossBattle.test.ts
+++ b/src/app/actions/createBossBattle.test.ts
@@ -23,7 +23,7 @@ describe('createBossBattle', () => {
       selfReport: 'Worked my off-hand cradle for 20 minutes.',
     })
 
-    expect(result).toEqual({ ok: true, id: 'bb-1' })
+    expect(result).toEqual({ ok: true, id: 'bb-1', coachNote: expect.any(String) })
     expect(generate).toHaveBeenCalledOnce()
     const arg = vi.mocked(prisma.bossBattle.upsert).mock.calls[0][0]
     expect(arg.where).toEqual({ laneId_weekStarting: { laneId: 'lane-1', weekStarting } })

--- a/src/app/actions/createBossBattle.ts
+++ b/src/app/actions/createBossBattle.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 
 export async function createBossBattle(
   input: unknown
-): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; id: string; coachNote: string } | { ok: false; error: string }> {
   const parsed = bossBattleSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: "validation" };
@@ -23,5 +23,5 @@ export async function createBossBattle(
   });
 
   revalidatePath("/boss-battles");
-  return { ok: true, id: battle.id };
+  return { ok: true, id: battle.id, coachNote };
 }

--- a/src/app/actions/createReflection.test.ts
+++ b/src/app/actions/createReflection.test.ts
@@ -22,7 +22,7 @@ describe('createReflection', () => {
       playerNote: 'Trained four days, rested two, felt strong.',
     })
 
-    expect(result).toEqual({ ok: true, id: 'wr-1' })
+    expect(result).toEqual({ ok: true, id: 'wr-1', coachSummary: 'You stayed consistent all week — that is the habit taking hold.' })
     expect(generate).toHaveBeenCalledOnce()
     const arg = vi.mocked(prisma.weeklyReflection.upsert).mock.calls[0][0]
     expect(arg.where).toEqual({ weekStarting })

--- a/src/app/actions/createReflection.ts
+++ b/src/app/actions/createReflection.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 
 export async function createReflection(
   input: unknown
-): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; id: string; coachSummary: string } | { ok: false; error: string }> {
   const parsed = reflectionSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: "validation" };
@@ -23,5 +23,5 @@ export async function createReflection(
   });
 
   revalidatePath("/reflection");
-  return { ok: true, id: reflection.id };
+  return { ok: true, id: reflection.id, coachSummary };
 }

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -42,8 +42,8 @@ export default async function BossBattlesPage() {
               existingCoachNote={existing?.coachNote ?? undefined}
               createBossBattle={async (data) => {
                 "use server"
-                await createBossBattle(data)
-                return {}
+                const r = await createBossBattle(data)
+                return { coachNote: r.ok ? r.coachNote : undefined }
               }}
             />
           </section>

--- a/src/app/reflection/page.tsx
+++ b/src/app/reflection/page.tsx
@@ -25,8 +25,8 @@ export default async function ReflectionPage() {
         existingCoachSummary={reflection?.coachSummary ?? undefined}
         createReflection={async (data) => {
           "use server"
-          await createReflection(data)
-          return {}
+          const r = await createReflection(data)
+          return { coachSummary: r.ok ? r.coachSummary : undefined }
         }}
       />
     </main>


### PR DESCRIPTION
Actions return the generated coachNote/coachSummary; page wrappers pass it to the form so it renders on submit instead of only after refresh. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)