### PR TITLE
feat(#88): Story 6.4 — Boss Battles and Reflection Use the Training Day

### DIFF
--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,16 +1,13 @@
 import { prisma } from "@/lib/db"
 import { get2WeekBlockStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
 
 export const dynamic = "force-dynamic"
 
-function utcMidnight(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
-
 export default async function BossBattlesPage() {
-  const blockStart = get2WeekBlockStart(utcMidnight(new Date()))
+  const blockStart = get2WeekBlockStart(getTrainingDay(new Date()))
 
   const lanes = await prisma.lane.findMany({
     where: { isActive: true },
@@ -20,7 +17,7 @@ export default async function BossBattlesPage() {
 
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
-      <h1 className="text-2xl font-bold">
+      <h1 className="text-2rab font-bold">
         Boss Battles — {formatWeekLabel(blockStart)}
       </h1>
       <p className="mt-1 text-sm text-zinc-500">Every two weeks, test a skill and describe how it went. The coach note is about your process — never a grade.</p>

--- a/src/app/reflection/page.tsx
+++ b/src/app/reflection/page.tsx
@@ -1,5 +1,6 @@
 import { prisma as db } from "@/lib/db"
 import { getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 import { createReflection } from "@/app/actions/createReflection"
 import { editReflection } from "@/app/actions/editReflection"
 import { deleteReflection } from "@/app/actions/deleteReflection"
@@ -8,12 +9,8 @@ import ReflectionList from "@/components/ReflectionList"
 
 export const dynamic = "force-dynamic"
 
-function utcMidnight(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
-
 export default async function ReflectionPage() {
-  const weekStart = getWeekStart(utcMidnight(new Date()))
+  const weekStart = getWeekStart(getTrainingDay(new Date()))
 
   const allReflections = await db.weeklyReflection.findMany({
     orderBy: { weekStarting: "desc" },


### PR DESCRIPTION
## Summary

Implements story #88: Story 6.4 — Boss Battles and Reflection Use the Training Day

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 1
- Prompt tokens: 8689
- Output tokens: 1250

Closes #88