### PR TITLE
feat(#191): Story 6 — resetSeason action

### DIFF
--- a/src/app/actions/resetSeason.test.ts
+++ b/src/app/actions/resetSeason.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { resetSeason } from './resetSeason'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    checkIn: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    bossBattle: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    weeklyReflection: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    streakFreeze: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    prize: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+describe('resetSeason', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('it clears seasonStart on the prize row', async () => {
+    vi.mocked(prisma.prize.update).mockResolvedValue(
+      { id: 'prize', title: 'Test', description: '', reasons: [], photoUrl: null, seasonStart: null, createdAt: new Date(0), updatedAt: new Date(0) }
+    )
+
+    await resetSeason()
+
+    expect(prisma.prize.update).toHaveBeenCalledWith({
+      where: { id: 'prize' },
+      data: { seasonStart: null }
+    })
+  })
+
+  it('a missing prize row surfaces the Prisma error unchanged', async () => {
+    const error = new Error('Record to update not found.')
+    vi.mocked(prisma.prize.update).mockRejectedValue(error)
+
+    await expect(resetSeason()).rejects.toThrow('Record to update not found.')
+  })
+})

--- a/src/app/actions/resetSeason.ts
+++ b/src/app/actions/resetSeason.ts
@@ -1,0 +1,10 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+
+export async function resetSeason(): Promise<void> {
+  await prisma.prize.update({
+    where: { id: 'prize' },
+    data: { seasonStart: null },
+  })
+}


### PR DESCRIPTION
## Summary

Implements story #191: Story 6 — resetSeason action

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 13815
- Output tokens: 914

Closes #191