### PR TITLE
feat(#168): Story 11.7 — getSeasonWeekIndex

### DIFF
--- a/src/lib/isQualifyingWeek.test.ts
+++ b/src/lib/isQualifyingWeek.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { isQualifyingWeek } from './isQualifyingWeek'
+
+// We use a fixed date for the week start to ensure deterministic tests.
+// We use UTC to avoid timezone-related failures in CI.
+const WEEK_START = new Date(Date.UTC(2024, 0, 1))
+// A date within the same week as WEEK_START
+const CHECK_IN_DATE = new Date(Date.UTC(2024, 0, 2))
+// A date in a different week
+const OTHER_WEEK_DATE = new Date(Date.UTC(2024, 1, 1))
+
+describe('isQualifyingWeek', () => {
+  it('three lanes each meeting targetPerWeek make the week qualify', () => {
+    const lanes = [
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      },
+      {
+        targetPerWeek: 2,
+        checkIns: [
+          { date: CHECK_IN_DATE, isRest: false },
+          { date: new Date(Date.UTC(2024, 0, 3)), isRest: false }
+        ]
+      },
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      }
+    ]
+
+    // Assuming LANES_REQUIRED is 3 based on the AC description
+    // If LANES_REQUIRED were different, this test would fail, but the AC implies 3.
+    expect(isQualifyingWeek(lanes, WEEK_START)).toBe(true)
+  })
+
+  it('two lanes at target do not make the week qualify', () => {
+    const lanes = [
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      },
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      },
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: OTHER_WEEK_DATE, isRest: false }]
+      }
+    ]
+
+    expect(isQualifyingWeek(lanes, WEEK_START)).toBe(false)
+  })
+
+  it('a lane short of its targetPerWeek does not count toward the three', () => {
+    const lanes = [
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      },
+      {
+        targetPerWeek: 1,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      },
+      {
+        targetPerWeek: 2,
+        checkIns: [{ date: CHECK_IN_DATE, isRest: false }]
+      }
+    ]
+
+    expect(isQualifyingWeek(lanes, WEEK_START)).toBe(false)
+  })
+})

--- a/src/lib/isQualifyingWeek.ts
+++ b/src/lib/isQualifyingWeek.ts
@@ -1,0 +1,29 @@
+import { countQualifyingHits } from "@/lib/qualifyingWeek";
+import { LANES_REQUIRED } from "@/lib/season";
+
+interface CheckIn {
+  date: Date;
+  isRest: boolean;
+}
+
+interface Lane {
+  targetPerWeek: number;
+  checkIns: CheckIn[];
+}
+
+/**
+ * Determines if a specific week qualifies based on whether a minimum number of lanes
+ * have met their target number of qualifying check-ins.
+ */
+export function isQualifyingWeek(lanes: Lane[], weekStart: Date): boolean {
+  let qualifyingLanesCount = 0;
+
+  for (const lane of lanes) {
+    const hits = countQualifyingHits(lane.checkIns, weekStart);
+    if (hits >= lane.targetPerWeek) {
+      qualifyingLanesCount++;
+    }
+  }
+
+  return qualifyingLanesCount >= LANES_REQUIRED;
+}

--- a/src/lib/qualifyingWeek.test.ts
+++ b/src/lib/qualifyingWeek.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { countQualifyingHits } from './qualifyingWeek'
+import { REST_CAP_PER_WEEK } from '@/lib/season'
+
+describe('qualifyingWeek', () => {
+  it('four non-rest check-ins inside the week return 4', () => {
+    const weekStart = new Date(Date.UTC(2024, 0, 1))
+    const checkIns = [
+      { date: new Date(Date.UTC(2024, 0, 1)), isRest: false },
+      { date: new Date(Date.UTC(2024, 0, 2)), isRest: false },
+      { date: new Date(Date.UTC(2024, 0, 3)), isRest: false },
+      { date: new Date(Date.UTC(2024, 0, 4)), isRest: false },
+    ]
+
+    const result = countQualifyingHits(checkIns, weekStart)
+    expect(result).toBe(4)
+  })
+
+  it('three rest check-ins in one week contribute only 1', () => {
+    const weekStart = new Date(Date.UTC(2024, 0, 1))
+    const checkIns = [
+      { date: new Date(Date.UTC(2024, 0, 1)), isRest: true },
+      { date: new Date(Date.UTC(2024, 0, 2)), isRest: true },
+      { date: new Date(Date.UTC(2024, 0, 3)), isRest: true },
+    ]
+
+    // Since REST_CAP_PER_WEEK is 1 (as implied by the AC example),
+    // three rest days should contribute exactly 1.
+    const result = countQualifyingHits(checkIns, weekStart)
+    expect(result).toBe(1)
+  })
+
+  it('check-ins dated outside the week window are ignored', () => {
+    const weekStart = new Date(Date.UTC(2024, 0, 1))
+    const weekEndMs = weekStart.getTime() + 7 * 24 * 60 * 60 * 1000
+
+    const checkIns = [
+      // Before the week
+      { date: new Date(Date.UTC(2023, 12, 31)), isRest: false },
+      // Exactly at the start (valid)
+      { date: new Date(Date.UTC(2024, 0, 1)), isRest: false },
+      // Inside the week
+      { date: new Date(Date.UTC(2024, 0, 3)), isRest: false },
+      // Exactly at the end (invalid - must be strictly less than)
+      { date: new Date(weekEndMs), isRest: false },
+      // After the week
+      { date: new Date(Date.UTC(2024, 0, 10)), isRest: false },
+    ]
+
+    const result = countQualifyingHits(checkIns, weekStart)
+    // Only the two check-ins at Jan 1 and Jan 3 are within [Jan 1, Jan 8)
+    expect(result).toBe(2)
+  })
+})

--- a/src/lib/qualifyingWeek.ts
+++ b/src/lib/qualifyingWeek.ts
@@ -1,0 +1,44 @@
+import { REST_CAP_PER_WEEK } from "@/lib/season";
+
+export function countQualifyingHits(
+  checkIns: { date: Date; isRest: boolean }[],
+  weekStart: Date
+): number {
+  const weekEnd = new Date(weekStart.getTime() + 7 * 24 * 60 * 6/0);
+  // Note: The AC says strictly less than weekStart plus 7 days.
+  // We use the millisecond arithmetic logic.
+  const windowEndMs = weekStart.getTime() + 7 * 24 * 60 * 60 * 1000;
+  const windowStartMs = weekStart.getTime();
+
+  let regularHits = 0;
+  let restHitsCount = 0;
+
+  for (const checkIn of checkIns) {
+    const checkInMs = checkIn.date.getTime();
+
+    if (checkInMs >= windowStartMs && checkInMs < windowEndMs) {
+      if (checkIn.isRest) {
+        restHitsCount++;
+      } else {
+        regularHits++;
+      }
+    }
+  }
+
+  // All check-ins with isRest true contribute at most REST_CAP_PER_WEEK to the total combined.
+  // Three rest days in one week therefore contribute 1, not 3 (if REST_CAP_PER_WEEK is 1).
+  // The logic: regularHits + min(restHitsCount, REST_CAP_PER_WEEK)
+  // However, the AC says: "all check-ins with isRest true contribute at most REST_CAP_PER_WEEK to the total combined, however many there are."
+  // This implies the contribution of the REST group is capped.
+  
+  const cappedRestContribution = Math.min(restHitsCount, REST_CAP_PER_WEEK);
+  
+  // If there are NO rest days, we shouldn't add a cap of 1 if it doesn't exist.
+  // But if there are rest days, they contribute up to the cap.
+  // If restHitsCount is 0, Math.min(0, cap) is 0. Correct.
+  
+  // Re-reading: "Three rest days in one week therefore contribute 1, not 3".
+  // This implies if REST_CAP_PER_WEEK is 1, then 3 rest days = 1 hit.
+  
+  return regularHits + (restHitsCount > 0 ? Math.min(restHitsCount, REST_CAP_PER_WEEK) : 0);
+}

--- a/src/lib/season.test.ts
+++ b/src/lib/season.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { SEASON_START, SEASON_WEEKS, getSeasonWeeks, getSeasonEnd } from './season'
+
+describe('season', () => {
+  it('getSeasonWeeks returns 13 dates and the first equals SEASON_START', () => {
+    const weeks = getSeasonWeeks()
+    expect(weeks).toHaveLength(SEASON_WEEKS)
+    expect(weeks[0].getTime()).toBe(SEASON_START.getTime())
+  })
+
+  it('every consecutive pair in getSeasonWeeks is exactly 7 days apart', () => {
+    const weeks = getSeasonWeeks()
+    const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000
+
+    for (let i = 0; i < weeks.length - 1; i++) {
+      const diff = weeks[i + 1].getTime() - weeks[i].getTime()
+      expect(diff).toBe(MS_PER_WEEK)
+    }
+  })
+
+  it('getSeasonEnd is 91 days after SEASON_START', () => {
+    const end = getSeasonEnd()
+    const MS_PER_DAY = 24 * 60 * 60 * 1000
+    const expectedDiff = 91 * MS_PER_DAY
+    
+    const actualDiff = end.getTime() - SEASON_START.getTime()
+    expect(actualDiff).toBe(expectedDiff)
+  })
+})

--- a/src/lib/season.ts
+++ b/src/lib/season.ts
@@ -1,0 +1,29 @@
+export const SEASON_START = new Date("2026-08-10T00:00:00.000Z");
+export const SEASON_WEEKS = 13;
+export const WEEKS_REQUIRED = 11;
+export const LANES_REQUIRED = 3;
+export const REST_CAP_PER_WEEK = 1;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MS_PER_WEEK = 7 * MS_PER_DAY;
+
+/**
+ * Returns exactly SEASON_WEEKS dates, starting with SEASON_START,
+ * with each subsequent date being exactly 7 days after the previous one.
+ */
+export function getSeasonWeeks(): Date[] {
+  const weeks: Date[] = [];
+  for (let i = 0; i < SEASON_WEEKS; i++) {
+    const weekDate = new Date(SEASON_START.getTime() + i * MS_PER_WEEK);
+    weeks.push(weekDate);
+  }
+  return weeks;
+}
+
+/**
+ * Returns the exclusive end of the season:
+ * SEASON_START plus (SEASON_WEEKS * 7) days.
+ */
+export function getSeasonEnd(): Date {
+  return new Date(SEASON_START.getTime() + SEASON_WEEKS * MS_PER_WEEK);
+}

--- a/src/lib/seasonProgress.test.ts
+++ b/src/lib/seasonProgress.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonProgress } from './seasonProgress'
+import { SEASON_WEEKS, WEEKS_REQUIRED } from '@/lib/season'
+
+describe('seasonProgress', () => {
+  it('missesAllowed is the difference between SEASON_WEEKS and WEEKS_REQUIRED', () => {
+    const lanes: Array<any> = []
+    const today = new Date('2026-11-30T00:00:00.000Z')
+    const progress = getSeasonProgress(lanes, today)
+    
+    expect(progress.missedAllowed).toBe(SEASON_WEEKS - WEEKS_REQUIRED)
+  })
+
+  it('an empty lanes array with a today after the season end leaves qualified at 0 and earned false', () => {
+    const lanes: Array<any> = []
+    const today = new Date('2026-11-30T00:00:00.000Z')
+    const progress = getSeasonProgress(lanes, today)
+    
+    expect(progress.qualified).toBe(0)
+    expect(progress.earned).toBe(false)
+  })
+
+  it('an empty lanes array with a today after the season end floors missesRemaining at 0', () => {
+    const lanes: Array<any> = []
+    const today = new Date('2026-11-30T00:00:00.000Z')
+    const progress = getSeasonProgress(lanes, today)
+    
+    expect(progress.missesRemaining).toBe(0)
+  })
+})

--- a/src/lib/seasonProgress.ts
+++ b/src/lib/seasonProgress.ts
@@ -1,0 +1,43 @@
+import { getWeekStatuses, type WeekStatus } from "@/lib/weekStatuses";
+import { SEASON_WEEKS, WEEKS_REQUIRED } from "@/lib/season";
+
+export interface SeasonProgress {
+  weeks: Array<{
+    weekStart: Date;
+    status: WeekStatus;
+  }>;
+  qualified: number;
+  missed: number;
+  missedAllowed: number;
+  missesRemaining: number;
+  earned: boolean;
+}
+
+export function getSeasonProgress(
+  lanes: Array<{
+    targetPerWeek: number;
+    checkIns: Array<{
+      date: Date;
+      isRest: boolean;
+    }>;
+  }>,
+  today: Date
+): SeasonProgress {
+  const weeks = getWeekStatuses(lanes, today);
+
+  const qualified = weeks.filter((w) => w.status === "qualified").length;
+  const missed = weeks.filter((w) => w.status === "missed").length;
+
+  const missedAllowed = SEASON_WEEKS - WEEKS_REQUIRED;
+  const missesRemaining = Math.max(0, missedAllowed - missed);
+  const earned = qualified >= WEEKS_REQUIRED;
+
+  return {
+    weeks,
+    qualified,
+    missed,
+    missedAllowed,
+    missesRemaining,
+    earned,
+  };
+}

--- a/src/lib/seasonWeekIndex.test.ts
+++ b/src/lib/seasonWeekIndex.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonWeekIndex } from './seasonWeekIndex'
+
+/**
+ * The season is defined as 2026-08-10 to 2026-11-09.
+ * We use UTC dates to ensure test stability across environments.
+ */
+
+describe('seasonWeekIndex', () => {
+  it('a date inside the first season week returns 1', () => {
+    // The season starts 2026-08-10. 
+    // A date like 2026-08-12 is clearly within the first week.
+    const date = new Date('2026-08-12T00:00:00.000Z')
+    const index = getSeasonWeekIndex(date)
+    expect(index).toBe(1)
+  })
+
+  it('a date before the season starts returns null', () => {
+    // 2026-08-09 is one day before the season start.
+    const date = new Date('2026-08-09T00:00:00.000Z')
+    const index = getSeasonWeekIndex(date)
+    expect(index).toBeNull()
+  })
+
+  it('a date after the season ends returns null', () => {
+    // The season ends 2026-11-09. 
+    // A date on or after the end date should return null.
+    const date = new Date('2026-11-10T00:00:00.000Z')
+    const index = getSeasonWeekIndex(date)
+    expect(index).toBeNull()
+  })
+})

--- a/src/lib/seasonWeekIndex.ts
+++ b/src/lib/seasonWeekIndex.ts
@@ -1,0 +1,31 @@
+import { getSeasonWeeks, getSeasonEnd } from "@/lib/season";
+
+/**
+ * Returns the 1-based position of the season week containing `today`.
+ * Returns null if the date is before the season starts or on/after the season ends.
+ */
+export function getSeasonWeekIndex(today: Date): number | null {
+  const seasonStart = getSeasonWeeks()[0].getTime();
+  const seasonEnd = getSeasonEnd().getTime();
+  const targetTime = today.getTime();
+
+  // Check if outside the season bounds
+  if (targetTime < seasonStart || targetTime >= seasonEnd) {
+    return null;
+  }
+
+  const weeks = getSeasonWeeks();
+
+  for (let i = 0; i < weeks.length; i++) {
+    const weekStart = weeks[i].getTime();
+    const nextWeekStart = i + 1 < weeks.length ? weeks[i + 1].getTime() : seasonEnd;
+
+    // Check if today falls within this week's range
+    // [weekStart, nextWeekStart)
+    if (targetTime >= weekStart && targetTime < nextWeekStart) {
+      return i + 1;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/weekStatuses.test.ts
+++ b/src/lib/weekStatuses.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { getWeekStatuses } from './weekStatuses'
+import { getSeasonWeeks } from '@/lib/season'
+
+describe('weekStatuses', () => {
+  it('returns one entry per season week with weekStart values matching getSeasonWeeks', () => {
+    const seasonWeeks = getSeasonWeeks()
+    const today = new Date(Date.UTC(2026, 7, 10)) // 2026-08-10
+    const lanes: any[] = []
+
+    const results = getWeekStatuses(lanes, today)
+
+    expect(results.length).toBe(seasonWeeks.length)
+    seasonWeeks.forEach((weekStart, index) => {
+      expect(results[index].weekStart.getTime()).toBe(weekStart.getTime())
+    })
+  })
+
+  it('a today inside the season marks exactly one week current and every later week upcoming', () => {
+    // Season starts 2026-08-10. 
+    // We pick a date that is clearly in the middle of the season.
+    // We use a date that is definitely not the very first or very last week.
+    const today = new Date(Date.UTC(2026, 8, 15)) // 2026-09-15
+    const lanes: any[] = []
+    const results = getWeekStatuses(lanes, today)
+
+    let currentCount = 0
+    let upcomingCount = 0
+    let elapsedCount = 0
+
+    results.forEach((res) => {
+      if (res.status === 'current') currentCount++
+      if (res.status === 'upcoming') upcomingCount++
+      if (res.status === 'qualified' || res.status === 'missed') elapsedCount++
+    })
+
+    expect(currentCount).toBe(1)
+    expect(upcomingCount).toBeGreaterThan(0)
+    // Ensure no 'upcoming' week is marked 'current'
+    const upcomingWeek = results.find(r => r.status === 'upcoming')
+    if (upcomingWeek) {
+      expect(upcomingWeek.weekStart.getTime()).toBeGreaterThan(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+    }
+  })
+
+  it('an elapsed week with no check-ins at all is missed', () => {
+    // Pick a date far in the future so the first week of the season is definitely elapsed
+    const today = new Date(Date.UTC(2027, 0, 1)) 
+    const lanes: any[] = [] // No check-ins
+    const results = getWeekStatuses(lanes, today)
+
+    // The first week of the season (2026-08-10) should be 'missed' because there are no check-ins
+    const firstWeek = results[0]
+    expect(firstWeek.weekStart.getUTCMonth()).toBe(7) // August
+    expect(firstWeek.weekStart.getUTCDate()).toBe(10)
+    expect(firstWeek.status).toBe('missed')
+  })
+})

--- a/src/lib/weekStatuses.ts
+++ b/src/lib/weekStatuses.ts
@@ -1,0 +1,36 @@
+import { getSeasonWeeks } from "@/lib/season";
+import { isQualifyingWeek } from "@/lib/isQualifyingWeek";
+
+export type WeekStatus = "qualified" | "missed" | "current" | "upcoming";
+
+interface LaneData {
+  targetPerWeek: number;
+  checkIns: { date: Date; isRest: boolean }[];
+}
+
+export function getWeekStatuses(
+  lanes: LaneData[],
+  today: Date
+): { weekStart: Date; status: WeekStatus }[] {
+  const seasonWeeks = getSeasonWeeks();
+
+  return seasonWeeks.map((weekStart) => {
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+
+    // A week whose window contains today gets status "current"
+    if (weekStart <= today && today < weekEnd) {
+      return { weekStart, status: "current" };
+    }
+
+    // A week whose weekStart is strictly after today gets status "upcoming"
+    if (weekStart > today) {
+      return { weekStart, status: "upcoming" };
+    }
+
+    // A week whose window has fully elapsed (weekEnd <= today)
+    // gets "qualified" if isQualifyingWeek returns true, and "missed" otherwise.
+    const qualifies = isQualifyingWeek(lanes, weekStart);
+    return { weekStart, status: qualifies ? "qualified" : "missed" };
+  });
+}


### PR DESCRIPTION
## Summary

Implements story #168: Story 11.7 — getSeasonWeekIndex

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13282
- Output tokens: 771

Closes #168