### PR TITLE
feat(#97): Story 7.2 — Boss Battles Gated by Weekly Target

### DIFF
--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,5 +1,5 @@
-import { prisma } from "@/lib/db"
-import { get2WeekBlockStart, formatWeekLabel } from "@/lib/weekUtils"
+import { prisma as db } from "@/lib/db"
+import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
@@ -7,42 +7,75 @@ import BossBattleForm from "@/components/BossBattleForm"
 export const dynamic = "force-dynamic"
 
 export default async function BossBattlesPage() {
-  const blockStart = get2WeekBlockStart(getTrainingDay(new Date()))
+  const trainingDay = getTrainingDay(new Date())
+  const weekStart = getLastCompletedWeekStart(trainingDay)
+  const thisWeekStart = getWeekStart(trainingDay)
 
-  const lanes = await prisma.lane.findMany({
+  const lanes = await db.lane.findMany({
     where: { isActive: true },
     orderBy: { sortOrder: "asc" },
-    include: { bossBattles: { where: { weekStarting: blockStart } } },
+    include: {
+      checkIns: {
+        where: {
+          date: { gte: weekStart, lt: thisWeekStart },
+        },
+      },
+      bossBattles: {
+        where: { weekStarting: weekStart },
+      },
+    },
   })
 
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
-      <h1 className="text-2rab font-bold">
-        Boss Battles — {formatWeekLabel(blockStart)}
+      <h1 className="text-2xl font-bold">
+        Boss Battles — week of {formatWeekLabel(weekStart)}
       </h1>
-      <p className="mt-1 text-sm text-zinc-500">Every two weeks, test a skill and describe how it went. The coach note is about your process — never a grade.</p>
+      <p className="mt-1 text-sm text-zinc-500">
+        Finish a lane's weekly target and you unlock its boss battle — describe how the week went. The coach note is about your process, never a grade.
+      </p>
+
       {lanes.length === 0 && (
         <p className="text-zinc-500">No active lanes yet.</p>
       )}
+
       {lanes.map((lane) => {
+        const hits = lane.checkIns.length
+        const hitTarget = hits >= lane.targetPerWeek
         const existing = lane.bossBattles[0]
+
         return (
           <section key={lane.id} className="space-y-3 rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">
-              {lane.emoji} {lane.name}
-            </h2>
-            <BossBattleForm
-              laneId={lane.id}
-              laneName={lane.name}
-              weekStarting={blockStart}
-              existingReport={existing?.selfReport}
-              existingCoachNote={existing?.coachNote ?? undefined}
-              createBossBattle={async (data) => {
-                "use server"
-                const r = await createBossBattle(data)
-                return { coachNote: r.ok ? r.coachNote : undefined }
-              }}
-            />
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold">
+                {lane.emoji} {lane.name}
+              </h2>
+              <span className="text-sm text-zinc-600">
+                {hits} / {lane.targetPerWeek} days
+              </span>
+            </div>
+
+            {hitTarget ? (
+              <div className="space-y-3">
+                <div className="text-sm font-medium text-green-600">
+                  ✅ Target hit
+                </div>
+                <BossBattleForm
+                  laneId={lane.id}
+                  laneName={lane.name}
+                  weekStarting={weekStart}
+                  existingReport={existing?.selfReport}
+                  existingCoachNote={existing?.coachNote ?? undefined}
+                  createBossBattle={async (data) => {
+                    "use server"
+                    const r = await createBossBattle(data)
+                    return { coachNote: r.ok ? r.coachNote : undefined }
+                  }}
+                />
+              </div>
+            ) : (
+              <p className="text-zinc-500 text-sm">No battle this week — target missed.</p>
+            )}
           </section>
         )
       })}


### PR DESCRIPTION
## Summary

Implements story #97: Story 7.2 — Boss Battles Gated by Weekly Target

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 17600
- Output tokens: 1715

Closes #97