### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/components/SeasonSetupPanel.test.tsx
+++ b/src/components/SeasonSetupPanel.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SeasonSetupPanel from './SeasonSetupPanel'
+
+describe('SeasonSetupPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('with no lanes and no prize neither step is marked done', async () => {
+    render(<SeasonSetupPanel laneCount={0} lanesNeeded={3} hasPrize={false} />)
+    expect(screen.getByText('Add 3 lanes (0/3)')).toBeInTheDocument()
+    expect(screen.getByText('Set your prize')).toBeInTheDocument()
+    expect(screen.queryByTestId('step-done')).toBeNull()
+  })
+
+  it('with enough lanes the lanes step is marked done', async () => {
+    render(<SeasonSetupPanel laneCount={3} lanesNeeded={3} hasPrize={false} />)
+    expect(screen.getByText('Add 3 lanes (3/3)')).toBeInTheDocument()
+    expect(screen.getByTestId('step-done')).toBeInTheDocument()
+  })
+
+  it('with a prize the prize step is marked done', async () => {
+    render(<SeasonSetupPanel laneCount={1} lanesNeeded={3} hasPrize={true} />)
+    expect(screen.getByText('Set your prize')).toBeInTheDocument()
+    expect(screen.getByTestId('step-done')).toBeInTheDocument()
+  })
+})

--- a/src/components/SeasonSetupPanel.tsx
+++ b/src/components/SeasonSetupPanel.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+
+interface SeasonSetupPanelProps {
+  laneCount: number;
+  lanesNeeded: number;
+  hasPrize: boolean;
+}
+
+export default function SeasonSetupPanel({ 
+  laneCount, 
+  lanesNeeded, 
+  hasPrize 
+}: SeasonSetupPanelProps) {
+  const lanesStepDone = laneCount >= lanesNeeded;
+  const prizeStepDone = hasPrize;
+
+  return (
+    <div className="p-4 bg-white rounded-xl shadow-sm border border-slate-200">
+      <h2 className="text-lg font-semibold text-slate-900 mb-4">Season Setup</h2>
+      <ol className="space-y-4">
+        <li 
+          className="flex items-center justify-between group"
+          data-testid={lanesStepDone ? "step-done" : undefined}
+        >
+          <Link 
+            href="/lanes"
+            className="text-sm text-slate-600 group-hover:text-emerald-600 transition-colors"
+          >
+            Add {lanesNeeded} lanes ({laneCount}/{lanesNeeded})
+          </Link>
+          {lanesStepDone && (
+            <span className="text-emerald-500 text-xs font-medium">✓</span>
+          )}
+        </li>
+        <li 
+          className="flex items-center justify-between group"
+          data-testid={prizeStepDone ? "step-done" : undefined}
+        >
+          <Link 
+            href="/prize"
+            className="text-sm text-slate-600 group-hover:text-emerald-600 transition-colors"
+          >
+            Set your prize
+          </Link>
+          {prizeStepDone && (
+            <span className="text-emerald-500 text-xs font-medium">✓</span>
+          )}
+        </li>
+      </ol>
+    </div>
+  );
+}

--- a/src/lib/seasonAnchor.test.ts
+++ b/src/lib/seasonAnchor.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSeasonStart } from './seasonAnchor'
+
+describe('seasonAnchor', () => {
+  it('a Monday returns that same Monday at midnight', () => {
+    // Monday, May 20, 2024
+    const monday = new Date(Date.UTC(2024, 4, 20, 14, 30, 0))
+    const result = resolveSeasonStart(monday)
+    
+    expect(result.getUTCFullYear()).toBe(2024)
+    expect(result.getUTCMonth()).toBe(4)
+    expect(result.getUTCDate()).toBe(20)
+    expect(result.getUTCHours()).toBe(0)
+    expect(result.getUTCMinutes()).toBe(0)
+    expect(result.getUTCSeconds()).toBe(0)
+  })
+
+  it('a Wednesday returns the following Monday', () => {
+    // Wednesday, May 22, 2024
+    const wednesday = new Date(Date.UTC(2024, 4, 22, 10, 0, 0))
+    const result = resolveSeasonStart(wednesday)
+    
+    // Should be Monday, May 27, 2024
+    expect(result.getUTCFullYear()).toBe(2024)
+    expect(result.getUTCMonth()).toBe(4)
+    expect(result.getUTCDate()).toBe(27)
+    expect(result.getUTCHours()).toBe(0)
+  })
+
+  it('a Sunday returns the next day', () => {
+    // Sunday, May 26, 2024
+    const sunday = new Date(Date.UTC(2024, 4, 26, 23, 59, 59))
+    const result = resolveSeasonStart(sunday)
+    
+    // Should be Monday, May 27, 2024
+    expect(result.getUTCFullYear()).toBe(2024)
+    expect(result.getUTCMonth()).toBe(4)
+    expect(result.getUTCDate()).toBe(27)
+    expect(result.getUTCHours()).toBe(0)
+  })
+})

--- a/src/lib/seasonAnchor.ts
+++ b/src/lib/seasonAnchor.ts
@@ -1,0 +1,31 @@
+/**
+ * Returns the UTC midnight of the Monday on or after the provided date.
+ * If the provided date is already a Monday, it returns that same Monday at UTC midnight.
+ */
+export function resolveSeasonStart(now: Date): Date {
+  const date = new Date(now.getTime());
+  const day = date.getUTCDay();
+
+  // getUTCDay(): 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+  // We want to find the distance to the next Monday.
+  // If it's Monday (1), distance is 0.
+  // If it's Sunday (0), distance is 1.
+  // If it's Tuesday (2), distance is 6.
+  
+  let daysUntilMonday = 0;
+  if (day === 0) {
+    // Sunday -> Next Monday is 1 day away
+    daysUntilMonday = 1;
+  } else if (day === 1) {
+    // Monday -> 0 days away
+    daysUntilMonday = 0;
+  } else {
+    // Tue (2) through Sat (6) -> distance to next Monday
+    daysUntilMonday = 8 - day;
+  }
+
+  date.setUTCDate(date.getUTCDate() + daysUntilMonday);
+  date.setUTCHours(0, 0, 0, 0);
+
+  return date;
+}

--- a/src/lib/seasonReadiness.test.ts
+++ b/src/lib/seasonReadiness.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonReadiness } from './seasonReadiness'
+import { LANES_REQUIRED } from '@/lib/season'
+
+describe('seasonReadiness', () => {
+  it('no lanes and no prize is not ready', () => {
+    const result = getSeasonReadiness(0, false)
+    expect(result.isReady).toBe(false)
+    expect(result.laneCount).toBe(0)
+    expect(result.hasPrize).toBe(false)
+    expect(result.lanesNeeded).toBe(LANES_REQUIRED)
+  })
+
+  it('three lanes without a prize is not ready', () => {
+    const result = getSeasonReadiness(3, false)
+    expect(result.isReady).toBe(false)
+    expect(result.hasPrize).toBe(false)
+  })
+
+  it('three lanes with a prize is ready', () => {
+    // We use a lane count that is guaranteed to satisfy the requirement
+    // regardless of what LANES_REQUIRED is set to in the config.
+    const sufficientLanes = Math.max(3, LANES_REQUIRED)
+    const result = getSeasonReadiness(sufficientLanes, true)
+    
+    expect(result.isReady).toBe(true)
+    expect(result.laneCount).toBe(sufficientLanes)
+    expect(result.hasPrize).toBe(true)
+  })
+})

--- a/src/lib/seasonReadiness.ts
+++ b/src/lib/seasonReadiness.ts
@@ -1,0 +1,18 @@
+import { LANES_REQUIRED } from "@/lib/season";
+
+export function getSeasonReadiness(laneCount: number, hasPrize: boolean): {
+  laneCount: number;
+  lanesNeeded: number;
+  hasPrize: boolean;
+  isReady: boolean;
+} {
+  const lanesNeeded = LANES_REQUIRED;
+  const isReady = laneCount >= lanesNeeded && hasPrize;
+
+  return {
+    laneCount,
+    lanesNeeded,
+    hasPrize,
+    isReady,
+  };
+}

--- a/src/lib/seasonWindow.test.ts
+++ b/src/lib/seasonWindow.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { getSeasonWeeksFrom } from './seasonWindow'
+import { SEASON_WEEKS } from '@/lib/season'
+
+describe('seasonWindow', () => {
+  it('returns thirteen weeks starting at the given date', () => {
+    const start = new Date(Date.UTC(2024, 0, 1))
+    const weeks = getSeasonWeeksFrom(start)
+    
+    expect(weeks).toHaveLength(SEASON_WEEKS)
+  })
+
+  it('each week is exactly seven days after the previous', () => {
+    const start = new Date(Date.UTC(2024, 5, 15))
+    const weeks = getSeasonWeeksFrom(start)
+
+    for (let i = 1; i < weeks.length; i++) {
+      const prev = weeks[i - 1].getTime()
+      const current = weeks[i].getTime()
+      const diffInMs = current - prev
+      const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000
+      
+      expect(diffInMs).toBe(sevenDaysInMs)
+    }
+  })
+
+  it('a different start date shifts every week', () => {
+    const startA = new Date(Date.UTC(2024, 0, 1))
+    const startB = new Date(Date.UTC(2024, 0, 8))
+    
+    const weeksA = getSeasonWeeksFrom(startA)
+    const weeksB = getSeasonWeeksFrom(startB)
+
+    // The first week of A should be different from the first week of B
+    expect(weeksA[0].getTime()).not.toBe(weeksB[0].getTime())
+    // The second week of A should be the first week of B
+    expect(weeksA[1].getTime()).toBe(weeksB[0].getTime())
+  })
+})

--- a/src/lib/seasonWindow.ts
+++ b/src/lib/seasonWindow.ts
@@ -1,0 +1,20 @@
+import { SEASON_WEEKS } from "@/lib/season";
+
+/**
+ * Returns an array of dates representing the start of each week in the season,
+ * starting from the provided seasonStart date.
+ * 
+ * @param seasonStart - The starting date of the season.
+ * @returns An array of Date objects, one for each week in the season.
+ */
+export function getSeasonWeeksFrom(seasonStart: Date): Date[] {
+  const weeks: Date[] = [];
+  const startMs = seasonStart.getTime();
+  const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000;
+
+  for (let i = 0; i < SEASON_WEEKS; i++) {
+    weeks.push(new Date(startMs + i * sevenDaysInMs));
+  }
+
+  return weeks;
+}


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#189, #190, #187, #192) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.