### PR TITLE
feat(#186): seasonStart on Prize

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Prize {
   description String?
   reasons     String[]
   photoUrl    String?
+  seasonStart DateTime?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 }


### PR DESCRIPTION
Hand-written after the grind corrupted a neighbouring model.

Adding one field to a **six-model** schema means regenerating the whole file — the same shape the capability profile records for multi-export files: *"corrupts a neighbour every time"*.

The `Prize` model it was asked for came back correct. Two others didn't:

```
Lane.emoji      @default("🥍")        →  @default("<0xF0><0x9F><0xA5><0x8D>")
BossBattle.id   @id @default(cuid())  →  @id @ngdefault(cuid())
```

**Credit where it's due:** dag-coder's byte-escape repair fixed the emoji before writing — zero escapes reached disk. What survived is `@ngdefault`, a hallucinated token in a model *three away* from the one being edited, and no generic repair catches an invented identifier. That's the Prisma validation error the build gate caught.

This PR is the one line the story asked for:

```diff
+  seasonStart DateTime?
```

No migrations directory here — deploys run `prisma db push` via `vercel-build`, so the column arrives with the next deploy.

Verified: `prisma validate`, `generate`, typecheck, test and build all pass.

Unblocks the eight stories behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3