### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/components/SidebarNav.test.tsx
+++ b/src/components/SidebarNav.test.tsx
@@ -13,11 +13,12 @@ describe('SidebarNav', () => {
     vi.mocked(usePathname).mockReturnValue('/')
   })
 
-  it('renders five nav links', async () => {
+  it('renders six nav links', async () => {
     render(<SidebarNav />)
     expect(screen.getByRole('link', { name: 'Today' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Lanes' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Battles' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Prize' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Reflect' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'History' })).toBeInTheDocument()
   })
@@ -56,5 +57,12 @@ describe('SidebarNav', () => {
     
     expect(inactiveLink).not.toHaveAttribute('aria-current')
     expect(inactiveLink).toHaveClass('text-zinc-400')
+  })
+
+  it('renders the prize nav link', async () => {
+    render(<SidebarNav />)
+    const prizeLink = screen.getByRole('link', { name: 'Prize' })
+    expect(prizeLink).toBeInTheDocument()
+    expect(prizeLink).toHaveAttribute('href', '/prize')
   })
 }) 

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -3,13 +3,14 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { 
-  TodayIcon, 
-  LanesIcon, 
-  BattlesIcon, 
-  ReflectIcon, 
-  HistoryIcon, 
-  MenuIcon 
+import {
+  TodayIcon,
+  LanesIcon,
+  BattlesIcon,
+  PrizeIcon,
+  ReflectIcon,
+  HistoryIcon,
+  MenuIcon
 } from '@/components/icons'
 
 interface NavItem {
@@ -22,6 +23,7 @@ const NAV: NavItem[] = [
   { href: '/', label: 'Today', icon: TodayIcon },
   { href: '/lanes', label: 'Lanes', icon: LanesIcon },
   { href: '/boss-battles', label: 'Battles', icon: BattlesIcon },
+  { href: '/prize', label: 'Prize', icon: PrizeIcon },
   { href: '/reflection', label: 'Reflect', icon: ReflectIcon },
   { href: '/history', label: 'History', icon: HistoryIcon },
 ]

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -65,10 +65,21 @@ export function HistoryIcon() {
 
 export function MenuIcon() {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-5 w-5">
+    <svg viewBox="0 0 24 24" fill="none" stroke="\currentColor" strokeWidth={1.5} className="h-5 w-5">
       <line x1="3" y1="12" x2="21" y2="12" />
       <line x1="3" y1="6" x2="21" y2="6" />
       <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  )
+}
+
+export function PrizeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-5 w-5">
+      <path d="M6 9l6-3 6 3v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V9z" />
+      <path d="M12 3v3" />
+      <path d="M12 12h.01" />
+      <path d="M9 15h6" />
     </svg>
   )
 }


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#125, #127) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.