### PR TITLE
feat: wire the lane swap into Lanes and Boss Battles

### DIFF
--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -3,6 +3,9 @@ import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from "@/lib/
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
+import BossBattleSwapTrigger from "@/components/BossBattleSwapTrigger"
+import { swapLane } from "@/app/actions/swapLane"
+import { validateSwap } from "@/lib/validateSwap"
 
 export const dynamic = "force-dynamic"
 
@@ -25,6 +28,13 @@ export default async function BossBattlesPage() {
       },
     },
   })
+
+  // What a lane change would cost right now, decided once for the page.
+  const inactiveLanes = await db.lane.findMany({
+    where: { isActive: false },
+    select: { id: true, name: true, emoji: true },
+  })
+  const swapState = validateSwap(lanes.length)
 
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
@@ -67,11 +77,22 @@ export default async function BossBattlesPage() {
                   existingReport={existing?.selfReport}
                   existingCoachNote={existing?.coachNote ?? undefined}
                   createBossBattle={async (data) => {
-                    "use server"
+                      "use server"
                     const r = await createBossBattle(data)
                     return { coachNote: r.ok ? r.coachNote : undefined }
                   }}
                 />
+                {existing && (
+                  <BossBattleSwapTrigger
+                    lane={{ id: lane.id, name: lane.name, emoji: lane.emoji }}
+                    inactiveLanes={inactiveLanes}
+                    swapState={swapState}
+                    onSwapLane={async (outLaneId, inLaneId) => {
+                      "use server"
+                      return swapLane({ outLaneId, inLaneId })
+                    }}
+                  />
+                )}
               </div>
             ) : (
               <p className="text-zinc-500 text-sm">No battle this week — target missed.</p>

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -3,6 +3,8 @@ import { createLane } from "@/app/actions/createLane"
 import { updateLane } from "@/app/actions/updateLane"
 import { setLaneActive } from "@/app/actions/setLaneActive"
 import { deleteLane } from "@/app/actions/deleteLane"
+import { swapLane } from "@/app/actions/swapLane"
+import { validateSwap } from "@/lib/validateSwap"
 import LaneList from "@/components/LaneList"
 import LaneForm from "@/components/LaneForm"
 
@@ -12,6 +14,14 @@ export default async function LanesPage() {
   const lanes = await prisma.lane.findMany({
     orderBy: [{ isActive: "desc" }, { sortOrder: "asc" }],
   })
+
+  // The floor of three governs every lane change, so the page decides once
+  // what is legal right now and hands the answer down.
+  const activeLaneCount = lanes.filter((l) => l.isActive).length
+  const swapState = validateSwap(activeLaneCount)
+  const inactiveLanes = lanes
+    .filter((l) => !l.isActive)
+    .map((l) => ({ id: l.id, name: l.name, emoji: l.emoji }))
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">
@@ -33,6 +43,12 @@ export default async function LanesPage() {
         deleteLane={async (id) => {
           "use server"
           return deleteLane(id)
+        }}
+        swapState={swapState}
+        inactiveLanes={inactiveLanes}
+        onSwapLane={async (outLaneId, inLaneId) => {
+          "use server"
+          return swapLane({ outLaneId, inLaneId })
         }}
       />
       <div className="border-t pt-6">

--- a/src/components/BossBattleSwapTrigger.test.tsx
+++ b/src/components/BossBattleSwapTrigger.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import BossBattleSwapTrigger from './BossBattleSwapTrigger'
+
+const LANE = { id: '1', name: 'Stick Skills', emoji: '🥍' }
+const INACTIVE = [{ id: '9', name: 'Running', emoji: '🏃' }]
+
+const props = (swapState: {
+  mustPickReplacement: boolean
+  canRetire: boolean
+  blocked: boolean
+}) => ({
+  lane: LANE,
+  inactiveLanes: INACTIVE,
+  swapState,
+  onSwapLane: vi.fn(),
+})
+
+describe('BossBattleSwapTrigger', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('offers the trade once the battle is done', () => {
+    render(
+      <BossBattleSwapTrigger
+        {...props({ mustPickReplacement: false, canRetire: true, blocked: false })}
+      />
+    )
+
+    expect(screen.getByTestId('trade-btn-1')).toBeInTheDocument()
+  })
+
+  it('offers nothing when the season would not allow the change', () => {
+    // An offer Eddie cannot accept is worse than no offer.
+    render(
+      <BossBattleSwapTrigger
+        {...props({ mustPickReplacement: false, canRetire: false, blocked: true })}
+      />
+    )
+
+    expect(screen.queryByTestId('trade-btn-1')).not.toBeInTheDocument()
+  })
+
+  it('trades the lane through the action when confirmed', async () => {
+    const user = userEvent.setup()
+    const p = props({ mustPickReplacement: false, canRetire: true, blocked: false })
+    render(<BossBattleSwapTrigger {...p} />)
+
+    await user.click(screen.getByTestId('trade-btn-1'))
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    expect(p.onSwapLane).toHaveBeenCalledWith('1')
+  })
+})

--- a/src/components/BossBattleSwapTrigger.tsx
+++ b/src/components/BossBattleSwapTrigger.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+import LaneSwapModal from "@/components/LaneSwapModal"
+
+interface LaneInfo {
+  id: string
+  name: string
+  emoji: string
+}
+
+interface BossBattleSwapTriggerProps {
+  lane: LaneInfo
+  inactiveLanes: LaneInfo[]
+  swapState: { mustPickReplacement: boolean; canRetire: boolean; blocked: boolean }
+  onSwapLane: (outLaneId: string, inLaneId?: string) => Promise<unknown>
+}
+
+/**
+ * The moment a lane change is offered: right after Eddie logs a boss battle.
+ *
+ * A boss battle is the natural end of a chapter for that lane, so trading it
+ * here reads as finishing something rather than quitting it. Nothing renders
+ * when the season would not allow a change — an offer he cannot accept is
+ * worse than no offer.
+ *
+ * Its own file rather than inline in the page, because `"use client"` applies
+ * to a whole module: a client component cannot be declared inside a Server
+ * Component file.
+ */
+export default function BossBattleSwapTrigger({
+  lane,
+  inactiveLanes,
+  swapState,
+  onSwapLane,
+}: BossBattleSwapTriggerProps) {
+  const [open, setOpen] = useState(false)
+
+  if (swapState.blocked) return null
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid={`trade-btn-${lane.id}`}
+        onClick={() => setOpen(true)}
+        className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+      >
+        Trade this lane
+      </button>
+
+      {open && (
+        <LaneSwapModal
+          open={true}
+          outLane={lane}
+          inactiveLanes={inactiveLanes}
+          mustPickReplacement={swapState.mustPickReplacement}
+          canRetire={swapState.canRetire}
+          onSwap={async (outLaneId, inLaneId) => {
+            // A retire is not a swap to `undefined`.
+            if (inLaneId) await onSwapLane(outLaneId, inLaneId)
+            else await onSwapLane(outLaneId)
+            setOpen(false)
+          }}
+          onCancel={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/LaneList.test.tsx
+++ b/src/components/LaneList.test.tsx
@@ -8,7 +8,17 @@ const LANES = [
   { id: '2', name: 'Swimming', emoji: '🏊', isActive: false, targetPerWeek: 2 },
 ]
 
-const actions = () => ({ updateLane: vi.fn(), setActive: vi.fn(), deleteLane: vi.fn() })
+const SWAP_OK = { mustPickReplacement: false, canRetire: true, blocked: false }
+const INACTIVE = [{ id: '2', name: 'Swimming', emoji: '🏊' }]
+
+const actions = () => ({
+  updateLane: vi.fn(),
+  setActive: vi.fn(),
+  deleteLane: vi.fn(),
+  onSwapLane: vi.fn(),
+  swapState: SWAP_OK,
+  inactiveLanes: INACTIVE,
+})
 
 describe('LaneList', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -60,5 +70,36 @@ describe('LaneList', () => {
     await user.type(nameInput, 'Sprints')
     await user.click(screen.getByRole('button', { name: 'Save' }))
     expect(a.updateLane).toHaveBeenCalledWith('1', expect.objectContaining({ name: 'Sprints' }))
+  })
+
+  it('offers a swap on each lane when the season allows a change', () => {
+    render(<LaneList lanes={LANES} {...actions()} />)
+
+    expect(screen.getByTestId('swap-btn-1')).toBeInTheDocument()
+  })
+
+  it('offers no swap when a change would break the three-lane floor', () => {
+    const a = actions()
+    render(
+      <LaneList
+        lanes={LANES}
+        {...a}
+        swapState={{ mustPickReplacement: false, canRetire: false, blocked: true }}
+      />
+    )
+
+    expect(screen.queryByTestId('swap-btn-1')).not.toBeInTheDocument()
+  })
+
+  it('confirming the modal swaps the lane and closes it', async () => {
+    const user = userEvent.setup()
+    const a = actions()
+    render(<LaneList lanes={LANES} {...a} />)
+
+    await user.click(screen.getByTestId('swap-btn-1'))
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    expect(a.onSwapLane).toHaveBeenCalledWith('1')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/src/components/LaneList.tsx
+++ b/src/components/LaneList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import ToggleSwitch from "@/components/ToggleSwitch"
 import ConfirmModal from "@/components/ConfirmModal"
+import LaneSwapModal from "@/components/LaneSwapModal"
 import { PencilIcon, TrashIcon } from "@/components/icons"
 
 interface Lane {
@@ -21,6 +22,9 @@ interface LaneListProps {
   ) => Promise<unknown>
   setActive: (id: string, isActive: boolean) => Promise<unknown>
   deleteLane: (id: string) => Promise<unknown>
+  onSwapLane: (outLaneId: string, inLaneId?: string) => Promise<unknown>
+  swapState: { mustPickReplacement: boolean; canRetire: boolean; blocked: boolean }
+  inactiveLanes: { id: string; name: string; emoji: string }[]
 }
 
 const EMOJI_OPTIONS: { cp: number; label: string }[] = [
@@ -37,10 +41,20 @@ const EMOJI_OPTIONS: { cp: number; label: string }[] = [
   { cp: 0x1f525, label: "Conditioning" },
 ]
 
-export default function LaneList({ lanes, updateLane, setActive, deleteLane }: LaneListProps) {
+export default function LaneList({
+  lanes,
+  updateLane,
+  setActive,
+  deleteLane,
+  onSwapLane,
+  swapState,
+  inactiveLanes,
+}: LaneListProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draft, setDraft] = useState({ name: "", emoji: "", targetPerWeek: 5 })
   const [confirmLane, setConfirmLane] = useState<Lane | null>(null)
+  // One modal shared by every row: `swapLane` is the lane being traded out.
+  const [swapLane, setSwapLane] = useState<Lane | null>(null)
 
   function startEdit(lane: Lane) {
     setEditingId(lane.id)
@@ -139,6 +153,16 @@ export default function LaneList({ lanes, updateLane, setActive, deleteLane }: L
                     onChange={(next) => setActive(lane.id, next)}
                     label={`Toggle ${lane.name}`}
                   />
+                  {!swapState.blocked && (
+                    <button
+                      data-testid={`swap-btn-${lane.id}`}
+                      aria-label={`Swap ${lane.name}`}
+                      onClick={() => setSwapLane(lane)}
+                      className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+                    >
+                      Swap
+                    </button>
+                  )}
                   <button
                     aria-label={`Edit ${lane.name}`}
                     onClick={() => startEdit(lane)}
@@ -171,6 +195,24 @@ export default function LaneList({ lanes, updateLane, setActive, deleteLane }: L
         }}
         onCancel={() => setConfirmLane(null)}
       />
+
+      {swapLane && (
+        <LaneSwapModal
+          open={true}
+          outLane={{ id: swapLane.id, name: swapLane.name, emoji: swapLane.emoji }}
+          inactiveLanes={inactiveLanes}
+          mustPickReplacement={swapState.mustPickReplacement}
+          canRetire={swapState.canRetire}
+          onSwap={async (outLaneId, inLaneId) => {
+            // A retire is not a swap to `undefined`: pass one argument so the
+            // action takes its retire path.
+            if (inLaneId) await onSwapLane(outLaneId, inLaneId)
+            else await onSwapLane(outLaneId)
+            setSwapLane(null)
+          }}
+          onCancel={() => setSwapLane(null)}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
Closes #232. Closes #233. Closes #234.

The last three stories of the epic, hand-written. Every large `.tsx` target in this epic failed the grinder (~20 attempts, **zero** landed) while every lib module landed cleanly — whole-file regeneration mangles files with substantial JSX, and no amount of retry feedback fixes a file the model can't reproduce faithfully.

### What ships

**#232 — LaneList.** Gains `onSwapLane`, `swapState`, `inactiveLanes`. Each row shows a Swap button unless a change would break the three-lane floor; one shared `LaneSwapModal` is driven by which lane is being traded out.

**#233 — Lanes page.** Counts active lanes once, asks `validateSwap` what's legal, hands the answer down. Worth noting: making LaneList's props required broke this page *in the same compile* — which is exactly why these two couldn't be split for the TDD path, the same shape as #226 and #229.

**#234 — Boss Battles.** `BossBattleSwapTrigger` renders under a lane's boss battle form and opens the modal.

### Two deliberate deviations, because the spec couldn't work as written

- **The trigger lives in its own file.** The story asked for a `"use client"` component declared inline in a Server Component file. The directive is module-level, so that cannot compile. This is likely part of why #234 burned 1008s and then 777s against the grinder — it was chasing something impossible.
- **The offer is gated on `existing`** — the battle actually being *submitted* — not merely on the target being hit. "After he finishes a boss battle" is the point: a trade should read as finishing a chapter, not skipping one.

### On verification

Red-green for #232. The trigger's blocked-state test was checked to fail with the guard removed, since `queryByTestId(...)` returning null passes trivially if a component renders nothing at all.

The trigger itself was written **before** its test rather than after — impl-first, because the client/server boundary had to be settled first. Saying so rather than implying a cycle that didn't happen.

199 tests green · `tsc` clean · `next build` clean · 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3