### PR TITLE
feat(#212): Prize page grid reads the season Eddie started

### DIFF
--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { formatWeekLabel } from '@/lib/weekUtils'
+import { SEASON_WEEKS } from '@/lib/season'
+import PrizePage from './page'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    prize: { findUnique: vi.fn() },
+    lane: { findMany: vi.fn() },
+  },
+}))
+
+import { prisma } from '@/lib/db'
+
+const PRIZE = {
+  id: 'prize',
+  title: 'PS5',
+  description: null,
+  reasons: [] as string[],
+  photoUrl: null,
+  seasonStart: null as Date | null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+}
+
+describe('PrizePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([] as never)
+  })
+
+  it('titles the first week cell from the stored season start', async () => {
+    // Deliberately NOT the SEASON_START constant: if the page still reads the
+    // constant, the label is 2026-08-10 and this fails.
+    const started = new Date('2026-09-07T00:00:00.000Z')
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: started,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells[0].getAttribute('title')).toBe(formatWeekLabel(started))
+  })
+
+  it('marks every week upcoming before the season starts', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: null,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells.map((c) => c.getAttribute('data-status'))).toEqual(
+      Array(SEASON_WEEKS).fill('upcoming')
+    )
+  })
+})

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -4,26 +4,45 @@ import { deletePrize } from "@/app/actions/deletePrize"
 import { uploadPrizePhoto } from "@/app/actions/uploadPrizePhoto"
 import PrizeSection from "@/components/PrizeSection"
 import SeasonProgress from "@/components/SeasonProgress"
-import { SEASON_START, getSeasonEnd } from "@/lib/season"
+import { SEASON_WEEKS } from "@/lib/season"
+import { getSeasonWeeksFrom } from "@/lib/seasonWindow"
 import { getSeasonProgress } from "@/lib/seasonProgress"
 import { getTrainingDay } from "@/lib/trainingDay"
 
 export const dynamic = "force-dynamic"
 
+/** Exclusive end of a season that began on `start`: one week past week 13. */
+function seasonEnd(start: Date): Date {
+  const lastWeekStart = getSeasonWeeksFrom(start)[SEASON_WEEKS - 1]
+  const end = new Date(lastWeekStart)
+  end.setUTCDate(end.getUTCDate() + 7)
+  return end
+}
+
 export default async function PrizePage() {
   const prize = await prisma.prize.findUnique({ where: { id: "prize" } })
+
+  // Before Eddie presses START there is no window to filter on — the season
+  // hasn't begun, so every check-in is fair game and the grid renders as
+  // thirteen upcoming weeks.
+  const seasonStart = prize?.seasonStart ?? null
+  const checkInWhere = seasonStart
+    ? {
+        date: {
+          gte: seasonStart,
+          // The exclusive end is a week AFTER the last week starts, or the
+          // thirteenth week's check-ins fall outside the window.
+          lt: seasonEnd(seasonStart),
+        },
+      }
+    : {}
 
   const lanes = await prisma.lane.findMany({
     where: { isActive: true },
     select: {
       targetPerWeek: true,
       checkIns: {
-        where: {
-          date: {
-            gte: SEASON_START,
-            lt: getSeasonEnd(),
-          },
-        },
+        where: checkInWhere,
         select: {
           date: true,
           isRest: true,
@@ -32,7 +51,7 @@ export default async function PrizePage() {
     },
   })
 
-  const progress = getSeasonProgress(lanes, getTrainingDay(new Date()))
+  const progress = getSeasonProgress(lanes, getTrainingDay(new Date()), seasonStart)
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">


### PR DESCRIPTION
Closes #212. The last leg of the `seasonStart` migration.

The grid rendered from the `SEASON_START` constant, so pressing **START** on the TODAY page moved nothing on the Prize page — two sources of truth for when the season began.

The page now reads `seasonStart` off the prize row it already fetches and passes it through. When the season hasn't begun, the check-in query isn't date-windowed at all and the grid renders thirteen `upcoming` weeks, so Eddie sees the shape of the season he's about to play rather than a blank panel.

One thing worth calling out: `seasonEnd()` is a week **past** the thirteenth week's start. Indexing `getSeasonWeeksFrom(start)[SEASON_WEEKS - 1]` directly — my first version — would have silently dropped the final week's check-ins from the query.

### Why hand-written

Six grind iterations, every one failing on my story prose rather than on the code:

| Attempt | Defect |
|---|---|
| 1 | self-contradictory AC (`all upcoming` *and* windows from `today`) |
| 2 | two implementation files — the TDD path writes only `unit_path` |
| 3 | slash-joined `current/qualified/missed` leaked into a type literal |
| 4 | unobservable assertion (would require mocking a pure module) |
| 5 | `getByText` for a value that lives in a `title` attribute |
| 6 | arithmetic on a `Date[]` |

The code is four lines. Attempt 2's cause was Spike's (see the single-file limitation), the rest were mine.

**Red-green:** both tests failed for real first — `"current"` where `"upcoming"` was expected, proving the page still read the constant — then passed. `tsc` clean, `next build` clean, 189 tests green.

Based on `dispatch/integration` so it lands together with #210 and #213 via PR #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3