### PR TITLE
feat(#150): Story 11.1 — Season Constants and Week List

### DIFF
--- a/src/lib/season.test.ts
+++ b/src/lib/season.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { SEASON_START, SEASON_WEEKS, getSeasonWeeks, getSeasonEnd } from './season'
+
+describe('season', () => {
+  it('getSeasonWeeks returns 13 dates and the first equals SEASON_START', () => {
+    const weeks = getSeasonWeeks()
+    expect(weeks).toHaveLength(SEASON_WEEKS)
+    expect(weeks[0].getTime()).toBe(SEASON_START.getTime())
+  })
+
+  it('every consecutive pair in getSeasonWeeks is exactly 7 days apart', () => {
+    const weeks = getSeasonWeeks()
+    const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
+
+    for (let i = 0; i < weeks.length - 1; i++) {
+      const diff = weeks[i + 1].getTime() - weeks[i].getTime()
+      expect(diff).toBe(MS_PER_WEEK)
+    }
+  })
+
+  it('getSeasonEnd is 91 days after SEASON_START', () => {
+    const end = getSeasonEnd()
+    const MS_PER_DAY = 24 * 60 * 60 * 1000
+    const expectedDiff = 91 * MS_PER_DAY
+    
+    const actualDiff = end.getTime() - SEASON_START.getTime()
+    expect(actualDiff).toBe(expectedDiff)
+  })
+})

--- a/src/lib/season.ts
+++ b/src/lib/season.ts
@@ -1,0 +1,29 @@
+export const SEASON_START = new Date("2026-08-10T00:00:00.000Z");
+export const SEASON_WEEKS = 13;
+export const WEEKS_REQUIRED = 11;
+export const LANES_REQUIRED = 3;
+export const REST_CAP_PER_WEEK = 1;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+
+/**
+ * Returns exactly SEASON_WEEKS dates, starting with SEASON_START,
+ * with each subsequent date being exactly 7 days after the previous one.
+ */
+export function getSeasonWeeks(): Date[] {
+  const weeks: Date[] = [];
+  for (let i = 0; i < SEASON_WEEKS; i++) {
+    const weekDate = new Date(SEASON_START.getTime() + i * MS_PER_WEEK);
+    weeks.push(weekDate);
+  }
+  return weeks;
+}
+
+/**
+ * Returns the exclusive end of the season:
+ * SEASON_START plus (SEASON_WEEKS * 7) days.
+ */
+export function getSeasonEnd(): Date {
+  return new Date(SEASON_START.getTime() + SEASON_WEEKS * MS_PER_WEEK);
+}


### PR DESCRIPTION
## Summary

Implements story #150: Story 11.1 — Season Constants and Week List

## Verified gates (auto-captured by dag-poc)

- `lint` exit 0
- `build` exit 0
- `test` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13371
- Output tokens: 731

Closes #150