### PR TITLE
feat: edit + delete lanes

### DIFF
--- a/src/app/actions/deleteLane.test.ts
+++ b/src/app/actions/deleteLane.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { deleteLane } from './deleteLane'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: vi.fn(),
+    checkIn: { deleteMany: vi.fn() },
+    bossBattle: { deleteMany: vi.fn() },
+    streakFreeze: { deleteMany: vi.fn() },
+    lane: { delete: vi.fn() },
+  },
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('deleteLane', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('deletes the lane and its children in a transaction, returns ok', async () => {
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+    const result = await deleteLane('lane-1')
+    expect(result).toEqual({ ok: true })
+    expect(prisma.$transaction).toHaveBeenCalledOnce()
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('empty id returns missing-id without a db call', async () => {
+    const result = await deleteLane('')
+    expect(result).toEqual({ ok: false, error: 'missing-id' })
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('db error returns not-found', async () => {
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('nope'))
+    const result = await deleteLane('lane-1')
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+  })
+})

--- a/src/app/actions/deleteLane.ts
+++ b/src/app/actions/deleteLane.ts
@@ -1,0 +1,25 @@
+import { prisma } from "@/lib/db"
+import { revalidatePath } from "next/cache"
+
+export async function deleteLane(
+  id: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!id) return { ok: false, error: "missing-id" }
+
+  try {
+    // Cascade the lane's dependent rows in a single transaction (the schema has
+    // no ON DELETE CASCADE, so the FK'd check-ins/battles must go first).
+    await prisma.$transaction([
+      prisma.checkIn.deleteMany({ where: { laneId: id } }),
+      prisma.bossBattle.deleteMany({ where: { laneId: id } }),
+      prisma.streakFreeze.deleteMany({ where: { laneId: id } }),
+      prisma.lane.delete({ where: { id } }),
+    ])
+  } catch {
+    return { ok: false, error: "not-found" }
+  }
+
+  revalidatePath("/lanes")
+  revalidatePath("/")
+  return { ok: true }
+}

--- a/src/app/actions/setLaneActive.test.ts
+++ b/src/app/actions/setLaneActive.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { setLaneActive } from './setLaneActive'
+
+vi.mock('@/lib/db', () => ({ prisma: { lane: { update: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('setLaneActive', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('sets isActive and returns ok', async () => {
+    vi.mocked(prisma.lane.update).mockResolvedValue({} as never)
+    const result = await setLaneActive('lane-1', false)
+    expect(result).toEqual({ ok: true })
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-1' },
+      data: { isActive: false },
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('empty id returns missing-id without a db call', async () => {
+    const result = await setLaneActive('', true)
+    expect(result).toEqual({ ok: false, error: 'missing-id' })
+    expect(prisma.lane.update).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/setLaneActive.ts
+++ b/src/app/actions/setLaneActive.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/db"
+import { revalidatePath } from "next/cache"
+
+export async function setLaneActive(
+  id: string,
+  isActive: boolean
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!id) return { ok: false, error: "missing-id" }
+
+  try {
+    await prisma.lane.update({ where: { id }, data: { isActive } })
+  } catch {
+    return { ok: false, error: "not-found" }
+  }
+
+  revalidatePath("/lanes")
+  revalidatePath("/")
+  return { ok: true }
+}

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -1,5 +1,8 @@
 import { prisma } from "@/lib/db"
 import { createLane } from "@/app/actions/createLane"
+import { updateLane } from "@/app/actions/updateLane"
+import { setLaneActive } from "@/app/actions/setLaneActive"
+import { deleteLane } from "@/app/actions/deleteLane"
 import LaneList from "@/components/LaneList"
 import LaneForm from "@/components/LaneForm"
 
@@ -13,8 +16,25 @@ export default async function LanesPage() {
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">
       <h1 className="text-2xl font-bold">Lanes</h1>
-      <p className="mt-1 text-sm text-zinc-500">The skills you are training. Add a lane, set a weekly target, and toggle which ones are active.</p>
-      <LaneList lanes={lanes} />
+      <p className="mt-1 text-sm text-zinc-500">
+        The skills you are training. Add a lane, set a weekly target, and toggle,
+        edit, or remove them.
+      </p>
+      <LaneList
+        lanes={lanes}
+        updateLane={async (id, patch) => {
+          "use server"
+          return updateLane(id, patch)
+        }}
+        setActive={async (id, isActive) => {
+          "use server"
+          return setLaneActive(id, isActive)
+        }}
+        deleteLane={async (id) => {
+          "use server"
+          return deleteLane(id)
+        }}
+      />
       <div className="border-t pt-6">
         <h2 className="mb-3 text-lg font-semibold">Add a lane</h2>
         <LaneForm

--- a/src/components/LaneList.test.tsx
+++ b/src/components/LaneList.test.tsx
@@ -1,44 +1,61 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import LaneList from './LaneList'
 
-vi.mock('next/cache', () => ({
-  revalidatePath: vi.fn(),
-}))
+const LANES = [
+  { id: '1', name: 'Running', emoji: '🏃', isActive: true, targetPerWeek: 3 },
+  { id: '2', name: 'Swimming', emoji: '🏊', isActive: false, targetPerWeek: 2 },
+]
+
+const actions = () => ({ updateLane: vi.fn(), setActive: vi.fn(), deleteLane: vi.fn() })
 
 describe('LaneList', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+  beforeEach(() => vi.clearAllMocks())
 
-  it('renders all lanes', async () => {
-    const lanes = [
-      { id: '1', name: 'Running', emoji: '🏃', isActive: true, targetPerWeek: 3 },
-      { id: '2', name: 'Swimming', emoji: '🏊', isActive: false, targetPerWeek: 2 },
-    ]
-    render(<LaneList lanes={lanes} />)
-
+  it('renders lanes with active/inactive badges', () => {
+    render(<LaneList lanes={LANES} {...actions()} />)
     expect(screen.getByText('Running')).toBeInTheDocument()
     expect(screen.getByText('Swimming')).toBeInTheDocument()
-    expect(screen.getByText('🏃')).toBeInTheDocument()
-    expect(screen.getByText('🏊')).toBeInTheDocument()
-  })
-
-  it('active lane shows active badge', async () => {
-    const lanes = [
-      { id: '1', name: 'Running', emoji: '🏃', isActive: true, targetPerWeek: 3 },
-    ]
-    render(<LaneList lanes={lanes} />)
-
     expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
   })
 
-  it('inactive lane shows inactive badge', async () => {
-    const lanes = [
-      { id: '2', name: 'Swimming', emoji: '🏊', isActive: false, targetPerWeek: 2 },
-    ]
-    render(<LaneList lanes={lanes} />)
+  it('Toggle calls setActive with the flipped value', async () => {
+    const user = userEvent.setup()
+    const a = actions()
+    render(<LaneList lanes={[LANES[0]]} {...a} />)
+    await user.click(screen.getByRole('button', { name: /toggle/i }))
+    expect(a.setActive).toHaveBeenCalledWith('1', false)
+  })
 
-    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  it('Delete calls deleteLane after confirm', async () => {
+    const user = userEvent.setup()
+    const a = actions()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    render(<LaneList lanes={[LANES[0]]} {...a} />)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(a.deleteLane).toHaveBeenCalledWith('1')
+  })
+
+  it('Delete does nothing when confirm is cancelled', async () => {
+    const user = userEvent.setup()
+    const a = actions()
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    render(<LaneList lanes={[LANES[0]]} {...a} />)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(a.deleteLane).not.toHaveBeenCalled()
+  })
+
+  it('Edit then Save calls updateLane with the draft', async () => {
+    const user = userEvent.setup()
+    const a = actions()
+    render(<LaneList lanes={[LANES[0]]} {...a} />)
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    const nameInput = screen.getByTestId('edit-name-1')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Sprints')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(a.updateLane).toHaveBeenCalledWith('1', expect.objectContaining({ name: 'Sprints' }))
   })
 })

--- a/src/components/LaneList.tsx
+++ b/src/components/LaneList.tsx
@@ -1,89 +1,173 @@
-import { revalidatePath } from 'next/cache';
-import { prisma as db } from '@/lib/db';
+"use client"
+
+import { useState } from "react"
 
 interface Lane {
-  id: string;
-  name: string;
-  emoji: string;
-  isActive: boolean;
-  targetPerWeek: number;
+  id: string
+  name: string
+  emoji: string
+  isActive: boolean
+  targetPerWeek: number
 }
 
 interface LaneListProps {
-  lanes: Lane[];
+  lanes: Lane[]
+  updateLane: (
+    id: string,
+    patch: { name?: string; emoji?: string; targetPerWeek?: number }
+  ) => Promise<unknown>
+  setActive: (id: string, isActive: boolean) => Promise<unknown>
+  deleteLane: (id: string) => Promise<unknown>
 }
 
-/**
- * Server Action to toggle lane activity.
- * This is defined within the component file as a server action.
- */
-async function updateLaneAction(formData: FormData) {
-  'use server';
-  const laneId = formData.get('laneId') as string;
-  const isActive = formData.get('isActive') === 'true';
+// Single-code-point icons (<= 2 UTF-16 units so they satisfy the schema's
+// emoji .max(2)). Mirrors the LaneForm picker.
+const EMOJI_OPTIONS: { cp: number; label: string }[] = [
+  { cp: 0x1f94d, label: "Lacrosse" },
+  { cp: 0x1f3c3, label: "Running" },
+  { cp: 0x1f3cb, label: "Weights" },
+  { cp: 0x1f4aa, label: "Strength" },
+  { cp: 0x1f3af, label: "Shooting" },
+  { cp: 0x1f945, label: "Goals" },
+  { cp: 0x1f938, label: "Agility" },
+  { cp: 0x26a1, label: "Speed" },
+  { cp: 0x1f9e0, label: "Film / Mental" },
+  { cp: 0x1f634, label: "Recovery" },
+  { cp: 0x1f525, label: "Conditioning" },
+]
 
-  if (!laneId) return;
+export default function LaneList({ lanes, updateLane, setActive, deleteLane }: LaneListProps) {
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState({ name: "", emoji: "", targetPerWeek: 5 })
 
-  await db.lane.update({
-    where: { id: laneId },
-    data: { isActive: !isActive },
-  });
+  function startEdit(lane: Lane) {
+    setEditingId(lane.id)
+    setDraft({ name: lane.name, emoji: lane.emoji, targetPerWeek: lane.targetPerWeek })
+  }
 
-  revalidatePath('/');
-}
+  async function saveEdit(id: string) {
+    try {
+      await updateLane(id, {
+        name: draft.name.trim(),
+        emoji: draft.emoji,
+        targetPerWeek: draft.targetPerWeek,
+      })
+    } finally {
+      setEditingId(null)
+    }
+  }
 
-export default function LaneList({ lanes }: LaneListProps) {
+  if (lanes.length === 0) {
+    return <p className="text-zinc-500">No lanes yet — add one below.</p>
+  }
+
   return (
-    <div className="w-full max-w-2xl mx-auto">
-      <h2 className="text-2xl font-bold mb-6">Lanes</h2>
-      <ol className="space-y-4">
-        {lanes.map((lane) => (
-          <li
-            key={lane.id}
-            className="flex items-center justify-between p-4 rounded-lg border bg-card text-card-foreground shadow-sm"
-          >
-            <div className="flex items-center gap-3">
-              <span className="text-2xl" aria-hidden="true">
-                {lane.emoji}
-              </span>
-              <span className="font-medium text-lg">{lane.name}</span>
-              {lane.isActive && (
-                <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
-                  Active
-                </span>
-              )}
-              {!lane.isActive && (
-                <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">
-                  Inactive
-                </span>
-              )}
+    <ol className="w-full space-y-3">
+      {lanes.map((lane) => (
+        <li key={lane.id} className="rounded-lg border p-4">
+          {editingId === lane.id ? (
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-zinc-500">Name</label>
+                <input
+                  data-testid={`edit-name-${lane.id}`}
+                  className="rounded-md border p-2 text-black"
+                  value={draft.name}
+                  onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-zinc-500">Icon</label>
+                <select
+                  className="rounded-md border p-2 text-black"
+                  value={draft.emoji}
+                  onChange={(e) => setDraft({ ...draft, emoji: e.target.value })}
+                >
+                  {EMOJI_OPTIONS.map((o) => {
+                    const ch = String.fromCodePoint(o.cp)
+                    return (
+                      <option key={o.cp} value={ch}>
+                        {ch} {o.label}
+                      </option>
+                    )
+                  })}
+                </select>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-zinc-500">Target/wk</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={7}
+                  className="w-20 rounded-md border p-2 text-black"
+                  value={draft.targetPerWeek}
+                  onChange={(e) => setDraft({ ...draft, targetPerWeek: Number(e.target.value) })}
+                />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => saveEdit(lane.id)}
+                  className="rounded-md bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-700"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => setEditingId(null)}
+                  className="rounded-md border px-3 py-2 text-sm font-medium"
+                >
+                  Cancel
+                </button>
+              </div>
             </div>
-
-            <form
-              action={updateLaneAction}
-              className="flex items-center"
-            >
-              <input
-                type="hidden"
-                name="laneId"
-                value={lane.id}
-              />
-              <input
-                type="hidden"
-                name="isActive"
-                value={lane.isActive.toString()}
-              />
-              <button
-                type="submit"
-                className="text-sm font-medium text-blue-600 hover:text-blue-800 transition-colors"
-                aria-label={`Toggle activity for ${lane.name}`}
-              >
-                Toggle
-              </button>
-            </form>
-          </li>
-        ))}
-      </ol>
-    </div>
-  );
+          ) : (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <span className="text-2xl" aria-hidden="true">
+                  {lane.emoji}
+                </span>
+                <span className="text-lg font-medium">{lane.name}</span>
+                <span className="text-xs text-zinc-400">{lane.targetPerWeek}×/wk</span>
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                    lane.isActive ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-800"
+                  }`}
+                >
+                  {lane.isActive ? "Active" : "Inactive"}
+                </span>
+              </div>
+              <div className="flex items-center gap-3 text-sm">
+                <button
+                  onClick={() => setActive(lane.id, !lane.isActive)}
+                  className="font-medium text-blue-600 hover:text-blue-800"
+                  aria-label={`Toggle ${lane.name}`}
+                >
+                  Toggle
+                </button>
+                <button
+                  onClick={() => startEdit(lane)}
+                  className="font-medium text-zinc-600 hover:text-black"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => {
+                    if (
+                      window.confirm(
+                        `Delete "${lane.name}"? This also removes its check-ins and boss battles.`
+                      )
+                    ) {
+                      deleteLane(lane.id)
+                    }
+                  }}
+                  className="font-medium text-red-600 hover:text-red-800"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          )}
+        </li>
+      ))}
+    </ol>
+  )
 }


### PR DESCRIPTION
LaneList gets Toggle / Edit / Delete per lane. New actions: deleteLane (transaction-cascades children), setLaneActive. Gates green (72 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)