### PR TITLE
feat(prize): add PrizeForm component

### DIFF
--- a/src/components/PrizeForm.test.tsx
+++ b/src/components/PrizeForm.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PrizeForm from './PrizeForm'
+
+describe('PrizeForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders seeded title and reasons', async () => {
+    render(
+      <PrizeForm
+        existingTitle="PS5"
+        existingDescription="The disc one"
+        existingReasons={['I have wanted one for ages', 'Play with my team online']}
+        savePrize={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('prize-title')).toHaveValue('PS5')
+    expect(screen.getByTestId('prize-description')).toHaveValue('The disc one')
+    expect(screen.getByTestId('prize-reason-0')).toHaveValue('I have wanted one for ages')
+    expect(screen.getByTestId('prize-reason-1')).toHaveValue('Play with my team online')
+  })
+
+  it('empty title blocks submit', async () => {
+    const savePrize = vi.fn()
+    render(<PrizeForm savePrize={savePrize} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Name the thing you want')
+    expect(savePrize).not.toHaveBeenCalled()
+  })
+
+  it('add a reason appends an input', async () => {
+    render(<PrizeForm existingTitle="PS5" existingReasons={['First reason']} savePrize={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add a reason' }))
+
+    expect(screen.getByTestId('prize-reason-1')).toBeInTheDocument()
+    expect(screen.getByTestId('prize-reason-1')).toHaveValue('')
+  })
+
+  it('remove drops the first reason', async () => {
+    render(
+      <PrizeForm
+        existingTitle="PS5"
+        existingReasons={['First reason', 'Second reason']}
+        savePrize={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove reason 1' }))
+
+    // Rows are keyed by position, so the survivor shifts up into index 0 —
+    // assert on the remaining VALUE, never on a testid having disappeared.
+    const remaining = screen.getAllByTestId(/^prize-reason-/)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toHaveValue('Second reason')
+  })
+
+  it('submit sends trimmed values', async () => {
+    const savePrize = vi.fn().mockResolvedValue(undefined)
+    render(
+      <PrizeForm
+        existingTitle="  PS5  "
+        existingDescription="  The disc one  "
+        existingReasons={['  Play online  ', '   ']}
+        savePrize={savePrize}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(savePrize).toHaveBeenCalledTimes(1)
+    expect(savePrize).toHaveBeenCalledWith({
+      title: 'PS5',
+      description: 'The disc one',
+      reasons: ['Play online'],
+    })
+  })
+})

--- a/src/components/PrizeForm.tsx
+++ b/src/components/PrizeForm.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+const MAX_REASONS = 10
+
+interface PrizeFormProps {
+  existingTitle?: string
+  existingDescription?: string
+  existingReasons?: string[]
+  savePrize: (data: {
+    title: string
+    description: string
+    reasons: string[]
+  }) => Promise<unknown>
+  onCancel?: () => void
+}
+
+export default function PrizeForm({
+  existingTitle,
+  existingDescription,
+  existingReasons,
+  savePrize,
+  onCancel,
+}: PrizeFormProps) {
+  const [title, setTitle] = useState(existingTitle ?? "")
+  const [description, setDescription] = useState(existingDescription ?? "")
+  // One input per reason, keyed by position. Removing a row shifts the rest up,
+  // so a test must assert on the remaining VALUES, never on a fixed testid.
+  const [reasons, setReasons] = useState<string[]>(existingReasons ?? [])
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function updateReason(index: number, value: string) {
+    setReasons((prev) => prev.map((r, i) => (i === index ? value : r)))
+  }
+
+  function removeReason(index: number) {
+    setReasons((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!title.trim()) {
+      setError("Name the thing you want")
+      return
+    }
+
+    startTransition(async () => {
+      await savePrize({
+        title: title.trim(),
+        description: description.trim(),
+        // Blank rows are scaffolding for typing, not content.
+        reasons: reasons.map((r) => r.trim()).filter((r) => r.length > 0),
+      })
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="prize-title" className="text-sm font-medium">
+          What are you playing for?
+        </label>
+        <input
+          id="prize-title"
+          data-testid="prize-title"
+          type="text"
+          value={title}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+          className="rounded-lg border border-zinc-700 bg-zinc-800 p-2 text-zinc-100"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="prize-description" className="text-sm font-medium">
+          Describe it
+        </label>
+        <textarea
+          id="prize-description"
+          data-testid="prize-description"
+          value={description}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setDescription(e.target.value)
+          }
+          className="min-h-[100px] rounded-lg border border-zinc-700 bg-zinc-800 p-2 text-zinc-100"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium">Why I want it</span>
+        {reasons.map((reason, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <input
+              data-testid={"prize-reason-" + index}
+              type="text"
+              value={reason}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                updateReason(index, e.target.value)
+              }
+              className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800 p-2 text-zinc-100"
+            />
+            <button
+              type="button"
+              aria-label={"Remove reason " + (index + 1)}
+              onClick={() => removeReason(index)}
+              className="rounded-lg px-3 py-2 text-sm text-zinc-400 hover:bg-zinc-800 hover:text-red-400"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        {reasons.length < MAX_REASONS && (
+          <button
+            type="button"
+            onClick={() => setReasons((prev) => [...prev, ""])}
+            className="self-start rounded-lg px-3 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800"
+          >
+            Add a reason
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+        >
+          {isPending ? "Saving..." : "Save"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
Adds `PrizeForm` — title, description, and an add/remove list of up to 10 reasons — plus its five tests. Closes #123.

**Hand-written after five consecutive failed grinds.** The failure moved every time rather than converging:

1. hallucinated `@/components/ui/button|input|textarea` imports (this repo has no component library)
2. asserted the transient `Saving...` label against an instantly-resolving mock — unassertable by construction
3. emitted `data-testid="\$prize-reason-1"` — a literal \$ from nested backticks in my AC
4. scaffold-integrity: dropped 2 of 5 test names
5. scaffold-integrity again, same two names

Three of those were defects in my story spec, and each was fixed in turn; the last two were the coder losing the scaffold. At five attempts the cost had well exceeded writing it.

Behaviour: blank reasons dropped and all fields trimmed on submit; empty title rejected client-side with `Name the thing you want`; `Add a reason` hidden at 10. Reason rows are keyed by position, so removing row 1 shifts row 2 up — the test asserts on remaining values, not on a testid vanishing.

Gates: `tsc --noEmit` clean · 32 test files / 120 tests pass · `next build` clean · lint 0 errors.