### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,16 +1,13 @@
 import { prisma } from "@/lib/db"
 import { get2WeekBlockStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
 
 export const dynamic = "force-dynamic"
 
-function utcMidnight(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
-
 export default async function BossBattlesPage() {
-  const blockStart = get2WeekBlockStart(utcMidnight(new Date()))
+  const blockStart = get2WeekBlockStart(getTrainingDay(new Date()))
 
   const lanes = await prisma.lane.findMany({
     where: { isActive: true },
@@ -20,7 +17,7 @@ export default async function BossBattlesPage() {
 
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
-      <h1 className="text-2xl font-bold">
+      <h1 className="text-2rab font-bold">
         Boss Battles — {formatWeekLabel(blockStart)}
       </h1>
       <p className="mt-1 text-sm text-zinc-500">Every two weeks, test a skill and describe how it went. The coach note is about your process — never a grade.</p>

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db"
 import { computeStreak } from "@/lib/streak"
+import { getTrainingDay } from "@/lib/trainingDay"
 
 export const dynamic = "force-dynamic"
 
@@ -10,7 +11,7 @@ function utcMidnight(d: Date): Date {
 }
 
 export default async function HistoryPage() {
-  const today = utcMidnight(new Date())
+  const today = getTrainingDay(new Date())
   const start = new Date(today.getTime() - 29 * DAY_MS)
 
   const lanes = await prisma.lane.findMany({
@@ -39,7 +40,7 @@ export default async function HistoryPage() {
           lane.checkIns.map((c) => [utcMidnight(c.date).getTime(), c])
         )
         return (
-          <section key={lane.id} className="space-y-2">
+          <section key={lane.id} className="space\nspace-y-2">
             <h2 className="text-lg font-semibold">
               {lane.emoji} {lane.name} — {streak}🔥
             </h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db"
 import { computeStreak } from "@/lib/streak"
 import { getWeekStart } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 import { createCheckIn } from "@/app/actions/createCheckIn"
 import { deleteCheckIn } from "@/app/actions/deleteCheckIn"
 import CheckInCard from "@/components/CheckInCard"
@@ -8,12 +9,8 @@ import { WeeklyProgress } from "@/components/WeeklyProgress"
 
 export const dynamic = "force-dynamic"
 
-function utcMidnight(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
-
 export default async function DashboardPage() {
-  const today = utcMidnight(new Date())
+  const today = getTrainingDay(new Date())
   const weekStart = getWeekStart(today)
 
   const lanes = await prisma.lane.findMany({

--- a/src/app/reflection/page.tsx
+++ b/src/app/reflection/page.tsx
@@ -1,5 +1,6 @@
 import { prisma as db } from "@/lib/db"
 import { getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 import { createReflection } from "@/app/actions/createReflection"
 import { editReflection } from "@/app/actions/editReflection"
 import { deleteReflection } from "@/app/actions/deleteReflection"
@@ -8,12 +9,8 @@ import ReflectionList from "@/components/ReflectionList"
 
 export const dynamic = "force-dynamic"
 
-function utcMidnight(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
-
 export default async function ReflectionPage() {
-  const weekStart = getWeekStart(utcMidnight(new Date()))
+  const weekStart = getWeekStart(getTrainingDay(new Date()))
 
   const allReflections = await db.weeklyReflection.findMany({
     orderBy: { weekStarting: "desc" },

--- a/src/lib/streak.test.ts
+++ b/src/lib/streak.test.ts
@@ -59,4 +59,35 @@ describe('streak', () => {
     ]
     expect(computeStreak(checkIns, today)).toBe(0)
   })
+
+  it('inputs are not mutated', () => {
+    const date = createUTCDate(2023, 10, 10)
+    const originalTime = date.getTime()
+    const today = createUTCDate(2023, 10, 10)
+    const checkIns: { date: Date; isRest: boolean }[] = [
+      { date: new Date(date.getTime()), isRest: false }
+    ]
+
+    computeStreak(checkIns, today)
+
+    expect(checkIns[0].date.getTime()).toBe(originalTime)
+    expect(checkIns[0].date.getUTCHours()).toBe(0)
+    expect(checkIns[0].date.getUTCMinutes()).toBe(0)
+  })
+
+  it('streak counts UTC-midnight days', () => {
+    // Create a date that is NOT midnight UTC (e.g., 11 PM UTC on the previous day)
+    // If the function uses local setHours, this might shift to a different day in some timezones
+    const yesterdayLate = new Date(Date.UTC(2023, 9, 9, 23, 0, 0))
+    const todayMidnight = new Date(Date.UTC(2023, 9, 10, 0, 0, 0))
+    
+    const checkIns: { date: Date; isRest: boolean }[] = [
+      { date: yesterdayLate, isRest: false },
+      { date: todayMidnight, isRest: false }
+    ]
+    
+    // If normalized correctly to UTC midnight, yesterdayLate becomes Oct 9 00:00 UTC
+    // and todayMidnight is Oct 10 00:00 UTC. Streak should be 2.
+    expect(computeStreak(checkIns, todayMidnight)).toBe(2)
+  })
 })

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,15 +1,14 @@
 import { differenceInCalendarDays } from "date-fns";
 
 export function computeStreak(checkIns: { date: Date; isRest: boolean }[], today: Date) {
-  const todayStart = new Date(today);
-  todayStart.setHours(0, 0, 0, 0);
+  const todayStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
 
   // Filter for check-ins that are on or before today
-  // and normalize them to start of day for comparison
+  // and normalize them to start of day for comparison without mutating input
   const validCheckIns = checkIns
     .map((ci) => ({
       ...ci,
-      date: new Date(ci.date.setHours(0, 0, 0, 0)),
+      date: new Date(Date.UTC(ci.date.getUTCFullYear(), ci.date.getUTCMonth(), ci.date.getUTCDate())),
     }))
     .filter((ci) => ci.date <= todayStart);
 
@@ -36,7 +35,7 @@ export function computeStreak(checkIns: { date: Date; isRest: boolean }[], today
   for (const dateTimestamp of uniqueDates) {
     if (dateTimestamp === currentDay) {
       streak++;
-      // Move to the previous calendar day
+      // Move to the previous calendar day (86400000 ms = 1 day)
       currentDay -= 86400000;
     } else {
       // Gap found

--- a/src/lib/trainingDay.test.ts
+++ b/src/lib/trainingDay.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { TRAINING_TZ, DAY_ROLLOVER_HOUR, getTrainingDay } from './trainingDay'
+
+/**
+ * Helper to create a Date object from a UTC ISO string.
+ * This ensures tests are timezone-independent.
+ */
+const createUTCDate = (isoString: string) => new Date(isoString)
+
+/**
+ * Helper to assert that a Date object represents the start of a specific UTC day.
+ */
+const assertIsUtcMidnightOf = (date: Date, year: number, month: number, day: number) => {
+  const expected = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0))
+  expect(date.getUTCFullYear()).toBe(year)
+  expect(date.getUTCMonth()).toBe(month - 1)
+  expect(date.getUTCDate()).toBe(day)
+  expect(date.getUTCHours()).toBe(0)
+  expect(date.getUTCMinutes()).toBe(0)
+  expect(date.getUTCSeconds()).toBe(0)
+  expect(date.toISOString()).toBe(expected.toISOString())
+}
+
+describe('trainingDay', () => {
+  it('noon local maps to that day', () => {
+    // 2026-08-05 12:00:00 EDT (UTC-4)
+    // 12:00 EDT is 16:00 UTC
+    const now = createUTCDate('2026-08-05T16:00:00Z')
+    const result = getTrainingDay(now)
+    
+    // Noon is after 3am, so it should be the same day
+    assertIsUtcMidnightOf(result, 2026, 8, 5)
+  })
+
+  it('1am local maps to previous day', () => {
+    // 2026-08-05 01:00:00 EDT (UTC-4)
+    // 01:00 EDT is 05:00 UTC
+    const now = createUTCDate('2026-08-05T05:00:00Z')
+    const result = getTrainingDay(now)
+    
+    // 1am is before 3am rollover, so it belongs to the previous day (Aug 4)
+    assertIsUtcMidnightOf(result, 2026, 8, 4)
+  })
+
+  it('4am local maps to same day', () => {
+    // 2026-08-05 04:00:00 EDT (UTC-4)
+    // 04:00 EDT is 08:00 UTC
+    const now = createUTCDate('2026-08-05T08:00:00Z')
+    const result = getTrainingDay(now)
+    
+    // 4am is after 3am rollover, so it belongs to the same day (Aug 5)
+    assertIsUtcMidnightOf(result, 2026, 8, 5)
+  })
+
+  it('9pm local maps to same day', () => {
+    // 2026-08-05 21:00:00 EDT (UTC-4)
+    // 21:00 EDT is 01:00 UTC (next day)
+    const now = createUTCDate('2026-08-06T01:00:00Z')
+    const result = getTrainingDay(now)
+    
+    // 9pm is after 3am rollover, so it belongs to the same day (Aug 5)
+    assertIsUtcMidnightOf(result, 2026, 8, 5)
+  })
+})

--- a/src/lib/trainingDay.ts
+++ b/src/lib/trainingDay.ts
@@ -1,0 +1,27 @@
+import { formatInTimeZone } from "date-fns-tz";
+
+export const TRAINING_TZ = "America/New_York";
+export const DAY_ROLLOVER_HOUR = 3;
+
+/**
+ * Returns a Date object representing the start of the current training day.
+ * The training day is defined as the period from DAY_ROLLOVER_HOUR local time
+ * to DAY_ROLLOVER_HOUR local time the next morning.
+ * 
+ * The returned Date is pinned to UTC midnight (00:00:00.000Z) of the
+ * calendar date that corresponds to the training day label.
+ */
+export function getTrainingDay(now: Date = new Date()): Date {
+  // 1. Shift the instant back by the rollover hour.
+  // If it is 1:00 AM, shifting back 3 hours moves us into the previous calendar day.
+  const shiftedDate = new Date(now.getTime() - DAY_ROLLOVER_HOUR * 60 * 60 * 1000);
+
+  // 2. Format the shifted instant in the training timezone to get the yyyy-MM-dd label.
+  const dateLabel = formatInTimeZone(shiftedDate, TRAINING_TZ, "yyyy-MM-dd");
+
+  // 3. Construct the ISO string for UTC midnight of that date.
+  // We use string concatenation instead of template literals to avoid potential build issues.
+  const isoString = dateLabel + "T00:00:00.000Z";
+
+  return new Date(isoString);
+}


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#85, #86, #88, #87) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.