### PR TITLE
fix: restore three tests a TDD story silently deleted

### DIFF
--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import { formatWeekLabel } from '@/lib/weekUtils'
 import { SEASON_WEEKS } from '@/lib/season'
 import PrizePage from './page'
@@ -24,9 +24,60 @@ const PRIZE = {
   updatedAt: new Date(0),
 }
 
-describe('Page', () => {
+describe('PrizePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([] as never)
+  })
+
+  it('titles the first week cell from the stored season start', async () => {
+    // An arbitrary Monday: the grid must follow the stored date, which is
+    // now the only source of truth for when the season began.
+    const started = new Date('2026-09-07T00:00:00.000Z')
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: started,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells[0].getAttribute('title')).toBe(formatWeekLabel(started))
+  })
+
+  it('marks every week upcoming before the season starts', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: null,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells.map((c) => c.getAttribute('data-status'))).toEqual(
+      Array(SEASON_WEEKS).fill('upcoming')
+    )
+  })
+
+  it('does not exclude retired lanes from the season grid', async () => {
+    // The grid answers "what happened this season". A lane Eddie retired
+    // still earned its check-ins, so filtering the query by isActive would
+    // erase them from weeks he already qualified.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: new Date('2026-09-07T00:00:00.000Z'),
+    } as never)
+
+    render(await PrizePage())
+
+    // `where` may be absent entirely once the filter is gone — both that
+    // and a where-clause without isActive are correct.
+    const where = vi.mocked(prisma.lane.findMany).mock.calls[0][0]?.where as
+      | { isActive?: boolean }
+      | undefined
+    expect(where?.isActive).toBeUndefined()
   })
 
   it('the timeline note renders above the season grid', async () => {


### PR DESCRIPTION
Story #262 replaced `page.test.tsx` wholesale with only the two cases its own story declared. Three pre-existing tests went with it:

- `titles the first week cell from the stored season start`
- `marks every week upcoming before the season starts`
- **`does not exclude retired lanes from the season grid`**

That third one is the guard on the invariant the entire lane-swap epic turned on: retiring a lane must not erase the check-ins it earned, or weeks Eddie already qualified flip to missed and the prize becomes unreachable. It has been absent from `main` since #264 shipped.

All five tests now pass together. The restored invariant test was verified to still **bite**: reintroduce `where: { isActive: true }` on the lane query and it fails immediately.

### Why this happened

Stage B builds its scaffold from the story's `**Testing:**` bullets and enforces it byte-for-byte, so a story on an existing test file can replace prior coverage with its own cases. It is not universal — #260 was additive on `LaneList.test.tsx` (8 tests → 10) while #262 was destructive here (3 → 2) — which is what makes it dangerous: it looks fine most of the time, the suite stays green, and the loss is invisible unless you diff the test count.

The systemic fix is next. This PR restores the coverage first, because it protects live behaviour and shouldn't wait on the mechanism.

210 tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3