### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/components/SeasonStartButton.test.tsx
+++ b/src/components/SeasonStartButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SeasonStartButton from './SeasonStartButton'
+import { startSeason } from '@/app/actions/startSeason'
+import { resetSeason } from '@/app/actions/resetSeason'
+
+vi.mock('@/app/actions/startSeason', () => ({
+  startSeason: vi.fn(),
+}))
+
+vi.mock('@/app/actions/resetSeason', () => ({
+  resetSeason: vi.fn(),
+}))
+
+describe('SeasonStartButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('not started and not ready renders a disabled start button', async () => {
+    render(<SeasonStartButton hasStarted={false} isReady={false} />)
+    const button = screen.getByTestId('season-start')
+    expect(button).toBeInTheDocument()
+    expect(button).toBeDisabled()
+    expect(button).toHaveClass('bg-green-600')
+  })
+
+  it('not started and ready calls startSeason when clicked', async () => {
+    const user = userEvent.setup()
+    render(<SeasonStartButton hasStarted={false} isReady={true} />)
+    const button = screen.getByTestId('season-start')
+    expect(button).not.toBeDisabled()
+    await user.click(button)
+    expect(startSeason).toHaveBeenCalled()
+  })
+
+  it('started renders the reset button and calls resetSeason when clicked', async () => {
+    const user = userEvent.setup()
+    render(<SeasonStartButton hasStarted={true} isReady={true} />)
+    const button = screen.getByTestId('season-reset')
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveClass('bg-red-600')
+    await user.click(button)
+    expect(resetSeason).toHaveBeenCalled()
+  })
+})

--- a/src/components/SeasonStartButton.tsx
+++ b/src/components/SeasonStartButton.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useState } from 'react'
+import { startSeason } from '@/app/actions/startSeason'
+import { resetSeason } from '@/app/actions/resetSeason'
+
+interface SeasonStartButtonProps {
+  hasStarted: boolean
+  isReady: boolean
+}
+
+export default function SeasonStartButton({ hasStarted, isReady }: SeasonStartButtonProps) {
+  const [pending, setPending] = useState<boolean>(false)
+
+  const handleStart = async () => {
+    setPending(true)
+    try {
+      await startSeason()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to start season'
+      console.error(msg)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const handleReset = async () => {
+    setPending(true)
+    try {
+      await resetSeason()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to reset season'
+      console.error(msg)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  if (!hasStarted) {
+    return (
+      <button
+        type="button"
+        data-testid="season-start"
+        disabled={!isReady || pending}
+        onClick={handleStart}
+        className="w-full rounded-lg py-4 text-xl font-bold text-white bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {pending ? 'Starting...' : 'Start my season'}
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="season-reset"
+      disabled={pending}
+      onClick={handleReset}
+      className="w-full rounded-lg py-4 text-xl font-bold text-white bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? 'Resetting...' : 'Reset my season'}
+    </button>
+  )
+}


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#193) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.