### PR TITLE
feat(icons): add PrizeIcon

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -72,3 +72,16 @@ export function MenuIcon() {
     </svg>
   )
 }
+
+export function PrizeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-5 w-5">
+      <path d="M8 4h8v6a4 4 0 0 1-8 0V4z" />
+      <path d="M8 6H5v2a3 3 0 0 0 3 3" />
+      <path d="M16 6h3v2a3 3 0 0 1-3 3" />
+      <line x1="12" y1="14" x2="12" y2="17" />
+      <path d="M9 20h6" />
+      <path d="M10 17h4l1 3H9l1-3z" />
+    </svg>
+  )
+}


### PR DESCRIPTION
Adds `PrizeIcon` (trophy outline) for the Prize page's sidebar entry, following the existing icon pattern exactly: no props, inline SVG, `stroke="currentColor"`, `className="h-5 w-5"`.

**Hand-written rather than dispatched.** Story #125 was ground twice and both runs corrupted a *different* neighbouring export while adding this one:

- attempt 1 changed `MenuIcon`'s `className` from `h-5 w-5` to `h-5 w5`
- attempt 2 changed `BattlesIcon` (99.3% identical to the original)

The export-corruption guard caught both — working exactly as intended. Whole-file regeneration of an 8-export file reliably slips on one of the neighbours, so the story cannot pass as written. Same class of limit as the `get2WeekBlockStart` deletion.

Purely additive: 13 insertions, 0 deletions. Gates: `tsc --noEmit` clean · 31 test files / 115 tests pass · lint 0 errors.

Closes #125