### PR TITLE
Land queue → develop (dispatch/integration)

### DIFF
--- a/src/lib/validateSwap.test.ts
+++ b/src/lib/validateSwap.test.ts
@@ -26,4 +26,13 @@ describe('validateSwap', () => {
     const result = validateSwap(4)
     expect(result.canRetire).toBe(true)
   })
+
+  it('exactly three lanes must pick a replacement', () => {
+    const result = validateSwap(3)
+    expect(result).toEqual({
+      canRetire: false,
+      mustPickReplacement: true,
+      blocked: false
+    })
+  })
 })

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
+import { swapSchema, laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
 
 describe('validation', () => {
   it('laneSchema valid input passes', () => {
@@ -123,4 +123,28 @@ describe('validation', () => {
       expect(result.data.reasons).toEqual([])
     }
   })
-}) 
+
+  describe('swapSchema', () => {
+    it('a missing outLaneId is rejected', () => {
+      const invalidData = { inLaneId: 'some-id' }
+      const result = swapSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+
+    it('a valid outLaneId with no inLaneId is accepted', () => {
+      const validData = { outLaneId: 'some-id' }
+      const result = swapSchema.safeParse(validData)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.outLaneId).toBe('some-id')
+        expect(result.data.inLaneId).toBeUndefined()
+      }
+    })
+
+    it('an outLaneId of empty string is rejected', () => {
+      const invalidData = { outLaneId: '', inLaneId: 'some-id' }
+      const result = swapSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -31,8 +31,14 @@ export const prizeSchema = z.object({
   photoUrl: z.string().url().optional().nullable(),
 })
 
+export const swapSchema = z.object({
+  outLaneId: z.string().min(1),
+  inLaneId: z.string().min(1).optional(),
+})
+
 export type LaneInput = z.infer<typeof laneSchema>
 export type CheckInInput = z.infer<typeof checkInSchema>
 export type BossBattleInput = z.infer<typeof bossBattleSchema>
 export type ReflectionInput = z.infer<typeof reflectionSchema>
 export type PrizeInput = z.infer<typeof prizeSchema>
+export type SwapInput = z.infer<typeof swapSchema>


### PR DESCRIPTION
Auto-opened by the dispatcher. Merging this lands the queue's accumulated stories (#226, #227) on `develop`, in dependency order — one merge, no per-PR rebasing. `develop` is untouched until you merge.

After merging, resume the queue (`--resume`) to pick up failures + newly-unblocked stories.