### PR TITLE
feat(prize): accept a pasted image link

### DIFF
--- a/src/app/actions/uploadPrizePhoto.test.ts
+++ b/src/app/actions/uploadPrizePhoto.test.ts
@@ -100,4 +100,79 @@ describe('uploadPrizePhoto', () => {
     expect(result).toEqual({ ok: false, error: 'too-large' })
     expect(put).not.toHaveBeenCalled()
   })
+
+  describe('remote url', () => {
+    const remoteUrl = 'https://images.test/photos/ps5.png'
+
+    const okResponse = (type = 'image/png', size = 1024) =>
+      ({
+        ok: true,
+        headers: { get: (h: string) => (h === 'content-type' ? type : null) },
+        blob: async () => ({ size }) as Blob,
+      }) as unknown as Response
+
+    it('remote url uploads and stores', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse()))
+      vi.mocked(put).mockResolvedValue({ url: 'https://blob.test/prize/ps5.png' } as never)
+      vi.mocked(db.prize.findUnique).mockResolvedValue(null)
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+      const result = await uploadPrizePhoto(fd)
+
+      expect(result).toEqual({ ok: true, url: 'https://blob.test/prize/ps5.png' })
+      // the blob pathname keeps the final segment of the remote path
+      expect(vi.mocked(put).mock.calls[0][0]).toContain('ps5.png')
+      expect(db.prize.update).toHaveBeenCalledWith({
+        where: { id: 'prize' },
+        data: { photoUrl: 'https://blob.test/prize/ps5.png' },
+      })
+      expect(revalidatePath).toHaveBeenCalledWith('/prize')
+    })
+
+    it('non-image url returns not-an-image', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse('text/html')))
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: false, error: 'not-an-image' })
+      expect(put).not.toHaveBeenCalled()
+    })
+
+    it('oversized url returns too-large', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse('image/png', 6 * 1024 * 1024)))
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: false, error: 'too-large' })
+      expect(put).not.toHaveBeenCalled()
+    })
+
+    it('failed fetch returns fetch-failed', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as Response))
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: false, error: 'fetch-failed' })
+      expect(put).not.toHaveBeenCalled()
+    })
+
+    it('file wins when both are present', async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      vi.mocked(put).mockResolvedValue({ url: 'https://blob.test/prize/from-file.png' } as never)
+      vi.mocked(db.prize.findUnique).mockResolvedValue(null)
+
+      const fd = new FormData()
+      fd.append('photo', new File(['bytes'], 'from-file.png', { type: 'image/png' }))
+      fd.append('photoUrl', remoteUrl)
+      const result = await uploadPrizePhoto(fd)
+
+      expect(result).toEqual({ ok: true, url: 'https://blob.test/prize/from-file.png' })
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/app/actions/uploadPrizePhoto.ts
+++ b/src/app/actions/uploadPrizePhoto.ts
@@ -4,25 +4,74 @@ import { prisma as db } from "@/lib/db";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
-export async function uploadPrizePhoto(formData: FormData): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
-  const file = formData.get("photo");
+/** What we're about to upload, once a File or a remote URL has been resolved. */
+type Payload = { body: File | Blob; name: string };
 
-  if (!file || !(file instanceof File)) {
-    return { ok: false, error: "no-file" };
+/**
+ * Download a pasted image link so it can be re-uploaded to our own store.
+ *
+ * We deliberately do NOT keep the remote URL: `next/image` only renders hosts
+ * listed in `remotePatterns`, widening that to `**` would turn the app into an
+ * open image proxy, and a hotlinked image vanishes when its host deletes it.
+ */
+async function fetchRemoteImage(
+  url: string
+): Promise<{ ok: true; payload: Payload } | { ok: false; error: string }> {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch {
+    return { ok: false, error: "fetch-failed" };
   }
 
-  if (!file.type.startsWith("image/")) {
+  if (!response.ok) {
+    return { ok: false, error: "fetch-failed" };
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("image/")) {
     return { ok: false, error: "not-an-image" };
   }
 
-  if (file.size > MAX_FILE_SIZE) {
+  // Size is measured from the downloaded bytes, not content-length: that
+  // header is optional and a remote host can lie about it.
+  const body = await response.blob();
+  if (body.size > MAX_FILE_SIZE) {
     return { ok: false, error: "too-large" };
   }
 
+  const lastSegment = new URL(url).pathname.split("/").filter(Boolean).pop();
+  return { ok: true, payload: { body, name: lastSegment || "photo" } };
+}
+
+export async function uploadPrizePhoto(formData: FormData): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const file = formData.get("photo");
+  const remoteUrl = formData.get("photoUrl");
+
+  let payload: Payload;
+
+  if (file instanceof File) {
+    if (!file.type.startsWith("image/")) {
+      return { ok: false, error: "not-an-image" };
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      return { ok: false, error: "too-large" };
+    }
+    payload = { body: file, name: file.name };
+  } else if (typeof remoteUrl === "string" && remoteUrl.trim().length > 0) {
+    const fetched = await fetchRemoteImage(remoteUrl.trim());
+    if (!fetched.ok) {
+      return { ok: false, error: fetched.error };
+    }
+    payload = fetched.payload;
+  } else {
+    return { ok: false, error: "no-file" };
+  }
+
   try {
-    // 1. Upload the new file
-    const pathname = `prize/${Date.now()}-${file.name}`;
-    const blob = await put(pathname, file, { access: "public" });
+    // 1. Upload the new image — same path whether it came from disk or a link
+    const pathname = `prize/${Date.now()}-${payload.name}`;
+    const blob = await put(pathname, payload.body, { access: "public" });
     const newUrl = blob.url;
 
     // 2. Update the database


### PR DESCRIPTION
Completes the third photo route. `uploadPrizePhoto` now accepts either a `photo` File or a `photoUrl` string; a pasted link is fetched server-side, validated, and **re-uploaded to Blob**. Closes #146.

## Why re-upload rather than hotlink

- `next/image` only renders hosts in `remotePatterns`; an arbitrary pasted host fails exactly as the blob host did before it was allowed. Widening to `**` would make the app an open image proxy.
- A hotlinked image vanishes when its host deletes it.
- One store means one rendering rule and one cleanup path.

Size is measured from the **downloaded bytes**, not `content-length` — that header is optional and a remote host can lie about it.

## Hand-written, and why

Story #146 failed twice, both times on model output rather than the spec:

1. `return { ok: false, error: err instanceof Error ? err.string : ... }` — `err.string` is not a property of `Error`. Otherwise a complete implementation.
2. `formData.append('photoUrl', remote eslint-plugin-no-unused-vars: 'photoUrl', remoteUrl)` — a lint plugin name spliced into the middle of a statement.

The second is context bleed, not a missing instruction. The AC was already pinned as tightly as the ones that landed first try, so a third dispatch was a coin flip on ~6 minutes.

## Gates

`tsc --noEmit` clean · 33 test files / **133 tests** pass (5 new) · `next build` clean · lint 0 errors.