### PR TITLE
feat(#189): Story 4 — getSeasonReadiness for the setup checklist

### DIFF
--- a/src/lib/seasonReadiness.test.ts
+++ b/src/lib/seasonReadiness.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonReadiness } from './seasonReadiness'
+import { LANES_REQUIRED } from '@/lib/season'
+
+describe('seasonReadiness', () => {
+  it('no lanes and no prize is not ready', () => {
+    const result = getSeasonReadiness(0, false)
+    expect(result.isReady).toBe(false)
+    expect(result.laneCount).toBe(0)
+    expect(result.hasPrize).toBe(false)
+    expect(result.lanesNeeded).toBe(LANES_REQUIRED)
+  })
+
+  it('three lanes without a prize is not ready', () => {
+    const result = getSeasonReadiness(3, false)
+    expect(result.isReady).toBe(false)
+    expect(result.hasPrize).toBe(false)
+  })
+
+  it('three lanes with a prize is ready', () => {
+    // We use a lane count that is guaranteed to satisfy the requirement
+    // regardless of what LANES_REQUIRED is set to in the config.
+    const sufficientLanes = Math.max(3, LANES_REQUIRED)
+    const result = getSeasonReadiness(sufficientLanes, true)
+    
+    expect(result.isReady).toBe(true)
+    expect(result.laneCount).toBe(sufficientLanes)
+    expect(result.hasPrize).toBe(true)
+  })
+})

--- a/src/lib/seasonReadiness.ts
+++ b/src/lib/seasonReadiness.ts
@@ -1,0 +1,18 @@
+import { LANES_REQUIRED } from "@/lib/season";
+
+export function getSeasonReadiness(laneCount: number, hasPrize: boolean): {
+  laneCount: number;
+  lanesNeeded: number;
+  hasPrize: boolean;
+  isReady: boolean;
+} {
+  const lanesNeeded = LANES_REQUIRED;
+  const isReady = laneCount >= lanesNeeded && hasPrize;
+
+  return {
+    laneCount,
+    lanesNeeded,
+    hasPrize,
+    isReady,
+  };
+}


### PR DESCRIPTION
## Summary

Implements story #189: Story 4 — getSeasonReadiness for the setup checklist

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13155
- Output tokens: 1488

Closes #189