### PR TITLE
release: fix the setup panel's lane requirement

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Page from './page'
+import { LANES_REQUIRED } from '@/lib/season'
 import { prisma } from '@/lib/db'
 
 // Mocking the components as requested by the AC
@@ -83,5 +84,24 @@ describe('Page', () => {
 
     expect(screen.queryByTestId('season-setup-panel')).not.toBeInTheDocument()
     expect(screen.getByTestId('season-start-button')).toBeInTheDocument()
+  })
+
+  it('tells the setup panel how many lanes the season actually requires', async () => {
+    // The panel computes `laneCount >= lanesNeeded` to tick its step off. When
+    // the page hands it 0, that comparison is always true, so Eddie is told
+    // his setup is complete while the START button stays disabled.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      id: 'prize',
+      title: 'PS5',
+      seasonStart: null,
+      reasons: [],
+    } as any)
+    vi.mocked(prisma.lane.count).mockResolvedValue(1)
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([])
+
+    render(await Page())
+
+    const panel = screen.getByTestId('season-setup-panel')
+    expect(panel.getAttribute('data-lanes-needed')).toBe(String(LANES_REQUIRED))
   })
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default async function DashboardPage() {
         {!hasStarted && !readiness.isReady && (
           <SeasonSetupPanel 
             laneCount={activeLaneCount} 
-            lanesNeeded={0} 
+            lanesNeeded={readiness.lanesNeeded}
             hasPrize={Boolean(prize)} 
           />
         )}


### PR DESCRIPTION
Follow-up to the season-setup release. Two commits.

Fixes a bug visible in production right now: with one lane and a prize set, the setup panel rendered

```
Add 0 lanes (1/0)   ✓
Set your prize      ✓
[ Start my season ]  ← disabled
```

`page.tsx` hardcoded `lanesNeeded={0}` while `getSeasonReadiness` already returned the real `LANES_REQUIRED`, and the panel ticks a step off with `laneCount >= lanesNeeded`. So Eddie was told his setup was complete and handed a button that refused to work.

Found by reading the deployed HTML after the last release, not by any gate — `SeasonSetupPanel`'s own tests pass the prop explicitly, and the page's test recorded it without asserting it. That assertion now exists and fails against the old code.

175 tests green · `tsc` clean · `next build` clean · CI green on `1ea67d9`.

Merge with a **merge commit, not squash**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3