### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,3 +73,15 @@ model StreakFreeze {
 
   @@index([laneId])
 }
+
+// Prize — the single thing the player is training for.
+// id is a fixed singleton value and reasons is an ordered scalar list.
+model Prize {
+  id          String   @id @default("prize")
+  title       String
+  description String?
+  reasons     String[]
+  photoUrl    String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}

--- a/src/app/actions/upsertPrize.test.ts
+++ b/src/app/actions/upsertPrize.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma as db } from '@/lib/db'
+import type { Prize } from '@prisma/client'
+import { upsertPrize } from './upsertPrize'
+import { revalidatePath } from 'next/cache'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    checkIn: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    bossBattle: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    weeklyReflection: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    streakFreeze: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    prize: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+const makePrize = (overrides: Partial<Prize> = {}): Prize =>
+  ({
+    id: '',
+    title: '',
+    description: '',
+    reasons: [],
+    photoUrl: '',
+    createdAt: new Date(Date.UTC(2024, 0, 1)),
+    updatedAt: new Date(Date.UTC(2024, 0, 1)),
+    ...overrides,
+  } as unknown as Prize)
+
+describe('upsertPrize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('valid input upserts the singleton row', async () => {
+    const input = {
+      title: 'Epic Victory',
+      description: 'A great prize',
+      reasons: ['Hard work'],
+      photoUrl: 'https://example.com/photo.png',
+    }
+
+    vi.mocked(db.prize.upsert).mockResolvedValue(makePrize({ title: 'Epic Victory' }))
+
+    const res = await upsertPrize(input)
+
+    expect(res).toEqual({ ok: true, id: 'prize' })
+    expect(db.prize.upsert).toHaveBeenCalledWith({
+      where: { id: 'prize' },
+      update: expect.objectContaining({
+        title: 'Epic Victory',
+        photoUrl: 'https://example.com/photo.png',
+      }),
+      create: expect.objectContaining({
+        id: 'prize',
+        title: 'Epic Victory',
+      }),
+    })
+    expect(revalidatePath).toHaveBeenCalledWith('/prize')
+  })
+
+  it('empty title returns a validation error', async () => {
+    const input = {
+      title: '', // Invalid according to schema
+      description: 'No title',
+    }
+
+    const res = await upsertPrize(input)
+
+    expect(res).toEqual({ ok: false, error: 'validation' })
+    expect(db.prize.upsert).not.toHaveBeenCalled()
+  })
+
+  it('validation failure skips the database', async () => {
+    const input = {}
+
+    const res = await upsertPrize(input)
+
+    expect(res).toEqual({ ok: false, error: 'validation' })
+    expect(db.prize.upsert).not.toHaveBeenCalled()
+  })
+}) 

--- a/src/app/actions/upsertPrize.ts
+++ b/src/app/actions/upsertPrize.ts
@@ -1,0 +1,44 @@
+import { prisma as db } from "@/lib/db";
+import { prizeSchema } from "@/lib/validation";
+import { revalidatePath } from "next/cache";
+
+export async function upsertPrize(input: unknown): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const parsed = prizeSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return { ok: false, error: "validation" };
+  }
+
+  const data = parsed.data;
+  const inputAsObj = input as Record<string, unknown>;
+
+  // To ensure photoUrl is left untouched when the field is absent from the input,
+  // we check if 'photoUrl' exists in the raw input object.
+  let photoUrl: string | null | undefined = data.photoUrl;
+
+  if (!("photoUrl" in inputAsObj)) {
+    const existing = await db.prize.findUnique({
+      where: { id: "prize" },
+      select: { photoUrl: true },
+    });
+    photoUrl = existing?.photoUrl ?? null;
+  }
+
+  const updateData = {
+    ...data,
+    photoUrl: photoUrl ?? null,
+  };
+
+  await db.prize.upsert({
+    where: { id: "prize" },
+    update: updateData,
+    create: {
+      id: "prize",
+      ...updateData,
+    },
+  });
+
+  revalidatePath("/prize");
+
+  return { ok: true, id: "prize" };
+}

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema } from './validation'
+import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
 
 describe('validation', () => {
   it('laneSchema valid input passes', () => {
@@ -55,7 +55,7 @@ describe('validation', () => {
     const invalidData = {
       date: new Date(Date.UTC(2023, 10, 1)),
       isRest: false
-    }
+    } as any
     const result = checkInSchema.safeParse(invalidData)
     expect(result.success).toBe(false)
   })
@@ -78,4 +78,49 @@ describe('validation', () => {
     const result = reflectionSchema.safeParse(invalidData)
     expect(result.success).toBe(false)
   })
-})
+
+  it('prize accepts a full valid record', () => {
+    const validData = {
+      title: 'MVP Award',
+      description: 'For the best player of the season.',
+      reasons: ['Great teamwork', 'High scoring'],
+      photoUrl: 'https://example.com/photo.jpg'
+    }
+    const result = prizeSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.title).toBe('MVP Award')
+      expect(result.data.reasons).toHaveLength(2)
+    }
+  })
+
+  it('prize rejects an empty title', () => {
+    const invalidData = {
+      title: '   ',
+      description: 'Valid description'
+    }
+    const result = prizeSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('prize rejects more than ten reasons', () => {
+    const invalidData = {
+      title: 'Too many reasons',
+      reasons: Array(11).fill('Reason')
+    }
+    const result = prizeSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('prize accepts an empty reasons array', () => {
+    const validData = {
+      title: 'New Prize',
+      reasons: []
+    }
+    const result = prizeSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reasons).toEqual([])
+    }
+  })
+}) 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -24,7 +24,15 @@ export const reflectionSchema = z.object({
   playerNote: z.string().trim().min(1).max(500),
 })
 
+export const prizeSchema = z.object({
+  title: z.string().trim().min(1).max(80),
+  description: z.string().trim().max(500).optional().nullable().transform((val) => (val === "" ? undefined : val)),
+  reasons: z.array(z.string().trim().min(1).max(200)).max(10).default([]),
+  photoUrl: z.string().url().optional().nullable(),
+})
+
 export type LaneInput = z.infer<typeof laneSchema>
 export type CheckInInput = z.infer<typeof checkInSchema>
 export type BossBattleInput = z.infer<typeof bossBattleSchema>
 export type ReflectionInput = z.infer<typeof reflectionSchema>
+export type PrizeInput = z.infer<typeof prizeSchema>


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#118, #119, #120) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.