### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/app/actions/deleteLane.test.ts
+++ b/src/app/actions/deleteLane.test.ts
@@ -10,30 +10,57 @@ vi.mock('@/lib/db', () => ({
     bossBattle: { deleteMany: vi.fn() },
     streakFreeze: { deleteMany: vi.fn() },
     lane: { delete: vi.fn() },
+    prize: { findUnique: vi.fn() },
   },
 }))
-vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
 
 describe('deleteLane', () => {
-  beforeEach(() => vi.clearAllMocks())
-
-  it('deletes the lane and its children in a transaction, returns ok', async () => {
-    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
-    const result = await deleteLane('lane-1')
-    expect(result).toEqual({ ok: true })
-    expect(prisma.$transaction).toHaveBeenCalledOnce()
-    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('empty id returns missing-id without a db call', async () => {
-    const result = await deleteLane('')
-    expect(result).toEqual({ ok: false, error: 'missing-id' })
+  it('a started season refuses the delete and touches no rows', async () => {
+    // Arrange: seasonStart is set (season is running)
+    const seasonStart = new Date(Date.UTC(2024, 0, 1))
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      id: 'prize',
+      title: 'Test Prize',
+      seasonStart,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      description: null,
+      reasons: [],
+      photoUrl: null,
+    } as any)
+
+    // Act
+    const result = await deleteLane('lane-123')
+
+    // Assert
+    expect(result).toEqual({ ok: false, error: 'season-running' })
     expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
   })
 
-  it('db error returns not-found', async () => {
-    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('nope'))
-    const result = await deleteLane('lane-1')
-    expect(result).toEqual({ ok: false, error: 'not-found' })
+  it('a season that has not started deletes as before', async () => {
+    // Arrange: seasonStart is null (season not running)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      id: 'prize',
+      seasonStart: null,
+    } as any)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+
+    // Act
+    const result = await deleteLane('lane-123')
+
+    // Assert
+    expect(result).toEqual({ ok: true })
+    expect(prisma.$transaction).toHaveBeenCalled()
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+    expect(revalidatePath).toHaveBeenCalledWith('/')
   })
 })

--- a/src/app/actions/deleteLane.ts
+++ b/src/app/actions/deleteLane.ts
@@ -7,6 +7,16 @@ export async function deleteLane(
   if (!id) return { ok: false, error: "missing-id" }
 
   try {
+    // Check if a season is currently running.
+    // If the 'prize' row has a non-null seasonStart, the season is active.
+    const prize = await prisma.prize.findUnique({
+      where: { id: 'prize' },
+    })
+
+    if (prize?.seasonStart) {
+      return { ok: false, error: 'season-running' }
+    }
+
     // Cascade the lane's dependent rows in a single transaction (the schema has
     // no ON DELETE CASCADE, so the FK'd check-ins/battles must go first).
     await prisma.$transaction([
@@ -15,7 +25,7 @@ export async function deleteLane(
       prisma.streakFreeze.deleteMany({ where: { laneId: id } }),
       prisma.lane.delete({ where: { id } }),
     ])
-  } catch {
+  } catch (err) {
     return { ok: false, error: "not-found" }
   }
 

--- a/src/components/LaneSwapModal.test.tsx
+++ b/src/components/LaneSwapModal.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import LaneSwapModal from './LaneSwapModal'
+
+describe('LaneSwapModal', () => {
+  const defaultProps = {
+    open: true,
+    outLane: { id: '1', name: 'Stick Skills', emoji: '🥍' },
+    inactiveLanes: [{ id: '2', name: 'Running', emoji: '🏃' }],
+    mustPickReplacement: false,
+    canRetire: true,
+    onSwap: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when closed', async () => {
+    render(<LaneSwapModal {...defaultProps} open={false} />)
+    const dialog = screen.queryByRole('dialog')
+    expect(dialog).toBeNull()
+  })
+
+  it('renders dialog heading when open', async () => {
+    render(<LaneSwapModal {...defaultProps} />)
+    expect(screen.getByRole('heading', { name: 'Trade out 🥍 Stick Skills' })).toBeInTheDocument()
+  })
+
+  it('cancel button calls onCancel', async () => {
+    const user = (await import('@testing-library/user-event')).default.setup()
+    render(<LaneSwapModal {...defaultProps} />)
+    const cancelButton = screen.getByTestId('cancel-swap')
+    await user.click(cancelButton)
+    expect(defaultProps.onCancel).toHaveBeenCalled()
+  })
+})

--- a/src/components/LaneSwapModal.tsx
+++ b/src/components/LaneSwapModal.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import React, { useState } from 'react'
+
+interface LaneInfo {
+  id: string
+  name: string
+  emoji: string
+}
+
+interface LaneSwapModalProps {
+  open: boolean
+  outLane: LaneInfo
+  inactiveLanes: LaneInfo[]
+  mustPickReplacement: boolean
+  canRetire: boolean
+  onSwap: (outLaneId: string, inLaneId?: string) => Promise<void>
+  onCancel: () => void
+}
+
+export default function LaneSwapModal({
+  open,
+  outLane,
+  inactiveLanes,
+  mustPickReplacement,
+  canRetire,
+  onSwap,
+  onCancel,
+}: LaneSwapModalProps) {
+  const [selectedInLaneId, setSelectedInLaneId] = useState<string | undefined>(undefined)
+
+  if (!open) return null
+
+  const handleConfirm = async () => {
+    try {
+      await onSwap(outLane.id, selectedInLaneId)
+    } catch (err) {
+      console.error("Swap failed:", err)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="w-full max-w-md overflow-hidden rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900">
+        <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
+          Trade out {outLane.emoji} {outLane.name}
+        </h2>
+
+        <div className="mt-6 space-y-4">
+          {mustPickReplacement && inactiveLanes.length === 0 ? (
+            <p className="text-sm text-zinc-500">No inactive lanes available</p>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Select a replacement lane:
+              </p>
+              <div className="max-h-48 overflow-y-auto space-y-1">
+                {inactiveLanes.map((lane) => (
+                  <button
+                    key={lane.id}
+                    type="button"
+                    onClick={() => setSelectedInLaneId(lane.id)}
+                    className={`w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                      selectedInLaneId === lane.id
+                        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'
+                        : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300'
+                    }`}
+                  >
+                    <span>{lane.emoji}</span>
+                    <span>{lane.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {canRetire && (
+            <div className="flex items-center gap-2 rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <input
+                type="checkbox"
+                id="retire-lane"
+                className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setSelectedInLaneId(undefined)
+                  }
+                }}
+              />
+              <label htmlFor="retire-lane" className="text-sm text-zinc-600 dark:text-zinc-400">
+                Retire this lane instead
+              </label>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            data-testid="cancel-swap"
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!selectedInLaneId && mustPickReplacement}
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:pointer-events-none"
+          >
+            {mustPickReplacement ? 'Confirm Swap' : 'Retire Lane'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/validateSwap.test.ts
+++ b/src/lib/validateSwap.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { validateSwap } from './validateSwap'
+
+describe('validateSwap', () => {
+  it('fewer than 3 lanes is blocked', () => {
+    const result = validateSwap(2)
+    expect(result).
+      toEqual({
+        canRetire: false,
+        mustPickReplacement: false,
+        blocked: true
+      })
+  })
+
+  it('more than 3 lanes can retire', () => {
+    const result = validateSwap(5)
+    expect(result).
+      toEqual({
+        canRetire: true,
+        mustPickReplacement: false,
+        blocked: false
+      })
+  })
+
+  it('4 lanes returns canRetire true', () => {
+    const result = validateSwap(4)
+    expect(result.canRetire).toBe(true)
+  })
+})

--- a/src/lib/validateSwap.ts
+++ b/src/lib/validateSwap.ts
@@ -1,0 +1,11 @@
+export const validateSwap = (activeLaneCount: number) => {
+  if (activeLaneCount < 3) {
+    return { canRetire: false, mustPickReplacement: false, blocked: true };
+  }
+
+  if (activeLaneCount > 3) {
+    return { canRetire: true, mustPickReplacement: false, blocked: false };
+  }
+
+  return { canRetire: false, mustPickReplacement: true, blocked: false };
+};


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#246, #225, #230) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.