### PR TITLE
feat: season grid keeps retired lanes, swapLane action, modal confirm flow

### DIFF
--- a/src/app/actions/swapLane.test.ts
+++ b/src/app/actions/swapLane.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { swapLane } from './swapLane'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: { count: vi.fn(), update: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+import { prisma } from '@/lib/db'
+
+describe('swapLane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.lane.update).mockResolvedValue({} as never)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+  })
+
+  it('rejects input that is not a valid swap', async () => {
+    const result = await swapLane({ outLaneId: '' })
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(prisma.lane.count).not.toHaveBeenCalled()
+  })
+
+  it('refuses any change that would leave fewer than three lanes', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(2)
+
+    const result = await swapLane({ outLaneId: 'lane-2' })
+
+    expect(result).toEqual({ ok: false, error: 'blocked' })
+    expect(prisma.lane.update).not.toHaveBeenCalled()
+  })
+
+  it('retires a lane outright when more than three are active', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(4)
+
+    const result = await swapLane({ outLaneId: 'lane-2' })
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-2' },
+      data: { isActive: false },
+    })
+  })
+
+  it('demands a replacement at exactly three lanes', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+
+    const result = await swapLane({ outLaneId: 'lane-2' })
+
+    expect(result).toEqual({ ok: false, error: 'replacement-required' })
+    expect(prisma.lane.update).not.toHaveBeenCalled()
+  })
+
+  it('swaps one lane for another in a single transaction', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+
+    const result = await swapLane({ outLaneId: 'lane-2', inLaneId: 'lane-9' })
+
+    expect(result).toEqual({ ok: true })
+    // One transaction, so Eddie is never briefly left with two lanes.
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1)
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-2' },
+      data: { isActive: false },
+    })
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-9' },
+      data: { isActive: true },
+    })
+  })
+})

--- a/src/app/actions/swapLane.ts
+++ b/src/app/actions/swapLane.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { swapSchema } from '@/lib/validation'
+import { validateSwap } from '@/lib/validateSwap'
+
+type SwapResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * Retire a lane, or trade it for another.
+ *
+ * The season needs three active lanes at all times, so the rule is one
+ * invariant with two shapes: above the floor Eddie may simply retire; at the
+ * floor the only legal move is a straight swap, which runs as one transaction
+ * so he is never briefly left with two lanes.
+ *
+ * The retired lane's check-ins and boss battles are deliberately kept. They
+ * are what the season grid reads to decide which weeks he already earned —
+ * deleting them would let a swap quietly undo his season.
+ */
+export async function swapLane(input: unknown): Promise<SwapResult> {
+  const parsed = swapSchema.safeParse(input)
+  if (!parsed.success) return { ok: false, error: 'validation' }
+
+  const { outLaneId, inLaneId } = parsed.data
+
+  const activeLaneCount = await prisma.lane.count({ where: { isActive: true } })
+  const decision = validateSwap(activeLaneCount)
+
+  if (decision.blocked) return { ok: false, error: 'blocked' }
+  if (decision.mustPickReplacement && !inLaneId) {
+    return { ok: false, error: 'replacement-required' }
+  }
+
+  if (inLaneId) {
+    await prisma.$transaction([
+      prisma.lane.update({ where: { id: outLaneId }, data: { isActive: false } }),
+      prisma.lane.update({ where: { id: inLaneId }, data: { isActive: true } }),
+    ])
+  } else {
+    await prisma.lane.update({
+      where: { id: outLaneId },
+      data: { isActive: false },
+    })
+  }
+
+  revalidatePath('/lanes')
+  revalidatePath('/')
+  return { ok: true }
+}

--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -60,4 +60,23 @@ describe('PrizePage', () => {
       Array(SEASON_WEEKS).fill('upcoming')
     )
   })
+
+  it('does not exclude retired lanes from the season grid', async () => {
+    // The grid answers "what happened this season". A lane Eddie retired
+    // still earned its check-ins, so filtering the query by isActive would
+    // erase them from weeks he already qualified.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: new Date('2026-09-07T00:00:00.000Z'),
+    } as never)
+
+    render(await PrizePage())
+
+    // `where` may be absent entirely once the filter is gone — both that
+    // and a where-clause without isActive are correct.
+    const where = vi.mocked(prisma.lane.findMany).mock.calls[0][0]?.where as
+      | { isActive?: boolean }
+      | undefined
+    expect(where?.isActive).toBeUndefined()
+  })
 })

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -37,8 +37,12 @@ export default async function PrizePage() {
       }
     : {}
 
+  // Every lane Eddie has ever trained, not just the active ones. The grid
+  // answers "what happened this season", and a lane he retired still earned
+  // the check-ins it earned — filtering on isActive here would erase them
+  // from weeks he already qualified, so swapping a lane would silently undo
+  // his season. TODAY is the page that cares about what is active now.
   const lanes = await prisma.lane.findMany({
-    where: { isActive: true },
     select: {
       targetPerWeek: true,
       checkIns: {

--- a/src/components/LaneSwapModal.test.tsx
+++ b/src/components/LaneSwapModal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import LaneSwapModal from './LaneSwapModal'
 
@@ -34,5 +35,31 @@ describe('LaneSwapModal', () => {
     const cancelButton = screen.getByTestId('cancel-swap')
     await user.click(cancelButton)
     expect(defaultProps.onCancel).toHaveBeenCalled()
+  })
+
+  it('disables confirm until a replacement is chosen', async () => {
+    render(<LaneSwapModal {...defaultProps} mustPickReplacement={true} canRetire={false} />)
+
+    expect(screen.getByTestId('confirm-swap')).toBeDisabled()
+  })
+
+  it('confirms a swap with the lane Eddie picked', async () => {
+    const user = userEvent.setup()
+    render(<LaneSwapModal {...defaultProps} mustPickReplacement={true} canRetire={false} />)
+
+    await user.selectOptions(screen.getByTestId('replacement-select'), '2')
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    expect(defaultProps.onSwap).toHaveBeenCalledWith('1', '2')
+  })
+
+  it('retires with no replacement when above the floor', async () => {
+    const user = userEvent.setup()
+    render(<LaneSwapModal {...defaultProps} mustPickReplacement={false} canRetire={true} />)
+
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    // Exactly one argument: a retire is not a swap to `undefined`.
+    expect(defaultProps.onSwap).toHaveBeenCalledWith('1')
   })
 })

--- a/src/components/LaneSwapModal.tsx
+++ b/src/components/LaneSwapModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from 'react'
+import React, { useState, useTransition } from 'react'
 
 interface LaneInfo {
   id: string
@@ -27,16 +27,25 @@ export default function LaneSwapModal({
   onSwap,
   onCancel,
 }: LaneSwapModalProps) {
-  const [selectedInLaneId, setSelectedInLaneId] = useState<string | undefined>(undefined)
+  const [selectedInLaneId, setSelectedInLaneId] = useState('')
+  const [isPending, startTransition] = useTransition()
 
   if (!open) return null
 
-  const handleConfirm = async () => {
-    try {
-      await onSwap(outLane.id, selectedInLaneId)
-    } catch (err) {
-      console.error("Swap failed:", err)
-    }
+  const handleConfirm = () => {
+    startTransition(async () => {
+      try {
+        // A retire is not a swap to `undefined` — call with one argument so
+        // the action takes its retire path rather than the swap path.
+        if (selectedInLaneId) {
+          await onSwap(outLane.id, selectedInLaneId)
+        } else {
+          await onSwap(outLane.id)
+        }
+      } catch (err) {
+        console.error("Swap failed:", err)
+      }
+    })
   }
 
   return (
@@ -55,26 +64,26 @@ export default function LaneSwapModal({
             <p className="text-sm text-zinc-500">No inactive lanes available</p>
           ) : (
             <div className="space-y-2">
-              <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              <label
+                htmlFor="replacement-select"
+                className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
                 Select a replacement lane:
-              </p>
-              <div className="max-h-48 overflow-y-auto space-y-1">
+              </label>
+              <select
+                id="replacement-select"
+                data-testid="replacement-select"
+                value={selectedInLaneId}
+                onChange={(e) => setSelectedInLaneId(e.target.value)}
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              >
+                <option value="">Pick a replacement lane</option>
                 {inactiveLanes.map((lane) => (
-                  <button
-                    key={lane.id}
-                    type="button"
-                    onClick={() => setSelectedInLaneId(lane.id)}
-                    className={`w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
-                      selectedInLaneId === lane.id
-                        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'
-                        : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300'
-                    }`}
-                  >
-                    <span>{lane.emoji}</span>
-                    <span>{lane.name}</span>
-                  </button>
+                  <option key={lane.id} value={lane.id}>
+                    {lane.emoji} {lane.name}
+                  </option>
                 ))}
-              </div>
+              </select>
             </div>
           )}
 
@@ -86,7 +95,7 @@ export default function LaneSwapModal({
                 className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
                 onChange={(e) => {
                   if (e.target.checked) {
-                    setSelectedInLaneId(undefined)
+                    setSelectedInLaneId('')
                   }
                 }}
               />
@@ -108,8 +117,9 @@ export default function LaneSwapModal({
           </button>
           <button
             type="button"
+            data-testid="confirm-swap"
             onClick={handleConfirm}
-            disabled={!selectedInLaneId && mustPickReplacement}
+            disabled={isPending || (mustPickReplacement && !selectedInLaneId)}
             className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:pointer-events-none"
           >
             {mustPickReplacement ? 'Confirm Swap' : 'Retire Lane'}


### PR DESCRIPTION
Closes #245, #228, #231. Subsumes #229.

Hand-written after five grind rounds each produced a fresh defect in the same three files. The gates built along the way (malformed imports, invented props) are real and stay — they simply didn't cover these manifestations, and a sixth round was buying no new information.

### #245 — the invariant

The Prize grid queried `where: { isActive: true }` and recomputes all thirteen weeks against whatever survives. So retiring a lane **erased the check-ins it had already earned**, and weeks Eddie had qualified flipped to missed. Three lost weeks make the prize (11 of 13) unreachable — the anti-boredom feature would have ended his season the first time he used it.

The grid now counts every lane he has ever trained. TODAY still shows only active lanes: *what to do now* versus *what actually happened*.

### #228 (+#229) — swapLane

Implemented as one action rather than two stories. #229's swap path lives in the same file and is reachable from #228's implementation, so splitting them has the **#226 problem**: the second story has no behaviour left to introduce and cannot produce a legitimate red. #229 is closed as subsumed, covered by tests here.

The retired lane's check-ins and boss battles are deliberately kept — they're what the grid reads to decide which weeks were earned, so deleting them would let a swap quietly undo the season.

### #231 — the modal's confirm flow

Replaces #230's button-list picker with the `<select>` the story specifies, adds `data-testid="confirm-swap"`, and wraps the call in `useTransition`.

A retire calls `onSwap(outLane.id)` with **exactly one argument** — a retire is not a swap to `undefined`, and the action branches on the second argument's presence.

### Verification

Red-green throughout. #245's assertion was checked to fail against the old query before being accepted, since it would pass trivially if the where-clause were simply absent.

193 tests green · `tsc` clean · `next build` clean · 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3