### PR TITLE
feat(#210): Story 1 — getWeekStatuses accepts an explicit season start

### DIFF
--- a/src/lib/weekStatuses.test.ts
+++ b/src/lib/weekStatuses.test.ts
@@ -1,58 +1,50 @@
 import { describe, it, expect } from 'vitest'
 import { getWeekStatuses } from './weekStatuses'
-import { getSeasonWeeks } from '@/lib/season'
+import { getSeasonWeeksFrom } from '@/lib/seasonWindow'
+import { isQualifyingWeek } from '@/lib/isQualifyingWeek'
+import { SEASON_START, SEASON_WEEKS } from '@/lib/season'
 
 describe('weekStatuses', () => {
-  it('returns one entry per season week with weekStart values matching getSeasonWeeks', () => {
-    const seasonWeeks = getSeasonWeeks()
-    const today = new Date(Date.UTC(2026, 7, 10)) // 2026-08-10
+  it('the week windows follow an explicit seasonStart date', () => {
+    // Use a custom season start date far in the future to avoid overlap with real constants
+    const customStart = new Date(Date.UTC(2030, 0, 1))
+    const today = new Date(Date.UTC(2030, 0, 15))
     const lanes: any[] = []
 
-    const results = getWeekStatuses(lanes, today)
+    const results = getWeekStatuses(lanes, today, customStart)
 
-    expect(results.length).toBe(seasonWeeks.length)
-    seasonWeeks.forEach((weekStart, index) => {
-      expect(results[index].weekStart.getTime()).toBe(weekStart.getTime())
-    })
+    // Verify the first week in the results matches our custom start
+    expect(results[0].weekStart.getTime()).toBe(customStart.getTime())
+    
+    // Verify the number of weeks matches the expected season length
+    expect(results.length).toBe(SEASON_WEEKS)
   })
 
-  it('a today inside the season marks exactly one week current and every later week upcoming', () => {
-    // Season starts 2026-08-10. 
-    // We pick a date that is clearly in the middle of the season.
-    // We use a date that is definitely not the very first or very last week.
-    const today = new Date(Date.UTC(2026, 8, 15)) // 2026-09-15
+  it('a null seasonStart makes every one of the thirteen weeks upcoming', () => {
+    // When seasonStart is null, the function uses getSeasonWeeksFrom(today)
+    // and every week is 'upcoming'.
+    const today = new Date(Date.UTC(2025, 5, 10))
     const lanes: any[] = []
-    const results = getWeekStatuses(lanes, today)
 
-    let currentCount = 0
-    let upcomingCount = 0
-    let elapsedCount = 0
+    const results = getWeekStatuses(lanes, today, null)
 
+    expect(results.length).toBe(SEASON_WEEKS)
     results.forEach((res) => {
-      if (res.status === 'current') currentCount++
-      if (res.status === 'upcoming') upcomingCount++
-      if (res.status === 'qualified' || res.status === 'missed') elapsedCount++
+      expect(res.status).toBe('upcoming')
     })
 
-    expect(currentCount).toBe(1)
-    expect(upcomingCount).toBeGreaterThan(0)
-    // Ensure no 'upcoming' week is marked 'current'
-    const upcomingWeek = results.find(r => r.status === 'upcoming')
-    if (upcomingWeek) {
-      expect(upcomingWeek.weekStart.getTime()).toBeGreaterThan(today.getTime() - 7 * 24 * 60 * 60 * 1000)
-    }
+    // The first week should start at the 'today' date (as per AC: getSeasonWeeksFrom(today))
+    expect(results[0].weekStart.getTime()).toBe(today.getTime())
   })
 
-  it('an elapsed week with no check-ins at all is missed', () => {
-    // Pick a date far in the future so the first week of the season is definitely elapsed
-    const today = new Date(Date.UTC(2027, 0, 1)) 
-    const lanes: any[] = [] // No check-ins
+  it('omitting the third argument still uses the season constant', () => {
+    const today = new Date(Date.UTC(2025, 5, 10))
+    const lanes: any[] = []
+
+    // This calls getWeekStatuses(lanes, today) which should use SEASON_START
     const results = getWeekStatuses(lanes, today)
 
-    // The first week of the season (2026-08-10) should be 'missed' because there are no check-ins
-    const firstWeek = results[0]
-    expect(firstWeek.weekStart.getUTCMonth()).toBe(7) // August
-    expect(firstWeek.weekStart.getUTCDate()).toBe(10)
-    expect(firstWeek.status).toBe('missed')
+    // The first week should match the real SEASON_START
+    expect(results[0].weekStart.getTime()).toBe(SEASON_START.getTime())
   })
 })

--- a/src/lib/weekStatuses.ts
+++ b/src/lib/weekStatuses.ts
@@ -1,5 +1,6 @@
-import { getSeasonWeeks } from "@/lib/season";
-import { isQualifyingWeek } from "@/lib/isQualifyingWeek";
+import { getSeasonWeeksFrom } from '@/lib/seasonWindow';
+import { isQualifyingWeek } from '@/lib/isQualifyingWeek';
+import { SEASON_START, SEASON_WEEKS } from '@/lib/season';
 
 export type WeekStatus = "qualified" | "missed" | "current" | "upcoming";
 
@@ -10,9 +11,18 @@ interface LaneData {
 
 export function getWeekStatuses(
   lanes: LaneData[],
-  today: Date
+  today: Date,
+  seasonStart: Date | null = SEASON_START
 ): { weekStart: Date; status: WeekStatus }[] {
-  const seasonWeeks = getSeasonWeeks();
+  if (seasonStart === null) {
+    const weeks = getSeasonWeeksFrom(today);
+    return weeks.map((weekStart) => ({
+      weekStart,
+      status: "upcoming" as const,
+    }));
+  }
+
+  const seasonWeeks = getSeasonWeeksFrom(seasonStart);
 
   return seasonWeeks.map((weekStart) => {
     const weekEnd = new Date(weekStart);
@@ -20,17 +30,17 @@ export function getWeekStatuses(
 
     // A week whose window contains today gets status "current"
     if (weekStart <= today && today < weekEnd) {
-      return { weekStart, status: "current" };
+      return { weekStart, status: "current" as const };
     }
 
     // A week whose weekStart is strictly after today gets status "upcoming"
     if (weekStart > today) {
-      return { weekStart, status: "upcoming" };
+      return { weekStart, status: "upcoming" as const };
     }
 
     // A week whose window has fully elapsed (weekEnd <= today)
     // gets "qualified" if isQualifyingWeek returns true, and "missed" otherwise.
     const qualifies = isQualifyingWeek(lanes, weekStart);
-    return { weekStart, status: qualifies ? "qualified" : "missed" };
+    return { weekStart, status: qualifies ? "qualified" as const : "missed" as const };
   });
 }


### PR DESCRIPTION
## Summary

Implements story #210: Story 1 — getWeekStatuses accepts an explicit season start

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `typecheck` exit 0
- `lint` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 25797
- Output tokens: 5189

Closes #210