### PR TITLE
feat(prize): Prize page + PrizeSection wrapper

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        // Prize photos live in Vercel Blob. next/image refuses any remote host
+        // it hasn't been told about, and the store's subdomain is generated per
+        // store — so match the whole public blob domain rather than pinning
+        // this one, which would break if the store is ever recreated.
+        protocol: "https",
+        hostname: "**.public.blob.vercel-storage.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -1,0 +1,68 @@
+import { prisma } from "@/lib/db"
+import { upsertPrize } from "@/app/actions/upsertPrize"
+import { deletePrize } from "@/app/actions/deletePrize"
+import { uploadPrizePhoto } from "@/app/actions/uploadPrizePhoto"
+import PrizeSection from "@/components/PrizeSection"
+
+export const dynamic = "force-dynamic"
+
+export default async function PrizePage() {
+  const prize = await prisma.prize.findUnique({ where: { id: "prize" } })
+
+  return (
+    <main className="max-w-2xl mx-auto space-y-6 p-6">
+      <h1 className="text-2xl font-bold">The Prize</h1>
+      <p className="mt-1 text-sm text-zinc-500">
+        The one thing you&apos;re playing for. Keep it in sight.
+      </p>
+
+      <PrizeSection
+        prize={
+          prize
+            ? {
+                title: prize.title,
+                description: prize.description,
+                reasons: prize.reasons,
+                photoUrl: prize.photoUrl,
+              }
+            : null
+        }
+        savePrize={async (data) => {
+          "use server"
+          return upsertPrize(data)
+        }}
+        deletePrize={async () => {
+          "use server"
+          return deletePrize()
+        }}
+      />
+
+      {prize && (
+        <form
+          action={async (formData: FormData) => {
+            "use server"
+            await uploadPrizePhoto(formData)
+          }}
+          className="flex flex-col gap-2 border-t border-zinc-800 pt-6"
+        >
+          <label htmlFor="prize-photo" className="text-sm font-medium">
+            {prize.photoUrl ? "Replace photo" : "Upload photo"}
+          </label>
+          <input
+            id="prize-photo"
+            type="file"
+            name="photo"
+            accept="image/*"
+            className="text-sm text-zinc-400"
+          />
+          <button
+            type="submit"
+            className="self-start rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+          >
+            {prize.photoUrl ? "Replace photo" : "Upload photo"}
+          </button>
+        </form>
+      )}
+    </main>
+  )
+}

--- a/src/components/PrizeSection.tsx
+++ b/src/components/PrizeSection.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useState } from "react"
+import PrizeForm from "@/components/PrizeForm"
+import PrizeDisplay from "@/components/PrizeDisplay"
+
+interface PrizeSectionProps {
+  prize: {
+    title: string
+    description: string | null
+    reasons: string[]
+    photoUrl: string | null
+  } | null
+  savePrize: (data: {
+    title: string
+    description: string
+    reasons: string[]
+  }) => Promise<unknown>
+  deletePrize: () => Promise<unknown>
+}
+
+/**
+ * Owns the view/edit toggle for the Prize.
+ *
+ * This wrapper exists because `PrizeDisplay` needs an `onEdit` callback, and
+ * `/prize/page.tsx` is a server component — a server component can pass server
+ * ACTIONS across the boundary but not client callbacks. So the boolean lives
+ * here, on the client, and the page stays a plain data fetch.
+ */
+export default function PrizeSection({
+  prize,
+  savePrize,
+  deletePrize,
+}: PrizeSectionProps) {
+  const [isEditing, setIsEditing] = useState(false)
+
+  // No prize yet: the form IS the empty state, so a first visit lands straight
+  // on "What are you playing for?" rather than a dead end.
+  if (!prize) {
+    return <PrizeForm savePrize={savePrize} />
+  }
+
+  if (isEditing) {
+    return (
+      <PrizeForm
+        existingTitle={prize.title}
+        existingDescription={prize.description ?? undefined}
+        existingReasons={prize.reasons}
+        savePrize={async (data) => {
+          const result = await savePrize(data)
+          setIsEditing(false)
+          return result
+        }}
+        onCancel={() => setIsEditing(false)}
+      />
+    )
+  }
+
+  return (
+    <PrizeDisplay
+      title={prize.title}
+      description={prize.description}
+      reasons={prize.reasons}
+      photoUrl={prize.photoUrl}
+      onEdit={() => setIsEditing(true)}
+      deletePrize={deletePrize}
+    />
+  )
+}


### PR DESCRIPTION
Completes the Prize feature. Closes #126.

## Why this was hand-written

Story #126 as specced was **unbuildable**. `PrizeDisplay` takes an `onEdit: () => void` callback, but `/prize/page.tsx` is a server component — it can pass server *actions* across the client boundary, but not callbacks. The coder tried to satisfy that contract and invented a combined `@/app/actions/prize` module and a FormData-shaped `savePrize` in the attempt.

`PrizeSection` is the missing piece: a small client wrapper owning the view/edit boolean, so the page stays a plain data fetch. That gap was in my story breakdown, not in the coder.

## A bug only running the app found

The photo upload worked first try — a real blob URL came back. But `next/image` threw at render:

```
Invalid src prop ... hostname "cq8nyspkgflunzsg.public.blob.vercel-storage.com"
is not configured under images in your `next.config.js`
```

`tsc`, `lint`, `next build` and all 121 tests passed on that code. Nothing short of loading the page could have caught it — and it would have failed identically in production.

Fixed with a `remotePatterns` entry matching `**.public.blob.vercel-storage.com` rather than this store's generated subdomain, so recreating the store won't break it.

## Verified end to end

Created a prize (title, description, two reasons) → saved → switched to display → uploaded a photo to Vercel Blob → rendered → edit reopened the form seeded with existing values. DB row confirms `photoUrl` set and 2 reasons.

Gates: `tsc --noEmit` clean · 121 tests pass · `next build` clean · lint 0 errors.