### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { formatWeekLabel } from '@/lib/weekUtils'
+import { SEASON_WEEKS } from '@/lib/season'
+import PrizePage from './page'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    prize: { findUnique: vi.fn() },
+    lane: { findMany: vi.fn() },
+  },
+}))
+
+import { prisma } from '@/lib/db'
+
+const PRIZE = {
+  id: 'prize',
+  title: 'PS5',
+  description: null,
+  reasons: [] as string[],
+  photoUrl: null,
+  seasonStart: null as Date | null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+}
+
+describe('PrizePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([] as never)
+  })
+
+  it('titles the first week cell from the stored season start', async () => {
+    // Deliberately NOT the SEASON_START constant: if the page still reads the
+    // constant, the label is 2026-08-10 and this fails.
+    const started = new Date('2026-09-07T00:00:00.000Z')
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: started,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells[0].getAttribute('title')).toBe(formatWeekLabel(started))
+  })
+
+  it('marks every week upcoming before the season starts', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: null,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells.map((c) => c.getAttribute('data-status'))).toEqual(
+      Array(SEASON_WEEKS).fill('upcoming')
+    )
+  })
+})

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -4,26 +4,45 @@ import { deletePrize } from "@/app/actions/deletePrize"
 import { uploadPrizePhoto } from "@/app/actions/uploadPrizePhoto"
 import PrizeSection from "@/components/PrizeSection"
 import SeasonProgress from "@/components/SeasonProgress"
-import { SEASON_START, getSeasonEnd } from "@/lib/season"
+import { SEASON_WEEKS } from "@/lib/season"
+import { getSeasonWeeksFrom } from "@/lib/seasonWindow"
 import { getSeasonProgress } from "@/lib/seasonProgress"
 import { getTrainingDay } from "@/lib/trainingDay"
 
 export const dynamic = "force-dynamic"
 
+/** Exclusive end of a season that began on `start`: one week past week 13. */
+function seasonEnd(start: Date): Date {
+  const lastWeekStart = getSeasonWeeksFrom(start)[SEASON_WEEKS - 1]
+  const end = new Date(lastWeekStart)
+  end.setUTCDate(end.getUTCDate() + 7)
+  return end
+}
+
 export default async function PrizePage() {
   const prize = await prisma.prize.findUnique({ where: { id: "prize" } })
+
+  // Before Eddie presses START there is no window to filter on — the season
+  // hasn't begun, so every check-in is fair game and the grid renders as
+  // thirteen upcoming weeks.
+  const seasonStart = prize?.seasonStart ?? null
+  const checkInWhere = seasonStart
+    ? {
+        date: {
+          gte: seasonStart,
+          // The exclusive end is a week AFTER the last week starts, or the
+          // thirteenth week's check-ins fall outside the window.
+          lt: seasonEnd(seasonStart),
+        },
+      }
+    : {}
 
   const lanes = await prisma.lane.findMany({
     where: { isActive: true },
     select: {
       targetPerWeek: true,
       checkIns: {
-        where: {
-          date: {
-            gte: SEASON_START,
-            lt: getSeasonEnd(),
-          },
-        },
+        where: checkInWhere,
         select: {
           date: true,
           isRest: true,
@@ -32,7 +51,7 @@ export default async function PrizePage() {
     },
   })
 
-  const progress = getSeasonProgress(lanes, getTrainingDay(new Date()))
+  const progress = getSeasonProgress(lanes, getTrainingDay(new Date()), seasonStart)
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">

--- a/src/lib/seasonProgress.test.ts
+++ b/src/lib/seasonProgress.test.ts
@@ -1,30 +1,49 @@
 import { describe, it, expect } from 'vitest'
 import { getSeasonProgress } from './seasonProgress'
-import { SEASON_WEEKS, WEEKS_REQUIRED } from '@/lib/season'
+import { SEASON_WEEKS, WEEKS_REQUIRED, SEASON_START } from '@/lib/season'
 
 describe('seasonProgress', () => {
-  it('missesAllowed is the difference between SEASON_WEEKS and WEEKS_REQUIRED', () => {
-    const lanes: Array<any> = []
-    const today = new Date('2026-11-30T00:00:00.000Z')
-    const progress = getSeasonProgress(lanes, today)
-    
-    expect(progress.missedAllowed).toBe(SEASON_WEEKS - WEEKS_REQUIRED)
-  })
+  it('a null seasonStart reports zero qualified and earned false', () => {
+    const lanes: Array<any> = [
+      {
+        targetPerWeek: 1,
+        checkIns: []
+      }
+    ]
+    const today = new Date(Date.UTC(2099, 0, 1))
+    const progress = getSeasonProgress(lanes, today, null as any)
 
-  it('an empty lanes array with a today after the season end leaves qualified at 0 and earned false', () => {
-    const lanes: Array<any> = []
-    const today = new Date('2026-11-30T00:00:00.000Z')
-    const progress = getSeasonProgress(lanes, today)
-    
     expect(progress.qualified).toBe(0)
     expect(progress.earned).toBe(false)
   })
 
-  it('an empty lanes array with a today after the season end floors missesRemaining at 0', () => {
-    const lanes: Array<any> = []
-    const today = new Date('2026-11-30T00:00:00.000Z')
-    const progress = getSeasonProgress(lanes, today)
+  it('a null seasonStart leaves every allowed miss remaining', () => {
+    const lanes: Array<any> = [
+      {
+        targetPerWeek: 1,
+        checkIns: []
+      }
+    ]
+    const today = new Date(Date.UTC(2099, 0, 1))
+    const progress = getSeasonProgress(lanes, today, null as any)
     
-    expect(progress.missesRemaining).toBe(0)
+    const missedAllowed = SEASON_WEEKS - WEEKS_REQUIRED
+    expect(progress.missesRemaining).toBe(missedAllowed)
+  })
+
+  it('omitting the third argument still uses the season constant', () => {
+    const lanes: Array<any> = [
+      {
+        targetPerWeek: 1,
+        checkIns: []
+      }
+    ]
+    const today = new Date(Date.UTC(2099, 0, 1))
+    const progress = getSeasonProgress(lanes, today)
+
+    // If it uses the constant, the weeks array should be populated based on SEASON_START
+    // We check if the first week's start date matches the year of SEASON_START
+    expect(progress.weeks.length).toBeGreaterThan(0)
+    expect(progress.weeks[0].weekStart.getUTCFullYear()).toBe(SEASON_START.getUTCFullYear())
   })
 })

--- a/src/lib/seasonProgress.ts
+++ b/src/lib/seasonProgress.ts
@@ -1,5 +1,5 @@
 import { getWeekStatuses, type WeekStatus } from "@/lib/weekStatuses";
-import { SEASON_WEEKS, WEEKS_REQUIRED } from "@/lib/season";
+import { SEASON_START, SEASON_WEEKS, WEEKS_REQUIRED } from "@/lib/season";
 
 export interface SeasonProgress {
   weeks: Array<{
@@ -21,9 +21,10 @@ export function getSeasonProgress(
       isRest: boolean;
     }>;
   }>,
-  today: Date
+  today: Date,
+  seasonStart: Date | null = SEASON_START
 ): SeasonProgress {
-  const weeks = getWeekStatuses(lanes, today);
+  const weeks = getWeekStatuses(lanes, today, seasonStart);
 
   const qualified = weeks.filter((w) => w.status === "qualified").length;
   const missed = weeks.filter((w) => w.status === "missed").length;

--- a/src/lib/weekStatuses.test.ts
+++ b/src/lib/weekStatuses.test.ts
@@ -1,58 +1,50 @@
 import { describe, it, expect } from 'vitest'
 import { getWeekStatuses } from './weekStatuses'
-import { getSeasonWeeks } from '@/lib/season'
+import { getSeasonWeeksFrom } from '@/lib/seasonWindow'
+import { isQualifyingWeek } from '@/lib/isQualifyingWeek'
+import { SEASON_START, SEASON_WEEKS } from '@/lib/season'
 
 describe('weekStatuses', () => {
-  it('returns one entry per season week with weekStart values matching getSeasonWeeks', () => {
-    const seasonWeeks = getSeasonWeeks()
-    const today = new Date(Date.UTC(2026, 7, 10)) // 2026-08-10
+  it('the week windows follow an explicit seasonStart date', () => {
+    // Use a custom season start date far in the future to avoid overlap with real constants
+    const customStart = new Date(Date.UTC(2030, 0, 1))
+    const today = new Date(Date.UTC(2030, 0, 15))
     const lanes: any[] = []
 
-    const results = getWeekStatuses(lanes, today)
+    const results = getWeekStatuses(lanes, today, customStart)
 
-    expect(results.length).toBe(seasonWeeks.length)
-    seasonWeeks.forEach((weekStart, index) => {
-      expect(results[index].weekStart.getTime()).toBe(weekStart.getTime())
-    })
+    // Verify the first week in the results matches our custom start
+    expect(results[0].weekStart.getTime()).toBe(customStart.getTime())
+    
+    // Verify the number of weeks matches the expected season length
+    expect(results.length).toBe(SEASON_WEEKS)
   })
 
-  it('a today inside the season marks exactly one week current and every later week upcoming', () => {
-    // Season starts 2026-08-10. 
-    // We pick a date that is clearly in the middle of the season.
-    // We use a date that is definitely not the very first or very last week.
-    const today = new Date(Date.UTC(2026, 8, 15)) // 2026-09-15
+  it('a null seasonStart makes every one of the thirteen weeks upcoming', () => {
+    // When seasonStart is null, the function uses getSeasonWeeksFrom(today)
+    // and every week is 'upcoming'.
+    const today = new Date(Date.UTC(2025, 5, 10))
     const lanes: any[] = []
-    const results = getWeekStatuses(lanes, today)
 
-    let currentCount = 0
-    let upcomingCount = 0
-    let elapsedCount = 0
+    const results = getWeekStatuses(lanes, today, null)
 
+    expect(results.length).toBe(SEASON_WEEKS)
     results.forEach((res) => {
-      if (res.status === 'current') currentCount++
-      if (res.status === 'upcoming') upcomingCount++
-      if (res.status === 'qualified' || res.status === 'missed') elapsedCount++
+      expect(res.status).toBe('upcoming')
     })
 
-    expect(currentCount).toBe(1)
-    expect(upcomingCount).toBeGreaterThan(0)
-    // Ensure no 'upcoming' week is marked 'current'
-    const upcomingWeek = results.find(r => r.status === 'upcoming')
-    if (upcomingWeek) {
-      expect(upcomingWeek.weekStart.getTime()).toBeGreaterThan(today.getTime() - 7 * 24 * 60 * 60 * 1000)
-    }
+    // The first week should start at the 'today' date (as per AC: getSeasonWeeksFrom(today))
+    expect(results[0].weekStart.getTime()).toBe(today.getTime())
   })
 
-  it('an elapsed week with no check-ins at all is missed', () => {
-    // Pick a date far in the future so the first week of the season is definitely elapsed
-    const today = new Date(Date.UTC(2027, 0, 1)) 
-    const lanes: any[] = [] // No check-ins
+  it('omitting the third argument still uses the season constant', () => {
+    const today = new Date(Date.UTC(2025, 5, 10))
+    const lanes: any[] = []
+
+    // This calls getWeekStatuses(lanes, today) which should use SEASON_START
     const results = getWeekStatuses(lanes, today)
 
-    // The first week of the season (2026-08-10) should be 'missed' because there are no check-ins
-    const firstWeek = results[0]
-    expect(firstWeek.weekStart.getUTCMonth()).toBe(7) // August
-    expect(firstWeek.weekStart.getUTCDate()).toBe(10)
-    expect(firstWeek.status).toBe('missed')
+    // The first week should match the real SEASON_START
+    expect(results[0].weekStart.getTime()).toBe(SEASON_START.getTime())
   })
 })

--- a/src/lib/weekStatuses.ts
+++ b/src/lib/weekStatuses.ts
@@ -1,5 +1,6 @@
-import { getSeasonWeeks } from "@/lib/season";
-import { isQualifyingWeek } from "@/lib/isQualifyingWeek";
+import { getSeasonWeeksFrom } from '@/lib/seasonWindow';
+import { isQualifyingWeek } from '@/lib/isQualifyingWeek';
+import { SEASON_START, SEASON_WEEKS } from '@/lib/season';
 
 export type WeekStatus = "qualified" | "missed" | "current" | "upcoming";
 
@@ -10,9 +11,18 @@ interface LaneData {
 
 export function getWeekStatuses(
   lanes: LaneData[],
-  today: Date
+  today: Date,
+  seasonStart: Date | null = SEASON_START
 ): { weekStart: Date; status: WeekStatus }[] {
-  const seasonWeeks = getSeasonWeeks();
+  if (seasonStart === null) {
+    const weeks = getSeasonWeeksFrom(today);
+    return weeks.map((weekStart) => ({
+      weekStart,
+      status: "upcoming" as const,
+    }));
+  }
+
+  const seasonWeeks = getSeasonWeeksFrom(seasonStart);
 
   return seasonWeeks.map((weekStart) => {
     const weekEnd = new Date(weekStart);
@@ -20,17 +30,17 @@ export function getWeekStatuses(
 
     // A week whose window contains today gets status "current"
     if (weekStart <= today && today < weekEnd) {
-      return { weekStart, status: "current" };
+      return { weekStart, status: "current" as const };
     }
 
     // A week whose weekStart is strictly after today gets status "upcoming"
     if (weekStart > today) {
-      return { weekStart, status: "upcoming" };
+      return { weekStart, status: "upcoming" as const };
     }
 
     // A week whose window has fully elapsed (weekEnd <= today)
     // gets "qualified" if isQualifyingWeek returns true, and "missed" otherwise.
     const qualifies = isQualifyingWeek(lanes, weekStart);
-    return { weekStart, status: qualifies ? "qualified" : "missed" };
+    return { weekStart, status: qualifies ? "qualified" as const : "missed" as const };
   });
 }


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#210, #213) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.