### PR TITLE
feat: edit + delete past weekly reflections

### DIFF
--- a/src/app/actions/deleteReflection.test.ts
+++ b/src/app/actions/deleteReflection.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { deleteReflection } from './deleteReflection'
+
+vi.mock('@/lib/db', () => ({ prisma: { weeklyReflection: { delete: vi.fn() } } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('deleteReflection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('deletes and returns ok', async () => {
+    vi.mocked(prisma.weeklyReflection.delete).mockResolvedValue({} as never)
+    const result = await deleteReflection('wr-1')
+    expect(result).toEqual({ ok: true })
+    expect(prisma.weeklyReflection.delete).toHaveBeenCalledWith({ where: { id: 'wr-1' } })
+    expect(revalidatePath).toHaveBeenCalledWith('/reflection')
+  })
+
+  it('empty id returns missing-id without a db call', async () => {
+    const result = await deleteReflection('')
+    expect(result).toEqual({ ok: false, error: 'missing-id' })
+    expect(prisma.weeklyReflection.delete).not.toHaveBeenCalled()
+  })
+
+  it('db error returns not-found', async () => {
+    vi.mocked(prisma.weeklyReflection.delete).mockRejectedValue(new Error('x'))
+    const result = await deleteReflection('wr-1')
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+  })
+})

--- a/src/app/actions/deleteReflection.ts
+++ b/src/app/actions/deleteReflection.ts
@@ -1,0 +1,17 @@
+import { prisma } from "@/lib/db"
+import { revalidatePath } from "next/cache"
+
+export async function deleteReflection(
+  id: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!id) return { ok: false, error: "missing-id" }
+
+  try {
+    await prisma.weeklyReflection.delete({ where: { id } })
+  } catch {
+    return { ok: false, error: "not-found" }
+  }
+
+  revalidatePath("/reflection")
+  return { ok: true }
+}

--- a/src/app/actions/editReflection.test.ts
+++ b/src/app/actions/editReflection.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { generate } from '@/lib/llm'
+import { editReflection } from './editReflection'
+
+vi.mock('@/lib/db', () => ({ prisma: { weeklyReflection: { update: vi.fn() } } }))
+vi.mock('@/lib/llm', () => ({ generate: vi.fn() }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('editReflection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('regenerates the summary, updates, and returns coachSummary', async () => {
+    vi.mocked(generate).mockResolvedValue('You kept the habit going.')
+    vi.mocked(prisma.weeklyReflection.update).mockResolvedValue({} as never)
+    const result = await editReflection('wr-1', 'Trained hard this week')
+    expect(result).toEqual({ ok: true, coachSummary: 'You kept the habit going.' })
+    expect(generate).toHaveBeenCalledOnce()
+    expect(prisma.weeklyReflection.update).toHaveBeenCalledWith({
+      where: { id: 'wr-1' },
+      data: { playerNote: 'Trained hard this week', coachSummary: 'You kept the habit going.' },
+    })
+  })
+
+  it('empty note returns validation without generate or db', async () => {
+    const result = await editReflection('wr-1', '   ')
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(generate).not.toHaveBeenCalled()
+    expect(prisma.weeklyReflection.update).not.toHaveBeenCalled()
+  })
+
+  it('missing id returns missing-id', async () => {
+    const result = await editReflection('', 'note')
+    expect(result).toEqual({ ok: false, error: 'missing-id' })
+  })
+})

--- a/src/app/actions/editReflection.ts
+++ b/src/app/actions/editReflection.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@/lib/db"
+import { generate } from "@/lib/llm"
+import { revalidatePath } from "next/cache"
+
+export async function editReflection(
+  id: string,
+  playerNote: string
+): Promise<{ ok: true; coachSummary: string } | { ok: false; error: string }> {
+  if (!id) return { ok: false, error: "missing-id" }
+
+  const note = (playerNote ?? "").trim()
+  if (note.length === 0 || note.length > 500) {
+    return { ok: false, error: "validation" }
+  }
+
+  const prompt = `You are an effort-focused coach. Summarize Eddie's weekly reflection in 2-3 encouraging, process-framed sentences — never grades, never 'great job' filler: "${note}".`
+  const coachSummary = await generate(prompt)
+
+  await prisma.weeklyReflection.update({
+    where: { id },
+    data: { playerNote: note, coachSummary },
+  })
+
+  revalidatePath("/reflection")
+  return { ok: true, coachSummary }
+}

--- a/src/app/reflection/page.tsx
+++ b/src/app/reflection/page.tsx
@@ -1,7 +1,10 @@
 import { prisma } from "@/lib/db"
-import { getWeekStart } from "@/lib/weekUtils"
+import { getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
 import { createReflection } from "@/app/actions/createReflection"
+import { editReflection } from "@/app/actions/editReflection"
+import { deleteReflection } from "@/app/actions/deleteReflection"
 import ReflectionForm from "@/components/ReflectionForm"
+import ReflectionList from "@/components/ReflectionList"
 
 export const dynamic = "force-dynamic"
 
@@ -11,9 +14,22 @@ function utcMidnight(d: Date): Date {
 
 export default async function ReflectionPage() {
   const weekStart = getWeekStart(utcMidnight(new Date()))
+
   const reflection = await prisma.weeklyReflection.findUnique({
     where: { weekStarting: weekStart },
   })
+
+  const past = await prisma.weeklyReflection.findMany({
+    where: { weekStarting: { lt: weekStart } },
+    orderBy: { weekStarting: "desc" },
+  })
+
+  const pastReflections = past.map((r) => ({
+    id: r.id,
+    weekLabel: formatWeekLabel(r.weekStarting),
+    playerNote: r.playerNote,
+    coachSummary: r.coachSummary,
+  }))
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">
@@ -29,6 +45,23 @@ export default async function ReflectionPage() {
           return { coachSummary: r.ok ? r.coachSummary : undefined }
         }}
       />
+
+      {pastReflections.length > 0 && (
+        <section className="space-y-3 border-t border-zinc-800 pt-6">
+          <h2 className="text-lg font-semibold">Past reflections</h2>
+          <ReflectionList
+            reflections={pastReflections}
+            editReflection={async (id, playerNote) => {
+              "use server"
+              return editReflection(id, playerNote)
+            }}
+            deleteReflection={async (id) => {
+              "use server"
+              return deleteReflection(id)
+            }}
+          />
+        </section>
+      )}
     </main>
   )
 }

--- a/src/components/LaneList.tsx
+++ b/src/components/LaneList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import ToggleSwitch from "@/components/ToggleSwitch"
 import ConfirmModal from "@/components/ConfirmModal"
+import { PencilIcon, TrashIcon } from "@/components/icons"
 
 interface Lane {
   id: string
@@ -35,25 +36,6 @@ const EMOJI_OPTIONS: { cp: number; label: string }[] = [
   { cp: 0x1f634, label: "Recovery" },
   { cp: 0x1f525, label: "Conditioning" },
 ]
-
-function PencilIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-      <path d="M12 20h9" />
-      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
-    </svg>
-  )
-}
-
-function TrashIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-      <path d="M3 6h18" />
-      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-    </svg>
-  )
-}
 
 export default function LaneList({ lanes, updateLane, setActive, deleteLane }: LaneListProps) {
   const [editingId, setEditingId] = useState<string | null>(null)

--- a/src/components/ReflectionList.test.tsx
+++ b/src/components/ReflectionList.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ReflectionList from './ReflectionList'
+
+const reflections = [
+  {
+    id: 'r1',
+    weekLabel: 'Mon 05 Jan 2026',
+    playerNote: 'Tough week but I kept showing up.',
+    coachSummary: 'You stayed consistent.',
+  },
+  {
+    id: 'r2',
+    weekLabel: 'Mon 29 Dec 2025',
+    playerNote: 'Rested over the holidays.',
+    coachSummary: null,
+  },
+]
+
+describe('ReflectionList', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the empty state when there are no reflections', () => {
+    render(
+      <ReflectionList reflections={[]} editReflection={vi.fn()} deleteReflection={vi.fn()} />
+    )
+    expect(screen.getByText(/no past reflections yet/i)).toBeInTheDocument()
+  })
+
+  it('edits a reflection and shows the updated coach summary', async () => {
+    const user = userEvent.setup()
+    const editReflection = vi.fn().mockResolvedValue({ ok: true, coachSummary: 'Fresh summary.' })
+    render(
+      <ReflectionList
+        reflections={reflections}
+        editReflection={editReflection}
+        deleteReflection={vi.fn()}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /edit reflection mon 05 jan 2026/i }))
+    const textarea = screen.getByTestId('edit-reflection-r1')
+    await user.clear(textarea)
+    await user.type(textarea, 'Rewrote my reflection')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(editReflection).toHaveBeenCalledWith('r1', 'Rewrote my reflection')
+    expect(await screen.findByText(/fresh summary/i)).toBeInTheDocument()
+  })
+
+  it('deletes a reflection through the confirm modal', async () => {
+    const user = userEvent.setup()
+    const deleteReflection = vi.fn().mockResolvedValue({ ok: true })
+    render(
+      <ReflectionList
+        reflections={reflections}
+        editReflection={vi.fn()}
+        deleteReflection={deleteReflection}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /delete reflection mon 05 jan 2026/i }))
+    // modal appears
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(deleteReflection).toHaveBeenCalledWith('r1')
+  })
+
+  it('cancel in the modal does not delete', async () => {
+    const user = userEvent.setup()
+    const deleteReflection = vi.fn()
+    render(
+      <ReflectionList
+        reflections={reflections}
+        editReflection={vi.fn()}
+        deleteReflection={deleteReflection}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /delete reflection mon 29 dec 2025/i }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(deleteReflection).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/ReflectionList.tsx
+++ b/src/components/ReflectionList.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { useState } from "react"
+import ConfirmModal from "@/components/ConfirmModal"
+import { PencilIcon, TrashIcon } from "@/components/icons"
+
+interface Reflection {
+  id: string
+  weekLabel: string
+  playerNote: string
+  coachSummary: string | null
+}
+
+interface ReflectionListProps {
+  reflections: Reflection[]
+  editReflection: (
+    id: string,
+    playerNote: string
+  ) => Promise<{ ok: boolean; coachSummary?: string } | unknown>
+  deleteReflection: (id: string) => Promise<unknown>
+}
+
+export default function ReflectionList({
+  reflections,
+  editReflection,
+  deleteReflection,
+}: ReflectionListProps) {
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState("")
+  const [summaries, setSummaries] = useState<Record<string, string | null>>({})
+  const [confirmItem, setConfirmItem] = useState<Reflection | null>(null)
+
+  function startEdit(r: Reflection) {
+    setEditingId(r.id)
+    setDraft(r.playerNote)
+  }
+
+  async function save(id: string) {
+    try {
+      const res = (await editReflection(id, draft.trim())) as {
+        coachSummary?: string
+      }
+      if (res && res.coachSummary) {
+        setSummaries((s) => ({ ...s, [id]: res.coachSummary! }))
+      }
+    } finally {
+      setEditingId(null)
+    }
+  }
+
+  if (reflections.length === 0) {
+    return <p className="text-zinc-500">No past reflections yet.</p>
+  }
+
+  return (
+    <>
+      <ol className="space-y-3">
+        {reflections.map((r) => {
+          const summary = r.id in summaries ? summaries[r.id] : r.coachSummary
+          return (
+            <li key={r.id} className="rounded-xl border border-zinc-800 bg-zinc-900 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium text-zinc-400">{r.weekLabel}</span>
+                {editingId !== r.id && (
+                  <div className="flex items-center gap-2">
+                    <button
+                      aria-label={`Edit reflection ${r.weekLabel}`}
+                      onClick={() => startEdit(r)}
+                      className="rounded-lg p-2 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+                    >
+                      <PencilIcon />
+                    </button>
+                    <button
+                      aria-label={`Delete reflection ${r.weekLabel}`}
+                      onClick={() => setConfirmItem(r)}
+                      className="rounded-lg p-2 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-red-400"
+                    >
+                      <TrashIcon />
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {editingId === r.id ? (
+                <div className="mt-3 space-y-2">
+                  <textarea
+                    data-testid={`edit-reflection-${r.id}`}
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    className="min-h-[100px] w-full rounded-lg border border-zinc-700 bg-zinc-800 p-2"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => save(r.id)}
+                      className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="mt-2 whitespace-pre-wrap text-zinc-200">{r.playerNote}</p>
+                  {summary && (
+                    <div className="mt-2 rounded-md border border-blue-500/20 bg-blue-500/10 p-3 text-sm text-blue-200">
+                      🧠 Coach says: {summary}
+                    </div>
+                  )}
+                </>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+
+      <ConfirmModal
+        open={confirmItem !== null}
+        title={confirmItem ? `Delete the ${confirmItem.weekLabel} reflection?` : ""}
+        message="This removes the reflection and its coach summary."
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (confirmItem) deleteReflection(confirmItem.id)
+          setConfirmItem(null)
+        }}
+        onCancel={() => setConfirmItem(null)}
+      />
+    </>
+  )
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,18 @@
+export function PencilIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+    </svg>
+  )
+}
+
+export function TrashIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    </svg>
+  )
+}


### PR DESCRIPTION
Past-reflections list on /reflection with pencil/trash controls, editReflection + deleteReflection actions, shared icon module. Gates green (82 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)