### PR TITLE
feat(#168): Story 11.7 — getSeasonWeekIndex

### DIFF
--- a/src/lib/seasonWeekIndex.test.ts
+++ b/src/lib/seasonWeekIndex.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getSeasonWeekIndex } from './seasonWeekIndex'
+import * as season from '@/lib/season'
+
+// Mock the season module to control the boundaries
+vi.mock('@/lib/season', () => ({
+  getSeasonWeeks: vi.fn(),
+  getSeasonEnd: vi.fn(),
+}))
+
+describe('seasonWeekIndex', () => {
+  const seasonStart = new Date(Date.UTC(2026, 7, 10)) // 2026-08-10
+  const seasonEnd = new Date(Date.UTC(2026, 10, 9))   // 2026-11-09
+  const week1Start = new Date(Date.UTC(2026, 7, 10))
+  const week2Start = new Date(Date.UTC(2026, 7, 17))
+
+  it('a date inside the first season week returns 1', () => {
+    vi.mocked(season.getSeasonWeeks).mockReturnValue([week1Start, week2Start])
+    vi.mocked(season.getSeasonEnd).mockReturnValue(seasonEnd)
+
+    // A date inside the first week (e.g., Aug 12)
+    const testDate = new Date(Date.UTC(2026, 7, 12))
+    const result = getSeasonWeekIndex(testDate)
+
+    expect(result).toBe(1)
+  })
+
+  it('a date before the season starts returns null', () => {
+    vi.mocked(season.getSeasonWeeks).mockReturnValue([week1Start, week2Start])
+    vi.mocked(season.getSeasonEnd).mockReturnValue(seasonEnd)
+
+    // A date before Aug 10
+    const testDate = new Date(Date.UTC(2026, 7, 9))
+    const result = getSeasonWeekIndex(testDate)
+
+    expect(result).toBeNull()
+  })
+
+  it('a date after the season ends returns null', () => {
+    vi.mocked(season.getSeasonWeeks).mockReturnValue([week1Start, week2Start])
+    vi.mocked(season.getSeasonEnd).mockReturnValue(seasonEnd)
+
+    // A date on or after Nov 9
+    const testDate = new Date(Date.UTC(2026, 10, 9))
+    const result = getSeasonWeekIndex(testDate)
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/lib/seasonWeekIndex.ts
+++ b/src/lib/seasonWeekIndex.ts
@@ -1,0 +1,30 @@
+import { getSeasonWeeks, getSeasonEnd } from "@/lib/season";
+
+/**
+ * Returns the 1-based position of the season week containing `today`.
+ * Returns null if the date is before the season starts or on/after the season ends.
+ */
+export function getSeasonWeekIndex(today: Date): number | null {
+  const seasonStart = getSeasonWeeks()[0].getTime();
+  const seasonEnd = getSeasonEnd().getTime();
+  const todayTime = today.getTime();
+
+  // Check if outside the season bounds
+  if (todayTime < seasonStart || todayTime >= seasonEnd) {
+    return null;
+  }
+
+  const weeks = getSeasonWeeks();
+
+  for (let i = 0; i < weeks.length; i++) {
+    const weekStart = weeks[i].getTime();
+    const nextWeekStart = i + 1 < weeks.length ? weeks[i + 1].getTime() : Infinity;
+
+    // Check if today falls within this week's range
+    if (todayTime >= weekStart && todayTime < nextWeekStart) {
+      return i + 1;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Implements story #168: Story 11.7 — getSeasonWeekIndex

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13234
- Output tokens: 964

Closes #168