### PR TITLE
feat: tell Eddie how his season will unfold

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import CheckInCard from "@/components/CheckInCard"
 import { WeeklyProgress } from "@/components/WeeklyProgress"
 import SeasonStartButton from "@/components/SeasonStartButton"
 import SeasonSetupPanel from "@/components/SeasonSetupPanel"
+import SeasonTimelineNote from "@/components/SeasonTimelineNote"
 import { getSeasonReadiness } from "@/lib/seasonReadiness"
 
 export const dynamic = "force-dynamic"
@@ -36,6 +37,13 @@ export default async function DashboardPage() {
     <main className="max-w-2xl mx-auto space-y-6 p-6">
       <div className="space-y-4">
         <SeasonStartButton hasStarted={hasStarted} isReady={readiness.isReady} />
+        {/* Pressing START on a Friday commits Eddie to a season that begins
+            on Monday. Without this the button just turned red and nothing
+            else changed, which reads as "it didn't work". */}
+        <SeasonTimelineNote
+          seasonStart={prize?.seasonStart ?? null}
+          today={today}
+        />
         {!hasStarted && !readiness.isReady && (
           <SeasonSetupPanel 
             laneCount={activeLaneCount} 

--- a/src/components/SeasonTimelineNote.test.tsx
+++ b/src/components/SeasonTimelineNote.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import SeasonTimelineNote from './SeasonTimelineNote'
+
+const FRIDAY = new Date('2026-08-14T21:30:00.000Z')
+const MONDAY_START = new Date('2026-08-17T00:00:00.000Z')
+
+describe('SeasonTimelineNote', () => {
+  it('tells Eddie when his season would start, before he commits', () => {
+    render(<SeasonTimelineNote seasonStart={null} today={FRIDAY} />)
+
+    expect(screen.getByTestId('season-timeline')).toHaveTextContent(
+      /starts Mon 17 Aug 2026/i
+    )
+    expect(screen.getByTestId('season-timeline')).toHaveTextContent(/13 weeks/i)
+  })
+
+  it('explains the wait after he presses start on a Friday', () => {
+    // The whole point: the button went red but nothing else changed.
+    render(<SeasonTimelineNote seasonStart={MONDAY_START} today={FRIDAY} />)
+
+    const note = screen.getByTestId('season-timeline')
+    expect(note).toHaveTextContent(/locked in/i)
+    expect(note).toHaveTextContent(/Mon 17 Aug 2026/)
+    expect(note).toHaveTextContent(/check-ins before then build your streak/i)
+  })
+
+  it('counts the week once the season is running', () => {
+    render(
+      <SeasonTimelineNote
+        seasonStart={MONDAY_START}
+        today={new Date('2026-08-31T12:00:00.000Z')}
+      />
+    )
+
+    expect(screen.getByTestId('season-timeline')).toHaveTextContent(/Week 3 of 13/i)
+  })
+
+  it('says so when the season is over', () => {
+    render(
+      <SeasonTimelineNote
+        seasonStart={MONDAY_START}
+        today={new Date('2026-11-17T00:00:00.000Z')}
+      />
+    )
+
+    expect(screen.getByTestId('season-timeline')).toHaveTextContent(/season is over/i)
+  })
+})

--- a/src/components/SeasonTimelineNote.tsx
+++ b/src/components/SeasonTimelineNote.tsx
@@ -1,0 +1,61 @@
+import { describeSeason } from "@/lib/seasonTimeline"
+import { formatWeekLabel } from "@/lib/weekUtils"
+import { SEASON_WEEKS, WEEKS_REQUIRED, LANES_REQUIRED } from "@/lib/season"
+
+/**
+ * What is about to happen, said plainly.
+ *
+ * A season always begins on a Monday, so pressing START on a Friday commits
+ * Eddie to a season that begins three days later. Before this existed the
+ * button simply turned red and every other pixel stayed the same — the honest
+ * reading was that it hadn't worked, and the next move was to press RESET.
+ */
+export default function SeasonTimelineNote({
+  seasonStart,
+  today,
+}: {
+  seasonStart: Date | null
+  today: Date
+}) {
+  const season = describeSeason(seasonStart, today)
+  const starts = formatWeekLabel(season.startsOn)
+  const ends = formatWeekLabel(season.lastDay)
+
+  const body = (() => {
+    switch (season.phase) {
+      case "not-started":
+        return (
+          <>
+            Your season starts {starts} and runs {SEASON_WEEKS} weeks, to {ends}.
+            Seasons always begin on a Monday so week one is a full week.
+          </>
+        )
+      case "scheduled":
+        return (
+          <>
+            Locked in — your season starts {starts}. Check-ins before then build
+            your streak, but the {SEASON_WEEKS} weeks are counted from {starts}.
+          </>
+        )
+      case "running":
+        return (
+          <>
+            Week {season.weekNumber} of {SEASON_WEEKS}. A week counts when at
+            least {LANES_REQUIRED} lanes hit their target, and {WEEKS_REQUIRED}{" "}
+            counting weeks wins the prize. Season ends {ends}.
+          </>
+        )
+      case "ended":
+        return <>Your season is over — it ran {starts} to {ends}.</>
+    }
+  })()
+
+  return (
+    <p
+      data-testid="season-timeline"
+      className="rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-400"
+    >
+      {body}
+    </p>
+  )
+}

--- a/src/lib/seasonTimeline.test.ts
+++ b/src/lib/seasonTimeline.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { describeSeason } from './seasonTimeline'
+
+const FRIDAY = new Date('2026-08-14T21:30:00.000Z')
+const MONDAY = new Date('2026-08-17T08:00:00.000Z')
+
+describe('describeSeason', () => {
+  it('tells Eddie when a season WOULD start before he commits', () => {
+    // Friday night, nothing pressed yet.
+    const s = describeSeason(null, FRIDAY)
+
+    expect(s.phase).toBe('not-started')
+    expect(s.startsOn.toDateString()).toBe('Mon Aug 17 2026')
+    expect(s.endsOn.toDateString()).toBe('Mon Nov 16 2026')
+  })
+
+  it('says the season is scheduled once he presses, before it begins', () => {
+    // The gap that makes START feel broken: pressed on Friday, begins Monday.
+    const s = describeSeason(new Date('2026-08-17T00:00:00.000Z'), FRIDAY)
+
+    expect(s.phase).toBe('scheduled')
+    expect(s.startsOn.toDateString()).toBe('Mon Aug 17 2026')
+    expect(s.weekNumber).toBeNull()
+  })
+
+  it('counts the week once the season is running', () => {
+    const s = describeSeason(new Date('2026-08-17T00:00:00.000Z'), MONDAY)
+
+    expect(s.phase).toBe('running')
+    expect(s.weekNumber).toBe(1)
+  })
+
+  it('counts a later week correctly', () => {
+    const week3 = new Date('2026-08-31T12:00:00.000Z')
+    expect(describeSeason(new Date('2026-08-17T00:00:00.000Z'), week3).weekNumber).toBe(3)
+  })
+
+  it('knows when the season is over', () => {
+    const after = new Date('2026-11-17T00:00:00.000Z')
+    const s = describeSeason(new Date('2026-08-17T00:00:00.000Z'), after)
+
+    expect(s.phase).toBe('ended')
+    expect(s.weekNumber).toBeNull()
+  })
+
+  it('reports the last day of the final week, not the day it rolls over', () => {
+    const s = describeSeason(null, FRIDAY)
+    // 13 weeks from Mon 17 Aug: the season is done at the end of Sun 15 Nov.
+    expect(s.lastDay.toDateString()).toBe('Sun Nov 15 2026')
+  })
+})

--- a/src/lib/seasonTimeline.ts
+++ b/src/lib/seasonTimeline.ts
@@ -1,0 +1,55 @@
+import { SEASON_WEEKS } from "@/lib/season"
+import { getSeasonWeeksFrom } from "@/lib/seasonWindow"
+import { resolveSeasonStart } from "@/lib/seasonAnchor"
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export type SeasonPhase = "not-started" | "scheduled" | "running" | "ended"
+
+export interface SeasonTimeline {
+  phase: SeasonPhase
+  /** UTC midnight Monday the season begins, or would begin. */
+  startsOn: Date
+  /** Exclusive end: the Monday after the thirteenth week. */
+  endsOn: Date
+  /** The last day Eddie can train in this season — inclusive, for display. */
+  lastDay: Date
+  /** 1..SEASON_WEEKS while running, null otherwise. */
+  weekNumber: number | null
+}
+
+/**
+ * What is about to happen, in terms Eddie can act on.
+ *
+ * A season always begins on a Monday, so pressing START on a Friday commits
+ * him to a season that begins three days later. Nothing in the UI said so:
+ * the button turned red, the grid stayed identical, and no screen showed a
+ * date — so the honest reading was "it didn't work".
+ *
+ * The Monday anchor is right. A Friday start would make week 1 a three-day
+ * week against a five-a-week target, and he would burn one of his two allowed
+ * misses on a week he never had a chance at. It just has to be visible.
+ */
+export function describeSeason(
+  seasonStart: Date | null,
+  today: Date
+): SeasonTimeline {
+  const startsOn = seasonStart ?? resolveSeasonStart(today)
+  const weeks = getSeasonWeeksFrom(startsOn)
+  const endsOn = new Date(weeks[SEASON_WEEKS - 1].getTime() + 7 * MS_PER_DAY)
+  const lastDay = new Date(endsOn.getTime() - MS_PER_DAY)
+
+  if (seasonStart === null) {
+    return { phase: "not-started", startsOn, endsOn, lastDay, weekNumber: null }
+  }
+  if (today.getTime() < startsOn.getTime()) {
+    return { phase: "scheduled", startsOn, endsOn, lastDay, weekNumber: null }
+  }
+  if (today.getTime() >= endsOn.getTime()) {
+    return { phase: "ended", startsOn, endsOn, lastDay, weekNumber: null }
+  }
+
+  const elapsed = today.getTime() - startsOn.getTime()
+  const weekNumber = Math.floor(elapsed / (7 * MS_PER_DAY)) + 1
+  return { phase: "running", startsOn, endsOn, lastDay, weekNumber }
+}


### PR DESCRIPTION
## The question that found this

*"It's Friday — if Eddie sets up tonight, does his lane begin today, tomorrow or Monday?"*

**Monday.** `resolveSeasonStart` anchors to the Monday on or after the press, so START on Fri 14 Aug schedules a season beginning Mon 17 Aug.

That anchor is **right**: a Friday start would make week one a three-day week against a five-a-week target, and Eddie would burn one of his two allowed misses on a week he never had a chance at.

## The problem

`hasStarted` is `Boolean(prize.seasonStart)` — true the instant he presses. So the big green button turns red and **every other pixel stays the same**: the grid still shows thirteen `upcoming` weeks, and no screen anywhere displays the date. No component referenced `seasonStart` at all.

The honest reading is *"it didn't work"*, and the next move is RESET — which he can press freely. He could bounce off the feature on his first night.

## What it says now

| phase | copy |
|---|---|
| before | *Your season starts Mon 17 Aug 2026 and runs 13 weeks, to Sun 15 Nov 2026. Seasons always begin on a Monday so week one is a full week.* |
| scheduled | *Locked in — your season starts Mon 17 Aug 2026. Check-ins before then build your streak, but the 13 weeks are counted from Mon 17 Aug 2026.* |
| running | *Week 3 of 13. A week counts when at least 3 lanes hit their target, and 11 counting weeks wins the prize. Season ends Sun 15 Nov 2026.* |
| ended | *Your season is over — it ran … to …* |

That second line also closes a **silent** gap: weekend check-ins do build his streak but don't count toward the season, because the Prize query windows on `gte: seasonStart`. True before this change, and invisible.

## Notes

`describeSeason` holds the phase logic as a pure function, so all four states are tested directly and the component only chooses words.

`lastDay` is the inclusive final day (**Sun 15 Nov**), not the exclusive rollover Monday — showing 16 Nov would promise Eddie a day that isn't in his season.

Red-green throughout · 209 tests · `tsc` clean · `next build` clean · 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3