### PR TITLE
feat(#190): Story 5 — getSeasonWeeksFrom a given start date

### DIFF
--- a/src/lib/seasonWindow.test.ts
+++ b/src/lib/seasonWindow.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonWeeksFrom } from './seasonWindow'
+import { SEASON_WEEKS } from '@/lib/season'
+
+describe('seasonWindow', () => {
+  it('returns thirteen weeks starting at the given date', () => {
+    const start = new Date(Date.UTC(2024, 0, 1))
+    const weeks = getSeasonWeeksFrom(start)
+    
+    expect(weeks).toHaveLength(SEASON_WEEKS)
+  })
+
+  it('each week is exactly seven days after the previous', () => {
+    const start = new Date(Date.UTC(2024, 5, 15))
+    const weeks = getSeasonWeeksFrom(start)
+
+    for (let i = 1; i < weeks.length; i++) {
+      const prev = weeks[i - 1].getTime()
+      const current = weeks[i].getTime()
+      const diffInMs = current - prev
+      const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000
+      
+      expect(diffInMs).toBe(sevenDaysInMs)
+    }
+  })
+
+  it('a different start date shifts every week', () => {
+    const startA = new Date(Date.UTC(2024, 0, 1))
+    const startB = new Date(Date.UTC(2024, 0, 8))
+    
+    const weeksA = getSeasonWeeksFrom(startA)
+    const weeksB = getSeasonWeeksFrom(startB)
+
+    // The first week of A should be different from the first week of B
+    expect(weeksA[0].getTime()).not.toBe(weeksB[0].getTime())
+    // The second week of A should be the first week of B
+    expect(weeksA[1].getTime()).toBe(weeksB[0].getTime())
+  })
+})

--- a/src/lib/seasonWindow.ts
+++ b/src/lib/seasonWindow.ts
@@ -1,0 +1,20 @@
+import { SEASON_WEEKS } from "@/lib/season";
+
+/**
+ * Returns an array of dates representing the start of each week in the season,
+ * starting from the provided seasonStart date.
+ * 
+ * @param seasonStart - The starting date of the season.
+ * @returns An array of Date objects, one for each week in the season.
+ */
+export function getSeasonWeeksFrom(seasonStart: Date): Date[] {
+  const weeks: Date[] = [];
+  const startMs = seasonStart.getTime();
+  const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000;
+
+  for (let i = 0; i < SEASON_WEEKS; i++) {
+    weeks.push(new Date(startMs + i * sevenDaysInMs));
+  }
+
+  return weeks;
+}


### PR DESCRIPTION
## Summary

Implements story #190: Story 5 — getSeasonWeeksFrom a given start date

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13242
- Output tokens: 727

Closes #190