### PR TITLE
feat(#163): Story 11.3b — getSeasonProgress

### DIFF
--- a/src/lib/seasonProgress.test.ts
+++ b/src/lib/seasonProgress.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonProgress } from './seasonProgress'
+import { SEASON_WEEKS, WEEKS_REQUIRED } from '@/lib/season'
+
+describe('seasonProgress', () => {
+  it('missesAllowed is the difference between SEASON_WEEKS and WEEKS_REQUIRED', () => {
+    const lanes: Array<any> = []
+    const today = new Date('2026-11-30T00:00:00.000Z')
+    const progress = getSeasonProgress(lanes, today)
+    
+    expect(progress.missedAllowed).toBe(SEASON_WEEKS - WEEKS_REQUIRED)
+  })
+
+  it('an empty lanes array with a today after the season end leaves qualified at 0 and earned false', () => {
+    const lanes: Array<any> = []
+    const today = new Date('2026-11-30T00:00:00.000Z')
+    const progress = getSeasonProgress(lanes, today)
+    
+    expect(progress.qualified).toBe(0)
+    expect(progress.earned).toBe(false)
+  })
+
+  it('an empty lanes array with a today after the season end floors missesRemaining at 0', () => {
+    const lanes: Array<any> = []
+    const today = new Date('2026-11-30T00:00:00.000Z')
+    const progress = getSeasonProgress(lanes, today)
+    
+    expect(progress.missesRemaining).toBe(0)
+  })
+})

--- a/src/lib/seasonProgress.ts
+++ b/src/lib/seasonProgress.ts
@@ -1,0 +1,43 @@
+import { getWeekStatuses, type WeekStatus } from "@/lib/weekStatuses";
+import { SEASON_WEEKS, WEEKS_REQUIRED } from "@/lib/season";
+
+export interface SeasonProgress {
+  weeks: Array<{
+    weekStart: Date;
+    status: WeekStatus;
+  }>;
+  qualified: number;
+  missed: number;
+  missedAllowed: number;
+  missesRemaining: number;
+  earned: boolean;
+}
+
+export function getSeasonProgress(
+  lanes: Array<{
+    targetPerWeek: number;
+    checkIns: Array<{
+      date: Date;
+      isRest: boolean;
+    }>;
+  }>,
+  today: Date
+): SeasonProgress {
+  const weeks = getWeekStatuses(lanes, today);
+
+  const qualified = weeks.filter((w) => w.status === "qualified").length;
+  const missed = weeks.filter((w) => w.status === "missed").length;
+
+  const missedAllowed = SEASON_WEEKS - WEEKS_REQUIRED;
+  const missesRemaining = Math.max(0, missedAllowed - missed);
+  const earned = qualified >= WEEKS_REQUIRED;
+
+  return {
+    weeks,
+    qualified,
+    missed,
+    missedAllowed,
+    missesRemaining,
+    earned,
+  };
+}


### PR DESCRIPTION
## Summary

Implements story #163: Story 11.3b — getSeasonProgress

## Verified gates (auto-captured by dag-poc)

- `lint` exit 0
- `build` exit 0
- `test` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13870
- Output tokens: 1517

Closes #163