### PR TITLE
chore(weekUtils): remove the unused get2WeekBlockStart helper

### DIFF
--- a/src/lib/weekUtils.test.ts
+++ b/src/lib/weekUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getWeekStart, getLastCompletedWeekStart, get2WeekBlockStart, formatWeekLabel } from './weekUtils'
+import { getWeekStart, getLastCompletedWeekStart, formatWeekLabel } from './weekUtils'
 
 describe('weekUtils', () => {
   it('last completed week from midweek', () => {
@@ -62,31 +62,6 @@ describe('weekUtils', () => {
     expect(result.getUTCFullYear()).toBe(2024)
     expect(result.getUTCMonth()).toBe(0)
     expect(result.getUTCDate()).toBe(8)
-  })
-
-  it('get2WeekBlockStart same block as Monday', () => {
-    // Epoch starts 2024-01-01 (Monday). 
-    // Block 0 is 2024-01-01 to 2024-01-14
-    const date = new Date(Date.UTC(2024, 0, 5))
-    const result = get2WeekBlockStart(date)
-    expect(result.getUTCFullYear()).toBe(2024)
-    expect(result.getUTCMonth()).toBe(0)
-    expect(result.getUTCDate()).toBe(1)
-  })
-
-  it('get2WeekBlockStart two weeks apart different blocks', () => {
-    // Block 0 starts 2024-01-01
-    // Block 1 starts 2024-01-15
-    const date1 = new Date(Date.UTC(2024, 0, 5))
-    const date2 = new Date(Date.UTC(2024, 0, 20))
-    
-    const result1 = get2WeekBlockStart(date1)
-    const result2 = get2WeekBlockStart(date2)
-
-    expect(result1.getUTCDate()).toBe(1)
-    expect(result2.getUTCDate()).toBe(15)
-    expect(result2.getUTCMonth()).toBe(0)
-    expect(result2.getUTCFullYear()).toBe(2024)
   })
 
   it('formatWeekLabel output format', () => {

--- a/src/lib/weekUtils.ts
+++ b/src/lib/weekUtils.ts
@@ -1,10 +1,9 @@
 import { formatInTimeZone } from 'date-fns-tz';
 
+// All week math is UTC-based so results are stable regardless of the machine's
+// local timezone. (The test suite pins TZ to a non-UTC zone precisely to keep
+// this honest — see package.json.)
 const DAY_MS = 24 * 60 * 60 * 1000;
-// Epoch: Monday 2024-01-01 (UTC). All week math is UTC-based so results are
-// stable regardless of the machine's local timezone. (The test suite pins TZ
-// to a non-UTC zone precisely to keep this honest — see package.json.)
-const EPOCH_START = Date.UTC(2024, 0, 1);
 
 function utcMidnight(date: Date) {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
@@ -19,12 +18,6 @@ export function getWeekStart(date: Date) {
 
 export function getLastCompletedWeekStart(date: Date): Date {
   return new Date(getWeekStart(date).getTime() - 7 * DAY_MS);
-}
-
-export function get2WeekBlockStart(date: Date) {
-  const daysSinceEpoch = Math.floor((utcMidnight(date) - EPOCH_START) / DAY_MS);
-  const blockIndex = Math.floor(daysSinceEpoch / 14);
-  return new Date(EPOCH_START + blockIndex * 14 * DAY_MS);
 }
 
 export function formatWeekLabel(date: Date) {


### PR DESCRIPTION
Deletes `get2WeekBlockStart`, its `EPOCH_START` constant and its two tests. Boss battles are now gated on the last completed week's target (#97), so the two-week block concept has no remaining callers.

**Done by hand rather than dispatched.** dag-coder cannot express this change in any decomposition:

- Source + test in one story → fails `TS2724` (deletes the export, leaves the test import). Reproduced twice: #98.
- Test file alone → `ValueError: No non-test target files found; can't run two-stage flow`. The runner requires at least one non-test target: #103.

Follow-up #104 is closed alongside those.

**One judgement call:** the comment above `EPOCH_START` opened with an epoch-specific sentence but continued with a note about all week math being UTC-based and the test suite pinning a non-UTC `TZ` to keep it honest. That second part documents the whole module, so it is kept and reattached to `DAY_MS` rather than deleted with the constant.

Gates run locally on this exact branch: `tsc --noEmit` clean · `pnpm lint` 0 errors (3 pre-existing warnings) · 27 test files / 96 tests pass (2 fewer — the deleted ones) · `next build` clean.

Closes #104