### PR TITLE
feat(#227): Story 3 — swapSchema Zod addition

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
+import { swapSchema, laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
 
 describe('validation', () => {
   it('laneSchema valid input passes', () => {
@@ -123,4 +123,28 @@ describe('validation', () => {
       expect(result.data.reasons).toEqual([])
     }
   })
-}) 
+
+  describe('swapSchema', () => {
+    it('a missing outLaneId is rejected', () => {
+      const invalidData = { inLaneId: 'some-id' }
+      const result = swapSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+
+    it('a valid outLaneId with no inLaneId is accepted', () => {
+      const validData = { outLaneId: 'some-id' }
+      const result = swapSchema.safeParse(validData)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.outLaneId).toBe('some-id')
+        expect(result.data.inLaneId).toBeUndefined()
+      }
+    })
+
+    it('an outLaneId of empty string is rejected', () => {
+      const invalidData = { outLaneId: '', inLaneId: 'some-id' }
+      const result = swapSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -31,8 +31,14 @@ export const prizeSchema = z.object({
   photoUrl: z.string().url().optional().nullable(),
 })
 
+export const swapSchema = z.object({
+  outLaneId: z.string().min(1),
+  inLaneId: z.string().min(1).optional(),
+})
+
 export type LaneInput = z.infer<typeof laneSchema>
 export type CheckInInput = z.infer<typeof checkInSchema>
 export type BossBattleInput = z.infer<typeof bossBattleSchema>
 export type ReflectionInput = z.infer<typeof reflectionSchema>
 export type PrizeInput = z.infer<typeof prizeSchema>
+export type SwapInput = z.infer<typeof swapSchema>


### PR DESCRIPTION
## Summary

Implements story #227: Story 3 — swapSchema Zod addition

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `smoke` exit 0
- `smoke` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 7
- Prompt tokens: 61459
- Output tokens: 6728

Closes #227