### PR TITLE
release: lane swap — Eddie trades a lane without losing his season

### DIFF
--- a/src/app/actions/deleteLane.test.ts
+++ b/src/app/actions/deleteLane.test.ts
@@ -10,30 +10,57 @@ vi.mock('@/lib/db', () => ({
     bossBattle: { deleteMany: vi.fn() },
     streakFreeze: { deleteMany: vi.fn() },
     lane: { delete: vi.fn() },
+    prize: { findUnique: vi.fn() },
   },
 }))
-vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
 
 describe('deleteLane', () => {
-  beforeEach(() => vi.clearAllMocks())
-
-  it('deletes the lane and its children in a transaction, returns ok', async () => {
-    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
-    const result = await deleteLane('lane-1')
-    expect(result).toEqual({ ok: true })
-    expect(prisma.$transaction).toHaveBeenCalledOnce()
-    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it('empty id returns missing-id without a db call', async () => {
-    const result = await deleteLane('')
-    expect(result).toEqual({ ok: false, error: 'missing-id' })
+  it('a started season refuses the delete and touches no rows', async () => {
+    // Arrange: seasonStart is set (season is running)
+    const seasonStart = new Date(Date.UTC(2024, 0, 1))
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      id: 'prize',
+      title: 'Test Prize',
+      seasonStart,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      description: null,
+      reasons: [],
+      photoUrl: null,
+    } as any)
+
+    // Act
+    const result = await deleteLane('lane-123')
+
+    // Assert
+    expect(result).toEqual({ ok: false, error: 'season-running' })
     expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
   })
 
-  it('db error returns not-found', async () => {
-    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('nope'))
-    const result = await deleteLane('lane-1')
-    expect(result).toEqual({ ok: false, error: 'not-found' })
+  it('a season that has not started deletes as before', async () => {
+    // Arrange: seasonStart is null (season not running)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      id: 'prize',
+      seasonStart: null,
+    } as any)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+
+    // Act
+    const result = await deleteLane('lane-123')
+
+    // Assert
+    expect(result).toEqual({ ok: true })
+    expect(prisma.$transaction).toHaveBeenCalled()
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+    expect(revalidatePath).toHaveBeenCalledWith('/')
   })
 })

--- a/src/app/actions/deleteLane.ts
+++ b/src/app/actions/deleteLane.ts
@@ -7,6 +7,16 @@ export async function deleteLane(
   if (!id) return { ok: false, error: "missing-id" }
 
   try {
+    // Check if a season is currently running.
+    // If the 'prize' row has a non-null seasonStart, the season is active.
+    const prize = await prisma.prize.findUnique({
+      where: { id: 'prize' },
+    })
+
+    if (prize?.seasonStart) {
+      return { ok: false, error: 'season-running' }
+    }
+
     // Cascade the lane's dependent rows in a single transaction (the schema has
     // no ON DELETE CASCADE, so the FK'd check-ins/battles must go first).
     await prisma.$transaction([
@@ -15,7 +25,7 @@ export async function deleteLane(
       prisma.streakFreeze.deleteMany({ where: { laneId: id } }),
       prisma.lane.delete({ where: { id } }),
     ])
-  } catch {
+  } catch (err) {
     return { ok: false, error: "not-found" }
   }
 

--- a/src/app/actions/swapLane.test.ts
+++ b/src/app/actions/swapLane.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { swapLane } from './swapLane'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: { count: vi.fn(), update: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+import { prisma } from '@/lib/db'
+
+describe('swapLane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.lane.update).mockResolvedValue({} as never)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+  })
+
+  it('rejects input that is not a valid swap', async () => {
+    const result = await swapLane({ outLaneId: '' })
+
+    expect(result).toEqual({ ok: false, error: 'validation' })
+    expect(prisma.lane.count).not.toHaveBeenCalled()
+  })
+
+  it('refuses any change that would leave fewer than three lanes', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(2)
+
+    const result = await swapLane({ outLaneId: 'lane-2' })
+
+    expect(result).toEqual({ ok: false, error: 'blocked' })
+    expect(prisma.lane.update).not.toHaveBeenCalled()
+  })
+
+  it('retires a lane outright when more than three are active', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(4)
+
+    const result = await swapLane({ outLaneId: 'lane-2' })
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-2' },
+      data: { isActive: false },
+    })
+  })
+
+  it('demands a replacement at exactly three lanes', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+
+    const result = await swapLane({ outLaneId: 'lane-2' })
+
+    expect(result).toEqual({ ok: false, error: 'replacement-required' })
+    expect(prisma.lane.update).not.toHaveBeenCalled()
+  })
+
+  it('swaps one lane for another in a single transaction', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+
+    const result = await swapLane({ outLaneId: 'lane-2', inLaneId: 'lane-9' })
+
+    expect(result).toEqual({ ok: true })
+    // One transaction, so Eddie is never briefly left with two lanes.
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1)
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-2' },
+      data: { isActive: false },
+    })
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-9' },
+      data: { isActive: true },
+    })
+  })
+})

--- a/src/app/actions/swapLane.ts
+++ b/src/app/actions/swapLane.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import { prisma } from '@/lib/db'
+import { revalidatePath } from 'next/cache'
+import { swapSchema } from '@/lib/validation'
+import { validateSwap } from '@/lib/validateSwap'
+
+type SwapResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * Retire a lane, or trade it for another.
+ *
+ * The season needs three active lanes at all times, so the rule is one
+ * invariant with two shapes: above the floor Eddie may simply retire; at the
+ * floor the only legal move is a straight swap, which runs as one transaction
+ * so he is never briefly left with two lanes.
+ *
+ * The retired lane's check-ins and boss battles are deliberately kept. They
+ * are what the season grid reads to decide which weeks he already earned —
+ * deleting them would let a swap quietly undo his season.
+ */
+export async function swapLane(input: unknown): Promise<SwapResult> {
+  const parsed = swapSchema.safeParse(input)
+  if (!parsed.success) return { ok: false, error: 'validation' }
+
+  const { outLaneId, inLaneId } = parsed.data
+
+  const activeLaneCount = await prisma.lane.count({ where: { isActive: true } })
+  const decision = validateSwap(activeLaneCount)
+
+  if (decision.blocked) return { ok: false, error: 'blocked' }
+  if (decision.mustPickReplacement && !inLaneId) {
+    return { ok: false, error: 'replacement-required' }
+  }
+
+  if (inLaneId) {
+    await prisma.$transaction([
+      prisma.lane.update({ where: { id: outLaneId }, data: { isActive: false } }),
+      prisma.lane.update({ where: { id: inLaneId }, data: { isActive: true } }),
+    ])
+  } else {
+    await prisma.lane.update({
+      where: { id: outLaneId },
+      data: { isActive: false },
+    })
+  }
+
+  revalidatePath('/lanes')
+  revalidatePath('/')
+  return { ok: true }
+}

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -3,6 +3,9 @@ import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from "@/lib/
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
+import BossBattleSwapTrigger from "@/components/BossBattleSwapTrigger"
+import { swapLane } from "@/app/actions/swapLane"
+import { validateSwap } from "@/lib/validateSwap"
 
 export const dynamic = "force-dynamic"
 
@@ -25,6 +28,13 @@ export default async function BossBattlesPage() {
       },
     },
   })
+
+  // What a lane change would cost right now, decided once for the page.
+  const inactiveLanes = await db.lane.findMany({
+    where: { isActive: false },
+    select: { id: true, name: true, emoji: true },
+  })
+  const swapState = validateSwap(lanes.length)
 
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
@@ -67,11 +77,22 @@ export default async function BossBattlesPage() {
                   existingReport={existing?.selfReport}
                   existingCoachNote={existing?.coachNote ?? undefined}
                   createBossBattle={async (data) => {
-                    "use server"
+                      "use server"
                     const r = await createBossBattle(data)
                     return { coachNote: r.ok ? r.coachNote : undefined }
                   }}
                 />
+                {existing && (
+                  <BossBattleSwapTrigger
+                    lane={{ id: lane.id, name: lane.name, emoji: lane.emoji }}
+                    inactiveLanes={inactiveLanes}
+                    swapState={swapState}
+                    onSwapLane={async (outLaneId, inLaneId) => {
+                      "use server"
+                      return swapLane({ outLaneId, inLaneId })
+                    }}
+                  />
+                )}
               </div>
             ) : (
               <p className="text-zinc-500 text-sm">No battle this week — target missed.</p>

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -3,6 +3,8 @@ import { createLane } from "@/app/actions/createLane"
 import { updateLane } from "@/app/actions/updateLane"
 import { setLaneActive } from "@/app/actions/setLaneActive"
 import { deleteLane } from "@/app/actions/deleteLane"
+import { swapLane } from "@/app/actions/swapLane"
+import { validateSwap } from "@/lib/validateSwap"
 import LaneList from "@/components/LaneList"
 import LaneForm from "@/components/LaneForm"
 
@@ -12,6 +14,14 @@ export default async function LanesPage() {
   const lanes = await prisma.lane.findMany({
     orderBy: [{ isActive: "desc" }, { sortOrder: "asc" }],
   })
+
+  // The floor of three governs every lane change, so the page decides once
+  // what is legal right now and hands the answer down.
+  const activeLaneCount = lanes.filter((l) => l.isActive).length
+  const swapState = validateSwap(activeLaneCount)
+  const inactiveLanes = lanes
+    .filter((l) => !l.isActive)
+    .map((l) => ({ id: l.id, name: l.name, emoji: l.emoji }))
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">
@@ -33,6 +43,12 @@ export default async function LanesPage() {
         deleteLane={async (id) => {
           "use server"
           return deleteLane(id)
+        }}
+        swapState={swapState}
+        inactiveLanes={inactiveLanes}
+        onSwapLane={async (outLaneId, inLaneId) => {
+          "use server"
+          return swapLane({ outLaneId, inLaneId })
         }}
       />
       <div className="border-t pt-6">

--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -60,4 +60,23 @@ describe('PrizePage', () => {
       Array(SEASON_WEEKS).fill('upcoming')
     )
   })
+
+  it('does not exclude retired lanes from the season grid', async () => {
+    // The grid answers "what happened this season". A lane Eddie retired
+    // still earned its check-ins, so filtering the query by isActive would
+    // erase them from weeks he already qualified.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: new Date('2026-09-07T00:00:00.000Z'),
+    } as never)
+
+    render(await PrizePage())
+
+    // `where` may be absent entirely once the filter is gone — both that
+    // and a where-clause without isActive are correct.
+    const where = vi.mocked(prisma.lane.findMany).mock.calls[0][0]?.where as
+      | { isActive?: boolean }
+      | undefined
+    expect(where?.isActive).toBeUndefined()
+  })
 })

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -37,8 +37,12 @@ export default async function PrizePage() {
       }
     : {}
 
+  // Every lane Eddie has ever trained, not just the active ones. The grid
+  // answers "what happened this season", and a lane he retired still earned
+  // the check-ins it earned — filtering on isActive here would erase them
+  // from weeks he already qualified, so swapping a lane would silently undo
+  // his season. TODAY is the page that cares about what is active now.
   const lanes = await prisma.lane.findMany({
-    where: { isActive: true },
     select: {
       targetPerWeek: true,
       checkIns: {

--- a/src/components/BossBattleSwapTrigger.test.tsx
+++ b/src/components/BossBattleSwapTrigger.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import BossBattleSwapTrigger from './BossBattleSwapTrigger'
+
+const LANE = { id: '1', name: 'Stick Skills', emoji: '🥍' }
+const INACTIVE = [{ id: '9', name: 'Running', emoji: '🏃' }]
+
+const props = (swapState: {
+  mustPickReplacement: boolean
+  canRetire: boolean
+  blocked: boolean
+}) => ({
+  lane: LANE,
+  inactiveLanes: INACTIVE,
+  swapState,
+  onSwapLane: vi.fn(),
+})
+
+describe('BossBattleSwapTrigger', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('offers the trade once the battle is done', () => {
+    render(
+      <BossBattleSwapTrigger
+        {...props({ mustPickReplacement: false, canRetire: true, blocked: false })}
+      />
+    )
+
+    expect(screen.getByTestId('trade-btn-1')).toBeInTheDocument()
+  })
+
+  it('offers nothing when the season would not allow the change', () => {
+    // An offer Eddie cannot accept is worse than no offer.
+    render(
+      <BossBattleSwapTrigger
+        {...props({ mustPickReplacement: false, canRetire: false, blocked: true })}
+      />
+    )
+
+    expect(screen.queryByTestId('trade-btn-1')).not.toBeInTheDocument()
+  })
+
+  it('trades the lane through the action when confirmed', async () => {
+    const user = userEvent.setup()
+    const p = props({ mustPickReplacement: false, canRetire: true, blocked: false })
+    render(<BossBattleSwapTrigger {...p} />)
+
+    await user.click(screen.getByTestId('trade-btn-1'))
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    expect(p.onSwapLane).toHaveBeenCalledWith('1')
+  })
+})

--- a/src/components/BossBattleSwapTrigger.tsx
+++ b/src/components/BossBattleSwapTrigger.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+import LaneSwapModal from "@/components/LaneSwapModal"
+
+interface LaneInfo {
+  id: string
+  name: string
+  emoji: string
+}
+
+interface BossBattleSwapTriggerProps {
+  lane: LaneInfo
+  inactiveLanes: LaneInfo[]
+  swapState: { mustPickReplacement: boolean; canRetire: boolean; blocked: boolean }
+  onSwapLane: (outLaneId: string, inLaneId?: string) => Promise<unknown>
+}
+
+/**
+ * The moment a lane change is offered: right after Eddie logs a boss battle.
+ *
+ * A boss battle is the natural end of a chapter for that lane, so trading it
+ * here reads as finishing something rather than quitting it. Nothing renders
+ * when the season would not allow a change — an offer he cannot accept is
+ * worse than no offer.
+ *
+ * Its own file rather than inline in the page, because `"use client"` applies
+ * to a whole module: a client component cannot be declared inside a Server
+ * Component file.
+ */
+export default function BossBattleSwapTrigger({
+  lane,
+  inactiveLanes,
+  swapState,
+  onSwapLane,
+}: BossBattleSwapTriggerProps) {
+  const [open, setOpen] = useState(false)
+
+  if (swapState.blocked) return null
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid={`trade-btn-${lane.id}`}
+        onClick={() => setOpen(true)}
+        className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+      >
+        Trade this lane
+      </button>
+
+      {open && (
+        <LaneSwapModal
+          open={true}
+          outLane={lane}
+          inactiveLanes={inactiveLanes}
+          mustPickReplacement={swapState.mustPickReplacement}
+          canRetire={swapState.canRetire}
+          onSwap={async (outLaneId, inLaneId) => {
+            // A retire is not a swap to `undefined`.
+            if (inLaneId) await onSwapLane(outLaneId, inLaneId)
+            else await onSwapLane(outLaneId)
+            setOpen(false)
+          }}
+          onCancel={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/LaneList.test.tsx
+++ b/src/components/LaneList.test.tsx
@@ -8,7 +8,17 @@ const LANES = [
   { id: '2', name: 'Swimming', emoji: '🏊', isActive: false, targetPerWeek: 2 },
 ]
 
-const actions = () => ({ updateLane: vi.fn(), setActive: vi.fn(), deleteLane: vi.fn() })
+const SWAP_OK = { mustPickReplacement: false, canRetire: true, blocked: false }
+const INACTIVE = [{ id: '2', name: 'Swimming', emoji: '🏊' }]
+
+const actions = () => ({
+  updateLane: vi.fn(),
+  setActive: vi.fn(),
+  deleteLane: vi.fn(),
+  onSwapLane: vi.fn(),
+  swapState: SWAP_OK,
+  inactiveLanes: INACTIVE,
+})
 
 describe('LaneList', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -60,5 +70,36 @@ describe('LaneList', () => {
     await user.type(nameInput, 'Sprints')
     await user.click(screen.getByRole('button', { name: 'Save' }))
     expect(a.updateLane).toHaveBeenCalledWith('1', expect.objectContaining({ name: 'Sprints' }))
+  })
+
+  it('offers a swap on each lane when the season allows a change', () => {
+    render(<LaneList lanes={LANES} {...actions()} />)
+
+    expect(screen.getByTestId('swap-btn-1')).toBeInTheDocument()
+  })
+
+  it('offers no swap when a change would break the three-lane floor', () => {
+    const a = actions()
+    render(
+      <LaneList
+        lanes={LANES}
+        {...a}
+        swapState={{ mustPickReplacement: false, canRetire: false, blocked: true }}
+      />
+    )
+
+    expect(screen.queryByTestId('swap-btn-1')).not.toBeInTheDocument()
+  })
+
+  it('confirming the modal swaps the lane and closes it', async () => {
+    const user = userEvent.setup()
+    const a = actions()
+    render(<LaneList lanes={LANES} {...a} />)
+
+    await user.click(screen.getByTestId('swap-btn-1'))
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    expect(a.onSwapLane).toHaveBeenCalledWith('1')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/src/components/LaneList.tsx
+++ b/src/components/LaneList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import ToggleSwitch from "@/components/ToggleSwitch"
 import ConfirmModal from "@/components/ConfirmModal"
+import LaneSwapModal from "@/components/LaneSwapModal"
 import { PencilIcon, TrashIcon } from "@/components/icons"
 
 interface Lane {
@@ -21,6 +22,9 @@ interface LaneListProps {
   ) => Promise<unknown>
   setActive: (id: string, isActive: boolean) => Promise<unknown>
   deleteLane: (id: string) => Promise<unknown>
+  onSwapLane: (outLaneId: string, inLaneId?: string) => Promise<unknown>
+  swapState: { mustPickReplacement: boolean; canRetire: boolean; blocked: boolean }
+  inactiveLanes: { id: string; name: string; emoji: string }[]
 }
 
 const EMOJI_OPTIONS: { cp: number; label: string }[] = [
@@ -37,10 +41,20 @@ const EMOJI_OPTIONS: { cp: number; label: string }[] = [
   { cp: 0x1f525, label: "Conditioning" },
 ]
 
-export default function LaneList({ lanes, updateLane, setActive, deleteLane }: LaneListProps) {
+export default function LaneList({
+  lanes,
+  updateLane,
+  setActive,
+  deleteLane,
+  onSwapLane,
+  swapState,
+  inactiveLanes,
+}: LaneListProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draft, setDraft] = useState({ name: "", emoji: "", targetPerWeek: 5 })
   const [confirmLane, setConfirmLane] = useState<Lane | null>(null)
+  // One modal shared by every row: `swapLane` is the lane being traded out.
+  const [swapLane, setSwapLane] = useState<Lane | null>(null)
 
   function startEdit(lane: Lane) {
     setEditingId(lane.id)
@@ -139,6 +153,16 @@ export default function LaneList({ lanes, updateLane, setActive, deleteLane }: L
                     onChange={(next) => setActive(lane.id, next)}
                     label={`Toggle ${lane.name}`}
                   />
+                  {!swapState.blocked && (
+                    <button
+                      data-testid={`swap-btn-${lane.id}`}
+                      aria-label={`Swap ${lane.name}`}
+                      onClick={() => setSwapLane(lane)}
+                      className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+                    >
+                      Swap
+                    </button>
+                  )}
                   <button
                     aria-label={`Edit ${lane.name}`}
                     onClick={() => startEdit(lane)}
@@ -171,6 +195,24 @@ export default function LaneList({ lanes, updateLane, setActive, deleteLane }: L
         }}
         onCancel={() => setConfirmLane(null)}
       />
+
+      {swapLane && (
+        <LaneSwapModal
+          open={true}
+          outLane={{ id: swapLane.id, name: swapLane.name, emoji: swapLane.emoji }}
+          inactiveLanes={inactiveLanes}
+          mustPickReplacement={swapState.mustPickReplacement}
+          canRetire={swapState.canRetire}
+          onSwap={async (outLaneId, inLaneId) => {
+            // A retire is not a swap to `undefined`: pass one argument so the
+            // action takes its retire path.
+            if (inLaneId) await onSwapLane(outLaneId, inLaneId)
+            else await onSwapLane(outLaneId)
+            setSwapLane(null)
+          }}
+          onCancel={() => setSwapLane(null)}
+        />
+      )}
     </>
   )
 }

--- a/src/components/LaneSwapModal.test.tsx
+++ b/src/components/LaneSwapModal.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import LaneSwapModal from './LaneSwapModal'
+
+describe('LaneSwapModal', () => {
+  const defaultProps = {
+    open: true,
+    outLane: { id: '1', name: 'Stick Skills', emoji: '🥍' },
+    inactiveLanes: [{ id: '2', name: 'Running', emoji: '🏃' }],
+    mustPickReplacement: false,
+    canRetire: true,
+    onSwap: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when closed', async () => {
+    render(<LaneSwapModal {...defaultProps} open={false} />)
+    const dialog = screen.queryByRole('dialog')
+    expect(dialog).toBeNull()
+  })
+
+  it('renders dialog heading when open', async () => {
+    render(<LaneSwapModal {...defaultProps} />)
+    expect(screen.getByRole('heading', { name: 'Trade out 🥍 Stick Skills' })).toBeInTheDocument()
+  })
+
+  it('cancel button calls onCancel', async () => {
+    const user = (await import('@testing-library/user-event')).default.setup()
+    render(<LaneSwapModal {...defaultProps} />)
+    const cancelButton = screen.getByTestId('cancel-swap')
+    await user.click(cancelButton)
+    expect(defaultProps.onCancel).toHaveBeenCalled()
+  })
+})

--- a/src/components/LaneSwapModal.test.tsx
+++ b/src/components/LaneSwapModal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import LaneSwapModal from './LaneSwapModal'
 
@@ -34,5 +35,31 @@ describe('LaneSwapModal', () => {
     const cancelButton = screen.getByTestId('cancel-swap')
     await user.click(cancelButton)
     expect(defaultProps.onCancel).toHaveBeenCalled()
+  })
+
+  it('disables confirm until a replacement is chosen', async () => {
+    render(<LaneSwapModal {...defaultProps} mustPickReplacement={true} canRetire={false} />)
+
+    expect(screen.getByTestId('confirm-swap')).toBeDisabled()
+  })
+
+  it('confirms a swap with the lane Eddie picked', async () => {
+    const user = userEvent.setup()
+    render(<LaneSwapModal {...defaultProps} mustPickReplacement={true} canRetire={false} />)
+
+    await user.selectOptions(screen.getByTestId('replacement-select'), '2')
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    expect(defaultProps.onSwap).toHaveBeenCalledWith('1', '2')
+  })
+
+  it('retires with no replacement when above the floor', async () => {
+    const user = userEvent.setup()
+    render(<LaneSwapModal {...defaultProps} mustPickReplacement={false} canRetire={true} />)
+
+    await user.click(screen.getByTestId('confirm-swap'))
+
+    // Exactly one argument: a retire is not a swap to `undefined`.
+    expect(defaultProps.onSwap).toHaveBeenCalledWith('1')
   })
 })

--- a/src/components/LaneSwapModal.tsx
+++ b/src/components/LaneSwapModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from 'react'
+import React, { useState, useTransition } from 'react'
 
 interface LaneInfo {
   id: string
@@ -27,16 +27,25 @@ export default function LaneSwapModal({
   onSwap,
   onCancel,
 }: LaneSwapModalProps) {
-  const [selectedInLaneId, setSelectedInLaneId] = useState<string | undefined>(undefined)
+  const [selectedInLaneId, setSelectedInLaneId] = useState('')
+  const [isPending, startTransition] = useTransition()
 
   if (!open) return null
 
-  const handleConfirm = async () => {
-    try {
-      await onSwap(outLane.id, selectedInLaneId)
-    } catch (err) {
-      console.error("Swap failed:", err)
-    }
+  const handleConfirm = () => {
+    startTransition(async () => {
+      try {
+        // A retire is not a swap to `undefined` — call with one argument so
+        // the action takes its retire path rather than the swap path.
+        if (selectedInLaneId) {
+          await onSwap(outLane.id, selectedInLaneId)
+        } else {
+          await onSwap(outLane.id)
+        }
+      } catch (err) {
+        console.error("Swap failed:", err)
+      }
+    })
   }
 
   return (
@@ -55,26 +64,26 @@ export default function LaneSwapModal({
             <p className="text-sm text-zinc-500">No inactive lanes available</p>
           ) : (
             <div className="space-y-2">
-              <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              <label
+                htmlFor="replacement-select"
+                className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
                 Select a replacement lane:
-              </p>
-              <div className="max-h-48 overflow-y-auto space-y-1">
+              </label>
+              <select
+                id="replacement-select"
+                data-testid="replacement-select"
+                value={selectedInLaneId}
+                onChange={(e) => setSelectedInLaneId(e.target.value)}
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
+              >
+                <option value="">Pick a replacement lane</option>
                 {inactiveLanes.map((lane) => (
-                  <button
-                    key={lane.id}
-                    type="button"
-                    onClick={() => setSelectedInLaneId(lane.id)}
-                    className={`w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
-                      selectedInLaneId === lane.id
-                        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'
-                        : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300'
-                    }`}
-                  >
-                    <span>{lane.emoji}</span>
-                    <span>{lane.name}</span>
-                  </button>
+                  <option key={lane.id} value={lane.id}>
+                    {lane.emoji} {lane.name}
+                  </option>
                 ))}
-              </div>
+              </select>
             </div>
           )}
 
@@ -86,7 +95,7 @@ export default function LaneSwapModal({
                 className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
                 onChange={(e) => {
                   if (e.target.checked) {
-                    setSelectedInLaneId(undefined)
+                    setSelectedInLaneId('')
                   }
                 }}
               />
@@ -108,8 +117,9 @@ export default function LaneSwapModal({
           </button>
           <button
             type="button"
+            data-testid="confirm-swap"
             onClick={handleConfirm}
-            disabled={!selectedInLaneId && mustPickReplacement}
+            disabled={isPending || (mustPickReplacement && !selectedInLaneId)}
             className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:pointer-events-none"
           >
             {mustPickReplacement ? 'Confirm Swap' : 'Retire Lane'}

--- a/src/components/LaneSwapModal.tsx
+++ b/src/components/LaneSwapModal.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import React, { useState } from 'react'
+
+interface LaneInfo {
+  id: string
+  name: string
+  emoji: string
+}
+
+interface LaneSwapModalProps {
+  open: boolean
+  outLane: LaneInfo
+  inactiveLanes: LaneInfo[]
+  mustPickReplacement: boolean
+  canRetire: boolean
+  onSwap: (outLaneId: string, inLaneId?: string) => Promise<void>
+  onCancel: () => void
+}
+
+export default function LaneSwapModal({
+  open,
+  outLane,
+  inactiveLanes,
+  mustPickReplacement,
+  canRetire,
+  onSwap,
+  onCancel,
+}: LaneSwapModalProps) {
+  const [selectedInLaneId, setSelectedInLaneId] = useState<string | undefined>(undefined)
+
+  if (!open) return null
+
+  const handleConfirm = async () => {
+    try {
+      await onSwap(outLane.id, selectedInLaneId)
+    } catch (err) {
+      console.error("Swap failed:", err)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="w-full max-w-md overflow-hidden rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900">
+        <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
+          Trade out {outLane.emoji} {outLane.name}
+        </h2>
+
+        <div className="mt-6 space-y-4">
+          {mustPickReplacement && inactiveLanes.length === 0 ? (
+            <p className="text-sm text-zinc-500">No inactive lanes available</p>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Select a replacement lane:
+              </p>
+              <div className="max-h-48 overflow-y-auto space-y-1">
+                {inactiveLanes.map((lane) => (
+                  <button
+                    key={lane.id}
+                    type="button"
+                    onClick={() => setSelectedInLaneId(lane.id)}
+                    className={`w-full flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                      selectedInLaneId === lane.id
+                        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'
+                        : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300'
+                    }`}
+                  >
+                    <span>{lane.emoji}</span>
+                    <span>{lane.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {canRetire && (
+            <div className="flex items-center gap-2 rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+              <input
+                type="checkbox"
+                id="retire-lane"
+                className="h-4 w-4 rounded border-zinc-300 text-emerald-600 focus:ring-emerald-500"
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setSelectedInLaneId(undefined)
+                  }
+                }}
+              />
+              <label htmlFor="retire-lane" className="text-sm text-zinc-600 dark:text-zinc-400">
+                Retire this lane instead
+              </label>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            data-testid="cancel-swap"
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!selectedInLaneId && mustPickReplacement}
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:pointer-events-none"
+          >
+            {mustPickReplacement ? 'Confirm Swap' : 'Retire Lane'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/validateSwap.test.ts
+++ b/src/lib/validateSwap.test.ts
@@ -26,4 +26,13 @@ describe('validateSwap', () => {
     const result = validateSwap(4)
     expect(result.canRetire).toBe(true)
   })
+
+  it('exactly three lanes must pick a replacement', () => {
+    const result = validateSwap(3)
+    expect(result).toEqual({
+      canRetire: false,
+      mustPickReplacement: true,
+      blocked: false
+    })
+  })
 })

--- a/src/lib/validateSwap.test.ts
+++ b/src/lib/validateSwap.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { validateSwap } from './validateSwap'
+
+describe('validateSwap', () => {
+  it('fewer than 3 lanes is blocked', () => {
+    const result = validateSwap(2)
+    expect(result).
+      toEqual({
+        canRetire: false,
+        mustPickReplacement: false,
+        blocked: true
+      })
+  })
+
+  it('more than 3 lanes can retire', () => {
+    const result = validateSwap(5)
+    expect(result).
+      toEqual({
+        canRetire: true,
+        mustPickReplacement: false,
+        blocked: false
+      })
+  })
+
+  it('4 lanes returns canRetire true', () => {
+    const result = validateSwap(4)
+    expect(result.canRetire).toBe(true)
+  })
+})

--- a/src/lib/validateSwap.ts
+++ b/src/lib/validateSwap.ts
@@ -1,0 +1,11 @@
+export const validateSwap = (activeLaneCount: number) => {
+  if (activeLaneCount < 3) {
+    return { canRetire: false, mustPickReplacement: false, blocked: true };
+  }
+
+  if (activeLaneCount > 3) {
+    return { canRetire: true, mustPickReplacement: false, blocked: false };
+  }
+
+  return { canRetire: false, mustPickReplacement: true, blocked: false };
+};

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
+import { swapSchema, laneSchema, checkInSchema, bossBattleSchema, reflectionSchema, prizeSchema } from './validation'
 
 describe('validation', () => {
   it('laneSchema valid input passes', () => {
@@ -123,4 +123,28 @@ describe('validation', () => {
       expect(result.data.reasons).toEqual([])
     }
   })
-}) 
+
+  describe('swapSchema', () => {
+    it('a missing outLaneId is rejected', () => {
+      const invalidData = { inLaneId: 'some-id' }
+      const result = swapSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+
+    it('a valid outLaneId with no inLaneId is accepted', () => {
+      const validData = { outLaneId: 'some-id' }
+      const result = swapSchema.safeParse(validData)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.outLaneId).toBe('some-id')
+        expect(result.data.inLaneId).toBeUndefined()
+      }
+    })
+
+    it('an outLaneId of empty string is rejected', () => {
+      const invalidData = { outLaneId: '', inLaneId: 'some-id' }
+      const result = swapSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -31,8 +31,14 @@ export const prizeSchema = z.object({
   photoUrl: z.string().url().optional().nullable(),
 })
 
+export const swapSchema = z.object({
+  outLaneId: z.string().min(1),
+  inLaneId: z.string().min(1).optional(),
+})
+
 export type LaneInput = z.infer<typeof laneSchema>
 export type CheckInInput = z.infer<typeof checkInSchema>
 export type BossBattleInput = z.infer<typeof bossBattleSchema>
 export type ReflectionInput = z.infer<typeof reflectionSchema>
 export type PrizeInput = z.infer<typeof prizeSchema>
+export type SwapInput = z.infer<typeof swapSchema>


### PR DESCRIPTION
16 commits. Eddie can change what he trains without paying for it.

## What Eddie gets

After he logs a boss battle on a lane, he's offered a **trade**. With more than three lanes he can simply retire one; at exactly three the only legal move is a straight swap — one out, one in, in a single transaction, so he's never briefly below the floor. The Lanes page offers the same thing per row.

Crucially, **none of it touches the weeks he's already earned.**

## The bug this epic was really about

The Prize grid queried `where: { isActive: true }` and recomputes all thirteen weeks against whatever survives. So retiring a lane erased the check-ins it had already earned, and weeks Eddie had *qualified* flipped to *missed*. Three lost weeks make the prize (11 of 13) unreachable — the feature built to stop him getting bored would have quietly ended his season the first time he used it.

The grid now counts every lane he has ever trained. TODAY still shows only active lanes: *what to do now* versus *what actually happened*. `deleteLane` is refused while a season runs, closing the other route to destroying that history.

## What shipped

- `validateSwap` — the three-lane floor as a pure decision
- `swapSchema`, and `swapLane` — validate, count, then retire or swap in one transaction
- `LaneSwapModal` — pick a replacement or retire; confirm disabled until valid
- `LaneList`, Lanes page, Boss Battles page — the wiring
- `BossBattleSwapTrigger` — the offer, at the moment a chapter ends
- The Prize-grid invariant fix, and the `deleteLane` guard

## Verification

`tsc` clean · `next build` clean · **199 tests green** · 0 lint errors · CI green on `390c731`.

Merge with a **merge commit, not squash** — squashing severs history between `develop` and `main` and makes the next release conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3