### PR TITLE
Boss battles gated by weekly target

### DIFF
--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,5 +1,5 @@
-import { prisma } from "@/lib/db"
-import { get2WeekBlockStart, formatWeekLabel } from "@/lib/weekUtils"
+import { prisma as db } from "@/lib/db"
+import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
@@ -7,42 +7,75 @@ import BossBattleForm from "@/components/BossBattleForm"
 export const dynamic = "force-dynamic"
 
 export default async function BossBattlesPage() {
-  const blockStart = get2WeekBlockStart(getTrainingDay(new Date()))
+  const trainingDay = getTrainingDay(new Date())
+  const weekStart = getLastCompletedWeekStart(trainingDay)
+  const thisWeekStart = getWeekStart(trainingDay)
 
-  const lanes = await prisma.lane.findMany({
+  const lanes = await db.lane.findMany({
     where: { isActive: true },
     orderBy: { sortOrder: "asc" },
-    include: { bossBattles: { where: { weekStarting: blockStart } } },
+    include: {
+      checkIns: {
+        where: {
+          date: { gte: weekStart, lt: thisWeekStart },
+        },
+      },
+      bossBattles: {
+        where: { weekStarting: weekStart },
+      },
+    },
   })
 
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
-      <h1 className="text-2rab font-bold">
-        Boss Battles — {formatWeekLabel(blockStart)}
+      <h1 className="text-2xl font-bold">
+        Boss Battles — week of {formatWeekLabel(weekStart)}
       </h1>
-      <p className="mt-1 text-sm text-zinc-500">Every two weeks, test a skill and describe how it went. The coach note is about your process — never a grade.</p>
+      <p className="mt-1 text-sm text-zinc-500">
+        Finish a lane's weekly target and you unlock its boss battle — describe how the week went. The coach note is about your process, never a grade.
+      </p>
+
       {lanes.length === 0 && (
         <p className="text-zinc-500">No active lanes yet.</p>
       )}
+
       {lanes.map((lane) => {
+        const hits = lane.checkIns.length
+        const hitTarget = hits >= lane.targetPerWeek
         const existing = lane.bossBattles[0]
+
         return (
           <section key={lane.id} className="space-y-3 rounded-lg border p-4">
-            <h2 className="text-lg font-semibold">
-              {lane.emoji} {lane.name}
-            </h2>
-            <BossBattleForm
-              laneId={lane.id}
-              laneName={lane.name}
-              weekStarting={blockStart}
-              existingReport={existing?.selfReport}
-              existingCoachNote={existing?.coachNote ?? undefined}
-              createBossBattle={async (data) => {
-                "use server"
-                const r = await createBossBattle(data)
-                return { coachNote: r.ok ? r.coachNote : undefined }
-              }}
-            />
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold">
+                {lane.emoji} {lane.name}
+              </h2>
+              <span className="text-sm text-zinc-600">
+                {hits} / {lane.targetPerWeek} days
+              </span>
+            </div>
+
+            {hitTarget ? (
+              <div className="space-y-3">
+                <div className="text-sm font-medium text-green-600">
+                  ✅ Target hit
+                </div>
+                <BossBattleForm
+                  laneId={lane.id}
+                  laneName={lane.name}
+                  weekStarting={weekStart}
+                  existingReport={existing?.selfReport}
+                  existingCoachNote={existing?.coachNote ?? undefined}
+                  createBossBattle={async (data) => {
+                    "use server"
+                    const r = await createBossBattle(data)
+                    return { coachNote: r.ok ? r.coachNote : undefined }
+                  }}
+                />
+              </div>
+            ) : (
+              <p className="text-zinc-500 text-sm">No battle this week — target missed.</p>
+            )}
           </section>
         )
       })}

--- a/src/lib/weekUtils.test.ts
+++ b/src/lib/weekUtils.test.ts
@@ -1,7 +1,40 @@
 import { describe, it, expect } from 'vitest'
-import { getWeekStart, get2WeekBlockStart, formatWeekLabel } from './weekUtils'
+import { getWeekStart, getLastCompletedWeekStart, get2WeekBlockStart, formatWeekLabel } from './weekUtils'
 
 describe('weekUtils', () => {
+  it('last completed week from midweek', () => {
+    // Wednesday 2024-01-10
+    // Current week start: Monday 2024-01-08
+    // Last completed week start: Monday 2024-01-01
+    const date = new Date(Date.UTC(2024, 0, 10))
+    const result = getLastCompletedWeekStart(date)
+    expect(result.getUTCFullYear()).toBe(2024)
+    expect(result.getUTCMonth()).toBe(0)
+    expect(result.getUTCDate()).toBe(1)
+  })
+
+  it('last completed week from Monday', () => {
+    // Monday 2024-01-08
+    // Current week start: Monday 2024-01-08
+    // Last completed week start: Monday 2024-01-01
+    const date = new Date(Date.UTC(2024, 0, 8))
+    const result = getLastCompletedWeekStart(date)
+    expect(result.getUTCFullYear()).toBe(2024)
+    expect(result.getUTCMonth()).toBe(0)
+    expect(result.getUTCDate()).toBe(1)
+  })
+
+  it('last completed week from Sunday', () => {
+    // Sunday 2024-01-14
+    // Current week start: Monday 2024-01-08
+    // Last completed week start: Monday 2024-01-01
+    const date = new Date(Date.UTC(2024, 0, 14))
+    const result = getLastCompletedWeekStart(date)
+    expect(result.getUTCFullYear()).toBe(2024)
+    expect(result.getUTCMonth()).toBe(0)
+    expect(result.getUTCDate()).toBe(1)
+  })
+
   it('getWeekStart Monday input', () => {
     // Monday 2024-01-08
     const date = new Date(Date.UTC(2024, 0, 8))

--- a/src/lib/weekUtils.ts
+++ b/src/lib/weekUtils.ts
@@ -17,6 +17,10 @@ export function getWeekStart(date: Date) {
   return new Date(dayStart - daysSinceMonday * DAY_MS);
 }
 
+export function getLastCompletedWeekStart(date: Date): Date {
+  return new Date(getWeekStart(date).getTime() - 7 * DAY_MS);
+}
+
 export function get2WeekBlockStart(date: Date) {
   const daysSinceEpoch = Math.floor((utcMidnight(date) - EPOCH_START) / DAY_MS);
   const blockIndex = Math.floor(daysSinceEpoch / 14);


### PR DESCRIPTION
Lands stories #96 and #97 — replaces closed PR #102, which the dispatcher tore down when the queue bailed on an unrelated story (#103).

**What changes:** the two-week block concept is gone. Boss battles are now a per-lane review of the **last completed week**, offered only for lanes that reached their weekly target.

- Each lane shows `hits / targetPerWeek days`.
- Target hit → `✅ Target hit` plus the battle form.
- Target missed → "No battle this week — target missed.", no form.
- Rest days count toward the target, matching the dashboard's weekly counter.
- Outcome is computed in code (`hits >= lane.targetPerWeek`), not by the LLM.

Also fixes a live bug: the page heading carried `className="text-2rab font-bold"`, which is not a real Tailwind class, so that `<h1>` has been rendering unstyled.

No schema change — `BossBattle.weekStarting` already held a UTC-midnight Monday; it now holds a real week's Monday instead of a two-week block start, and the `(laneId, weekStarting)` unique constraint still means one battle per lane per week.

Gates run locally on this exact branch: `tsc --noEmit` clean · `pnpm lint` 0 errors (3 pre-existing warnings) · 27 test files / 98 tests pass · `next build` clean.

Not included: deleting the now-unused `get2WeekBlockStart` helper. It stays as harmless dead code for now — see #103/#104.

Closes #96
Closes #97