### PR TITLE
feat(prize): photo input in the form — drag, browse, or paste a link

### DIFF
--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -35,34 +35,12 @@ export default async function PrizePage() {
           "use server"
           return deletePrize()
         }}
+        uploadPhoto={async (formData: FormData) => {
+          "use server"
+          return uploadPrizePhoto(formData)
+        }}
       />
 
-      {prize && (
-        <form
-          action={async (formData: FormData) => {
-            "use server"
-            await uploadPrizePhoto(formData)
-          }}
-          className="flex flex-col gap-2 border-t border-zinc-800 pt-6"
-        >
-          <label htmlFor="prize-photo" className="text-sm font-medium">
-            {prize.photoUrl ? "Replace photo" : "Upload photo"}
-          </label>
-          <input
-            id="prize-photo"
-            type="file"
-            name="photo"
-            accept="image/*"
-            className="text-sm text-zinc-400"
-          />
-          <button
-            type="submit"
-            className="self-start rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
-          >
-            {prize.photoUrl ? "Replace photo" : "Upload photo"}
-          </button>
-        </form>
-      )}
     </main>
   )
 }

--- a/src/components/PrizeForm.tsx
+++ b/src/components/PrizeForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useTransition } from "react"
+import PrizePhotoInput, { type PrizePhotoSelection } from "@/components/PrizePhotoInput"
 
 const MAX_REASONS = 10
 
@@ -8,11 +9,18 @@ interface PrizeFormProps {
   existingTitle?: string
   existingDescription?: string
   existingReasons?: string[]
+  existingPhotoUrl?: string | null
   savePrize: (data: {
     title: string
     description: string
     reasons: string[]
   }) => Promise<unknown>
+  /**
+   * Uploads the chosen photo. Called AFTER savePrize resolves, because the
+   * upload writes onto the Prize row — the row has to exist first. Optional so
+   * the form still works without a photo path wired up.
+   */
+  uploadPhoto?: (formData: FormData) => Promise<unknown>
   onCancel?: () => void
 }
 
@@ -20,7 +28,9 @@ export default function PrizeForm({
   existingTitle,
   existingDescription,
   existingReasons,
+  existingPhotoUrl,
   savePrize,
+  uploadPhoto,
   onCancel,
 }: PrizeFormProps) {
   const [title, setTitle] = useState(existingTitle ?? "")
@@ -28,6 +38,7 @@ export default function PrizeForm({
   // One input per reason, keyed by position. Removing a row shifts the rest up,
   // so a test must assert on the remaining VALUES, never on a fixed testid.
   const [reasons, setReasons] = useState<string[]>(existingReasons ?? [])
+  const [photo, setPhoto] = useState<PrizePhotoSelection | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
 
@@ -55,6 +66,16 @@ export default function PrizeForm({
         // Blank rows are scaffolding for typing, not content.
         reasons: reasons.map((r) => r.trim()).filter((r) => r.length > 0),
       })
+
+      // Photo second, and only if one was chosen: uploadPrizePhoto updates the
+      // Prize row, so it needs the row savePrize just created. One Save from
+      // Eddie's side; two calls underneath.
+      if (photo && uploadPhoto) {
+        const formData = new FormData()
+        if (photo.file) formData.set("photo", photo.file)
+        if (photo.url) formData.set("photoUrl", photo.url)
+        await uploadPhoto(formData)
+      }
     })
   }
 
@@ -122,6 +143,10 @@ export default function PrizeForm({
           </button>
         )}
       </div>
+
+      {uploadPhoto && (
+        <PrizePhotoInput existingPhotoUrl={existingPhotoUrl} onChange={setPhoto} />
+      )}
 
       {error && (
         <p className="text-sm text-red-500" role="alert">

--- a/src/components/PrizePhotoInput.test.tsx
+++ b/src/components/PrizePhotoInput.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PrizePhotoInput from './PrizePhotoInput'
+
+// jsdom has no object-URL implementation; the component only uses it for the
+// local preview, so a stub keeps the assertions about behaviour not plumbing.
+beforeEach(() => {
+  vi.clearAllMocks()
+  globalThis.URL.createObjectURL = vi.fn(() => 'blob:preview')
+})
+
+const imageFile = () =>
+  new File(['fake-bytes'], 'ps5.png', { type: 'image/png' })
+
+describe('PrizePhotoInput', () => {
+  it('selecting a file reports it and shows a preview', async () => {
+    const onChange = vi.fn()
+    render(<PrizePhotoInput onChange={onChange} />)
+
+    const file = imageFile()
+    await userEvent.upload(screen.getByTestId('prize-photo-file'), file)
+
+    expect(onChange).toHaveBeenCalledWith({ file })
+    expect(screen.getByTestId('prize-photo-preview')).toHaveAttribute('src', 'blob:preview')
+  })
+
+  it('dropping a file reports it', async () => {
+    const onChange = vi.fn()
+    render(<PrizePhotoInput onChange={onChange} />)
+
+    const file = imageFile()
+    fireEvent.drop(screen.getByTestId('prize-photo-dropzone'), {
+      dataTransfer: { files: [file] },
+    })
+
+    expect(onChange).toHaveBeenCalledWith({ file })
+  })
+
+  it('rejects a non-image file', async () => {
+    const onChange = vi.fn()
+    render(<PrizePhotoInput onChange={onChange} />)
+
+    const notAnImage = new File(['x'], 'notes.txt', { type: 'text/plain' })
+    fireEvent.drop(screen.getByTestId('prize-photo-dropzone'), {
+      dataTransfer: { files: [notAnImage] },
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('not an image')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a file over 5 MB', async () => {
+    const onChange = vi.fn()
+    render(<PrizePhotoInput onChange={onChange} />)
+
+    const big = new File(['x'], 'huge.png', { type: 'image/png' })
+    Object.defineProperty(big, 'size', { value: 6 * 1024 * 1024 })
+    fireEvent.drop(screen.getByTestId('prize-photo-dropzone'), {
+      dataTransfer: { files: [big] },
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('bigger than 5 MB')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('pasting a url reports it and previews it', async () => {
+    const onChange = vi.fn()
+    render(<PrizePhotoInput onChange={onChange} />)
+
+    await userEvent.type(screen.getByTestId('prize-photo-url'), 'https://x.test/a.png')
+
+    expect(onChange).toHaveBeenLastCalledWith({ url: 'https://x.test/a.png' })
+    expect(screen.getByTestId('prize-photo-preview')).toHaveAttribute(
+      'src',
+      'https://x.test/a.png'
+    )
+  })
+
+  it('clearing a url restores the existing photo', async () => {
+    const onChange = vi.fn()
+    render(<PrizePhotoInput existingPhotoUrl="https://old.test/p.png" onChange={onChange} />)
+
+    const urlInput = screen.getByTestId('prize-photo-url')
+    await userEvent.type(urlInput, 'https://x.test/a.png')
+    await userEvent.clear(urlInput)
+
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(screen.getByTestId('prize-photo-preview')).toHaveAttribute(
+      'src',
+      'https://old.test/p.png'
+    )
+  })
+
+  it('shows the existing photo when there is no selection', () => {
+    render(<PrizePhotoInput existingPhotoUrl="https://old.test/p.png" onChange={vi.fn()} />)
+
+    expect(screen.getByTestId('prize-photo-preview')).toHaveAttribute(
+      'src',
+      'https://old.test/p.png'
+    )
+  })
+})

--- a/src/components/PrizePhotoInput.tsx
+++ b/src/components/PrizePhotoInput.tsx
@@ -1,0 +1,162 @@
+"use client"
+
+import { useRef, useState } from "react"
+
+export interface PrizePhotoSelection {
+  file?: File
+  url?: string
+}
+
+interface PrizePhotoInputProps {
+  existingPhotoUrl?: string | null
+  onChange: (selection: PrizePhotoSelection | null) => void
+}
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB — matches uploadPrizePhoto
+
+/**
+ * Three ways to give the prize a photo: drop a file, browse for one, or paste
+ * an image address. All three resolve to a `PrizePhotoSelection` handed to the
+ * parent — nothing uploads here. The upload happens after the Prize row is
+ * saved, because the photo attaches to that row.
+ */
+export default function PrizePhotoInput({
+  existingPhotoUrl,
+  onChange,
+}: PrizePhotoInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [preview, setPreview] = useState<string | null>(existingPhotoUrl ?? null)
+  const [pastedUrl, setPastedUrl] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  function selectFile(file: File) {
+    setError(null)
+
+    if (!file.type.startsWith("image/")) {
+      setError("That file is not an image")
+      return
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      setError("That image is bigger than 5 MB")
+      return
+    }
+
+    // Object URL is for the local preview only; the real upload sends the File.
+    setPreview(URL.createObjectURL(file))
+    setPastedUrl("")
+    onChange({ file })
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+    setIsDragging(false)
+    const file = e.dataTransfer.files?.[0]
+    if (file) selectFile(file)
+  }
+
+  function handleUrlChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value
+    setPastedUrl(value)
+    setError(null)
+
+    const trimmed = value.trim()
+    if (!trimmed) {
+      setPreview(existingPhotoUrl ?? null)
+      onChange(null)
+      return
+    }
+    setPreview(trimmed)
+    onChange({ url: trimmed })
+  }
+
+  function clearSelection() {
+    setPreview(existingPhotoUrl ?? null)
+    setPastedUrl("")
+    setError(null)
+    if (inputRef.current) inputRef.current.value = ""
+    onChange(null)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm font-medium">Photo</span>
+
+      <div
+        data-testid="prize-photo-dropzone"
+        onDragOver={(e) => {
+          e.preventDefault()
+          setIsDragging(true)
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+        className={
+          "flex flex-col items-center gap-2 rounded-lg border border-dashed p-4 text-center " +
+          (isDragging
+            ? "border-emerald-500 bg-emerald-500/5"
+            : "border-zinc-700 bg-zinc-900")
+        }
+      >
+        <p className="text-sm text-zinc-400">Drag an image here</p>
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800"
+        >
+          Choose a file
+        </button>
+        <input
+          ref={inputRef}
+          data-testid="prize-photo-file"
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0]
+            if (file) selectFile(file)
+          }}
+        />
+      </div>
+
+      <label htmlFor="prize-photo-url" className="text-sm text-zinc-400">
+        …or paste an image link
+      </label>
+      <input
+        id="prize-photo-url"
+        data-testid="prize-photo-url"
+        type="url"
+        value={pastedUrl}
+        onChange={handleUrlChange}
+        placeholder="https://"
+        className="rounded-lg border border-zinc-700 bg-zinc-800 p-2 text-zinc-100"
+      />
+
+      {error && (
+        <p className="text-sm text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+
+      {preview && (
+        <div className="flex items-center gap-3">
+          {/* Plain img, not next/image: a blob: object URL or a not-yet-fetched
+              remote host is exactly what next/image refuses to render. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            data-testid="prize-photo-preview"
+            src={preview}
+            alt="Prize photo preview"
+            className="h-20 w-20 rounded-lg object-cover"
+          />
+          <button
+            type="button"
+            onClick={clearSelection}
+            className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/PrizeSection.tsx
+++ b/src/components/PrizeSection.tsx
@@ -17,6 +17,7 @@ interface PrizeSectionProps {
     reasons: string[]
   }) => Promise<unknown>
   deletePrize: () => Promise<unknown>
+  uploadPhoto: (formData: FormData) => Promise<unknown>
 }
 
 /**
@@ -31,13 +32,14 @@ export default function PrizeSection({
   prize,
   savePrize,
   deletePrize,
+  uploadPhoto,
 }: PrizeSectionProps) {
   const [isEditing, setIsEditing] = useState(false)
 
   // No prize yet: the form IS the empty state, so a first visit lands straight
   // on "What are you playing for?" rather than a dead end.
   if (!prize) {
-    return <PrizeForm savePrize={savePrize} />
+    return <PrizeForm savePrize={savePrize} uploadPhoto={uploadPhoto} />
   }
 
   if (isEditing) {
@@ -46,6 +48,8 @@ export default function PrizeSection({
         existingTitle={prize.title}
         existingDescription={prize.description ?? undefined}
         existingReasons={prize.reasons}
+        existingPhotoUrl={prize.photoUrl}
+        uploadPhoto={uploadPhoto}
         savePrize={async (data) => {
           const result = await savePrize(data)
           setIsEditing(false)


### PR DESCRIPTION
The photo control only appeared once a prize existed, so a first-time user sees no way to add a photo at all — which is exactly what happened. This puts it in the form itself, with three ways in: **drag and drop**, **choose a file**, or **paste an image link**, plus a preview of the selection.

## How it fits together

`PrizePhotoInput` uploads nothing. It resolves any of the three inputs to a `{ file }` or `{ url }` selection and hands it to `PrizeForm`, which saves the prize and then uploads. That ordering is forced — `uploadPrizePhoto` writes onto the Prize row, so the row must exist — but from Eddie's side it is one Save.

Client-side guards mirror the action: images only, 5 MB max, with the message shown inline.

## Two deliberate choices

**The preview uses a plain `<img>`, not `next/image`.** A `blob:` object URL, or a pasted host that has not been fetched yet, is precisely what `next/image` refuses to render — the failure we hit yesterday. The lint suppression is narrowed to that one line.

**A pasted URL will be re-uploaded to Blob, not hotlinked** — that is story #146, still grinding. Until it lands the URL field will fail; the file and drag paths work today.

## Verified

Loaded the page, entered edit mode, confirmed the drop zone, file picker, URL field and existing-photo preview all render, and that the old gated form is gone.

Gates: `tsc --noEmit` clean · 33 test files / 128 tests pass (7 new) · lint 0 errors.