### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/app/actions/resetSeason.test.ts
+++ b/src/app/actions/resetSeason.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { resetSeason } from './resetSeason'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    checkIn: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    bossBattle: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    weeklyReflection: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    streakFreeze: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    prize: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+describe('resetSeason', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('it clears seasonStart on the prize row', async () => {
+    vi.mocked(prisma.prize.update).mockResolvedValue(
+      { id: 'prize', title: 'Test', description: '', reasons: [], photoUrl: null, seasonStart: null, createdAt: new Date(0), updatedAt: new Date(0) }
+    )
+
+    await resetSeason()
+
+    expect(prisma.prize.update).toHaveBeenCalledWith({
+      where: { id: 'prize' },
+      data: { seasonStart: null }
+    })
+  })
+
+  it('a missing prize row surfaces the Prisma error unchanged', async () => {
+    const error = new Error('Record to update not found.')
+    vi.mocked(prisma.prize.update).mockRejectedValue(error)
+
+    await expect(resetSeason()).rejects.toThrow('Record to update not found.')
+  })
+})

--- a/src/app/actions/resetSeason.ts
+++ b/src/app/actions/resetSeason.ts
@@ -1,0 +1,10 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+
+export async function resetSeason(): Promise<void> {
+  await prisma.prize.update({
+    where: { id: 'prize' },
+    data: { seasonStart: null },
+  })
+}

--- a/src/app/actions/startSeason.test.ts
+++ b/src/app/actions/startSeason.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { startSeason } from './startSeason'
+import { resolveSeasonStart } from '@/lib/seasonAnchor'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    checkIn: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    bossBattle: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    weeklyReflection: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    streakFreeze: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+    prize: { create: vi.fn(), createMany: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn(), updateMany: vi.fn(), delete: vi.fn(), deleteMany: vi.fn(), upsert: vi.fn(), count: vi.fn() },
+  },
+}))
+
+describe('startSeason', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Set a fixed time: Monday, May 20, 2024
+    vi.setSystemTime(new Date(Date.UTC(2024, 4, 20)))
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fewer than three lanes throws before touching the prize', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(2)
+
+    await expect(startSeason()).rejects.toThrow('Add at least 3 lanes before starting the season')
+    expect(prisma.prize.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('a missing prize throws', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
+
+    await expect(startSeason()).rejects.toThrow('Set your prize before starting the season')
+    expect(prisma.prize.update).not.toHaveBeenCalled()
+  })
+
+  it('three lanes and a prize writes the resolved Monday and returns it', async () => {
+    const mockPrize = { id: 'prize', title: 'Test Prize' }
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(mockPrize as any)
+    vi.mocked(prisma.prize.update).mockResolvedValue({ ...mockPrize, seasonStart: new Date(0) } as any)
+
+    // resolveSeasonStart(new Date()) for May 20 2024 should return May 20 2024
+    // because May 20 2024 is a Monday.
+    const result = await startSeason()
+
+    expect(prisma.prize.update).toHaveBeenCalledWith({
+      where: { id: 'prize' },
+      data: { seasonStart: expect.any(Date) }
+    })
+
+    // Verify the returned date is the correct Monday in UTC
+    expect(result.seasonStart.getUTCFullYear()).toBe(2024)
+    expect(result.seasonStart.getUTCMonth()).toBe(4) // May
+    expect(result.seasonStart.getUTCDate()).toBe(20)
+  })
+})

--- a/src/app/actions/startSeason.ts
+++ b/src/app/actions/startSeason.ts
@@ -1,0 +1,33 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { resolveSeasonStart } from '@/lib/seasonAnchor'
+
+export async function startSeason(): Promise<{ seasonStart: Date }> {
+  const activeLanesCount = await prisma.lane.count({
+    where: { isActive: true },
+  })
+
+  if (activeLanesCount < 3) {
+    throw new Error('Add at least 3 lanes before starting the season')
+  }
+
+  const prize = await prisma.prize.findUnique({
+    where: { id: 'prize' },
+  })
+
+  if (!prize) {
+    throw new Error('Set your prize before starting the season')
+  }
+
+  const seasonStart = resolveSeasonStart(new Date())
+
+  await prisma.prize.update({
+    where: { id: 'prize' },
+    data: {
+      seasonStart,
+    },
+  })
+
+  return { seasonStart }
+}


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#188, #191) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.