### PR TITLE
chore(build): sync prod schema on deploy via vercel-build

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,27 @@
 
 Source of truth for all persistence.
 
+**Schema changes reach production via the build, not by hand.** This repo is
+schema-first — there is no `prisma/migrations/`, so the schema file *is* the
+migration. `package.json` therefore defines a `vercel-build` script that runs
+`prisma db push` before `next build`; Vercel prefers `vercel-build` over
+`build` when present, so every production deploy syncs the database to the
+schema using the `DATABASE_URL` Vercel injects. Two consequences worth knowing:
+
+- **CI still runs plain `build`**, which has no `db push`. That is deliberate:
+  CI sets a placeholder `DATABASE_URL` pointing at a database that does not
+  exist, and a push there would fail every PR.
+- **`db push` refuses any change that would lose data.** Additive changes (a
+  new model, a new nullable column) apply silently; a rename or a dropped
+  column fails the build instead of destroying rows. Never add
+  `--accept-data-loss` to that script — it converts a blocked deploy into
+  silent data loss.
+
+Nobody needs the production connection string to ship a schema change. Vercel
+marks every Postgres variable *sensitive*, so `vercel env pull` returns
+`[SENSITIVE]` rather than the value and a local `prisma db push` against prod
+is not possible without fetching the string out of the Neon console by hand.
+
 ```prisma
 // Lane — a skill domain Eddie trains (e.g. "Stick Skills", "Shooting", "Conditioning")
 model Lane {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",
+    "vercel-build": "prisma generate && prisma db push && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "TZ=Pacific/Kiritimati vitest",


### PR DESCRIPTION
Adds a `vercel-build` script so production schema changes apply during deploy:

```json
"build":        "prisma generate && next build",
"vercel-build": "prisma generate && prisma db push && next build",
```

## Why

The repo is schema-first — no `prisma/migrations/` — so a new model reaches prod only if someone runs `prisma db push` against the production database. That turns out to be impractical by hand: Vercel marks **every** Postgres variable sensitive, so `vercel env pull` writes the literal string `[SENSITIVE]` and Prisma rejects it (`P1012: the URL must start with postgresql://`). Getting the real string means copying it out of the Neon console, and the inline-env-var route then failed twice on shell quoting — Neon URLs contain `&`, and the console's copy button includes a `psql '...'` wrapper.

The `Prize` table still does not exist in production as a result. With this change, the next deploy creates it.

Vercel prefers `vercel-build` over `build` when present, so it uses the `DATABASE_URL` it already injects — **nobody handles the credential.**

## Why CI keeps plain `build`

CI sets a placeholder `DATABASE_URL` pointing at a database that does not exist (see `ci.yml`), so a push there would fail every PR. Keeping the push out of `build` leaves CI untouched — verified: `pnpm run build` is still clean.

## Safety

Plain `prisma db push` **refuses any change that would lose data**. Additive changes apply silently; a rename or dropped column fails the build instead of destroying rows. `--accept-data-loss` must never be added to this script — it would convert a blocked deploy into silent data loss. That is written into `docs/architecture.md` alongside the rest of the reasoning.