### PR TITLE
feat(#194): Story 9 — TODAY page shows the start button and setup panel

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Page from './page'
+import { prisma } from '@/lib/db'
+
+// Mocking the components as requested by the AC
+vi.mock('@/components/SeasonStartButton', () => ({
+  default: ({ hasStarted, isReady }: { hasStarted: boolean; isReady: boolean }) => (
+    <div data-testid="season-start-button" data-has-started={String(hasStarted)} data-is-ready={String(isReady)}>
+      Season Start Button
+    </div>
+  ),
+}))
+
+vi.mock('@/components/SeasonSetupPanel', () => ({
+  default: ({ laneCount, lanesNeeded, hasPrize }: any) => (
+    <div data-testid="season-setup-panel" data-lane-count={String(laneCount)} data-lanes-needed={String(lanesNeeded)} data-has-prize={String(hasPrize)}>
+      Season Setup Panel
+    </div>
+  ),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    prize: {
+      findUnique: vi.fn(),
+    },
+  },
+}))
+
+// Mocking next/font/google's loader only exists inside the Next build; under vitest
+// `Geist(...)` is not a function and the suite dies at module load.
+vi.mock('next/font/google', () => new Proxy({}, {
+  get: () => () => ({ variable: 'mock-font-variable', className: 'mock-font' }),
+}))
+
+// Do NOT vi.mock @/lib/seasonReadiness — pure module(s), no I/O.
+// Render them for real; mocking a collaborator makes the test assert against
+// its own mock and pass whatever the component does.
+
+describe('Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default mock for lanes to prevent crashes in the loop
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([])
+    vi.mocked(prisma.lane.count).mockResolvedValue(0)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
+  })
+
+  it('a not-ready season renders the setup panel', async () => {
+    // Setup: No prize, 0 active lanes (not ready)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.lane.count).mockResolvedValue(0)
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([])
+
+    // We must render the component. Since it's an async Server Component,
+    // we await the component call directly in the test.
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByTestId('season-setup-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('season-start-button')).toBeInTheDocument()
+  })
+
+  it('a started season renders no setup panel', async () => {
+    // Setup: Prize exists with seasonStart date (season has started)
+    const mockPrize = {
+      id: 'prize',
+      title: 'The Grand Prize',
+      seasonStart: new Date(),
+      reasons: [],
+    }
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(mockPrize as any)
+    vi.mocked(prisma.lane.count).mockResolvedValue(5)
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByTestId('season-setup-panel')).not.toBeInTheDocument()
+    expect(screen.getByTestId('season-start-button')).toBeInTheDocument()
+  })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,12 +6,23 @@ import { createCheckIn } from "@/app/actions/createCheckIn"
 import { deleteCheckIn } from "@/app/actions/deleteCheckIn"
 import CheckInCard from "@/components/CheckInCard"
 import { WeeklyProgress } from "@/components/WeeklyProgress"
+import SeasonStartButton from "@/components/SeasonStartButton"
+import SeasonSetupPanel from "@/components/SeasonSetupPanel"
+import { getSeasonReadiness } from "@/lib/seasonReadiness"
 
 export const dynamic = "force-dynamic"
 
 export default async function DashboardPage() {
   const today = getTrainingDay(new Date())
   const weekStart = getWeekStart(today)
+
+  const [prize, activeLaneCount] = await Promise.all([
+    prisma.prize.findUnique({ where: { id: 'prize' } }),
+    prisma.lane.count({ where: { isActive: true } })
+  ])
+
+  const readiness = getSeasonReadiness(activeLaneCount, Boolean(prize))
+  const hasStarted = Boolean(prize?.seasonStart)
 
   const lanes = await prisma.lane.findMany({
     where: { isActive: true },
@@ -23,6 +34,17 @@ export default async function DashboardPage() {
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">
+      <div className="space-y-4">
+        <SeasonStartButton hasStarted={hasStarted} isReady={readiness.isReady} />
+        {!hasStarted && !readiness.isReady && (
+          <SeasonSetupPanel 
+            laneCount={activeLaneCount} 
+            lanesNeeded={0} 
+            hasPrize={Boolean(prize)} 
+          />
+        )}
+      </div>
+
       <h1 className="text-2xl font-bold">Today</h1>
       <p className="mt-1 text-sm text-zinc-500">Your daily check-in. Show up for each lane — effort and consistency are the only score, and rest days count too.</p>
       {lanes.length === 0 && (
@@ -37,6 +59,7 @@ export default async function DashboardPage() {
           lane.checkIns.map((c) => ({ date: c.date, isRest: c.isRest })),
           today
         )
+
         return (
           <div key={lane.id} className="space-y-2 rounded-lg border p-4">
             <CheckInCard


### PR DESCRIPTION
## Summary

Implements story #194: Story 9 — TODAY page shows the start button and setup panel

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `typecheck` exit 2
- `lint` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 30921
- Output tokens: 8365

Closes #194