### PR TITLE
fix: setup panel was told the season needs 0 lanes

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Page from './page'
+import { LANES_REQUIRED } from '@/lib/season'
 import { prisma } from '@/lib/db'
 
 // Mocking the components as requested by the AC
@@ -83,5 +84,24 @@ describe('Page', () => {
 
     expect(screen.queryByTestId('season-setup-panel')).not.toBeInTheDocument()
     expect(screen.getByTestId('season-start-button')).toBeInTheDocument()
+  })
+
+  it('tells the setup panel how many lanes the season actually requires', async () => {
+    // The panel computes `laneCount >= lanesNeeded` to tick its step off. When
+    // the page hands it 0, that comparison is always true, so Eddie is told
+    // his setup is complete while the START button stays disabled.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      id: 'prize',
+      title: 'PS5',
+      seasonStart: null,
+      reasons: [],
+    } as any)
+    vi.mocked(prisma.lane.count).mockResolvedValue(1)
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([])
+
+    render(await Page())
+
+    const panel = screen.getByTestId('season-setup-panel')
+    expect(panel.getAttribute('data-lanes-needed')).toBe(String(LANES_REQUIRED))
   })
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default async function DashboardPage() {
         {!hasStarted && !readiness.isReady && (
           <SeasonSetupPanel 
             laneCount={activeLaneCount} 
-            lanesNeeded={0} 
+            lanesNeeded={readiness.lanesNeeded}
             hasPrize={Boolean(prize)} 
           />
         )}


### PR DESCRIPTION
Found by reading the **deployed HTML** after today's release, not by any gate.

`page.tsx` passed `lanesNeeded={0}` to `SeasonSetupPanel` (hardcoded in #194) while `getSeasonReadiness` already returned the real `LANES_REQUIRED`. The panel ticks a step off with `laneCount >= lanesNeeded`, so `0` made that always true.

In production right now, with one lane and a prize set:

```
Add 0 lanes (1/0)   ✓
Set your prize      ✓
[ Start my season ]  ← disabled
```

Both steps complete, next to a START button that correctly refuses to work — and nothing on screen explains the contradiction. The setup panel exists precisely to answer *"what do I still need to do?"*, so this is the one component where being wrong is worst.

### Why nothing caught it

- `SeasonSetupPanel.test.tsx` passes `lanesNeeded={3}` explicitly → passes.
- `page.test.tsx` mocks the panel and records the prop as `data-lanes-needed` → **never asserted it**.

Both sides tested, the wire between them untested. That's the same seam shape as most of this campaign's defects, and it's why the assertion added here fails against the old code before passing against the new.

175 tests green · `tsc` clean · `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3