### PR TITLE
feat(#162): Story 11.3a — getWeekStatuses

### DIFF
--- a/src/lib/weekStatuses.test.ts
+++ b/src/lib/weekStatuses.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { getWeekStatuses } from './weekStatuses'
+import { getSeasonWeeks } from '@/lib/season'
+
+describe('weekStatuses', () => {
+  it('returns one entry per season week with weekStart values matching getSeasonWeeks', () => {
+    const seasonWeeks = getSeasonWeeks()
+    const today = new Date(Date.UTC(2026, 7, 10)) // 2026-08-10
+    const lanes: any[] = []
+
+    const results = getWeekStatuses(lanes, today)
+
+    expect(results.length).toBe(seasonWeeks.length)
+    seasonWeeks.forEach((weekStart, index) => {
+      expect(results[index].weekStart.getTime()).toBe(weekStart.getTime())
+    })
+  })
+
+  it('a today inside the season marks exactly one week current and every later week upcoming', () => {
+    // Season starts 2026-08-10. 
+    // We pick a date that is clearly in the middle of the season.
+    // We use a date that is definitely not the very first or very last week.
+    const today = new Date(Date.UTC(2026, 8, 15)) // 2026-09-15
+    const lanes: any[] = []
+    const results = getWeekStatuses(lanes, today)
+
+    let currentCount = 0
+    let upcomingCount = 0
+    let elapsedCount = 0
+
+    results.forEach((res) => {
+      if (res.status === 'current') currentCount++
+      if (res.status === 'upcoming') upcomingCount++
+      if (res.status === 'qualified' || res.status === 'missed') elapsedCount++
+    })
+
+    expect(currentCount).toBe(1)
+    expect(upcomingCount).toBeGreaterThan(0)
+    // Ensure no 'upcoming' week is marked 'current'
+    const upcomingWeek = results.find(r => r.status === 'upcoming')
+    if (upcomingWeek) {
+      expect(upcomingWeek.weekStart.getTime()).toBeGreaterThan(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+    }
+  })
+
+  it('an elapsed week with no check-ins at all is missed', () => {
+    // Pick a date far in the future so the first week of the season is definitely elapsed
+    const today = new Date(Date.UTC(2027, 0, 1)) 
+    const lanes: any[] = [] // No check-ins
+    const results = getWeekStatuses(lanes, today)
+
+    // The first week of the season (2026-08-10) should be 'missed' because there are no check-ins
+    const firstWeek = results[0]
+    expect(firstWeek.weekStart.getUTCMonth()).toBe(7) // August
+    expect(firstWeek.weekStart.getUTCDate()).toBe(10)
+    expect(firstWeek.status).toBe('missed')
+  })
+})

--- a/src/lib/weekStatuses.ts
+++ b/src/lib/weekStatuses.ts
@@ -1,0 +1,36 @@
+import { getSeasonWeeks } from "@/lib/season";
+import { isQualifyingWeek } from "@/lib/isQualifyingWeek";
+
+export type WeekStatus = "qualified" | "missed" | "current" | "upcoming";
+
+interface LaneData {
+  targetPerWeek: number;
+  checkIns: { date: Date; isRest: boolean }[];
+}
+
+export function getWeekStatuses(
+  lanes: LaneData[],
+  today: Date
+): { weekStart: Date; status: WeekStatus }[] {
+  const seasonWeeks = getSeasonWeeks();
+
+  return seasonWeeks.map((weekStart) => {
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    // A week whose window contains today gets status "current"
+    if (weekStart <= today && today < weekEnd) {
+      return { weekStart, status: "current" };
+    }
+
+    // A week whose weekStart is strictly after today gets status "upcoming"
+    if (weekStart > today) {
+      return { weekStart, status: "upcoming" };
+    }
+
+    // A week whose window has fully elapsed (weekEnd <= today)
+    // gets "qualified" if isQualifyingWeek returns true, and "missed" otherwise.
+    const qualifies = isQualifyingWeek(lanes, weekStart);
+    return { weekStart, status: qualifies ? "qualified" : "missed" };
+  });
+}


### PR DESCRIPTION
## Summary

Implements story #162: Story 11.3a — getWeekStatuses

## Verified gates (auto-captured by dag-poc)

- `lint` exit 0
- `build` exit 0
- `test` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13748
- Output tokens: 1170

Closes #162