### PR TITLE
fix: restore three more tests a story silently deleted

### DIFF
--- a/src/app/actions/deleteLane.test.ts
+++ b/src/app/actions/deleteLane.test.ts
@@ -63,4 +63,31 @@ describe('deleteLane', () => {
     expect(revalidatePath).toHaveBeenCalledWith('/lanes')
     expect(revalidatePath).toHaveBeenCalledWith('/')
   })
+
+  it('deletes the lane and its children in a transaction, returns ok', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null as never)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+
+    const result = await deleteLane('lane-1')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.$transaction).toHaveBeenCalledOnce()
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('empty id returns missing-id without a db call', async () => {
+    const result = await deleteLane('')
+
+    expect(result).toEqual({ ok: false, error: 'missing-id' })
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('db error returns not-found', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null as never)
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('nope'))
+
+    const result = await deleteLane('lane-1')
+
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+  })
 })


### PR DESCRIPTION
Found by sweeping **all 33 commits** of this campaign through the new coverage guard, rather than by noticing another diff.

Story #246 (`deleteLane` refuses while a season is running) kept only its own two cases and deleted three:

- `deletes the lane and its children in a transaction, returns ok` — the cascade removing check-ins, boss battles and freezes
- `empty id returns missing-id without a db call` — the input guard
- `db error returns not-found` — error handling

The cascade one matters most: `deleteLane` is the most destructive action in the app, and the test proving it removes children **in one transaction** was gone.

All five pass together. The restored guard was verified to still bite — remove the `missing-id` check and it fails.

### What the sweep found

| commit | file | before → after | verdict |
|---|---|---|---|
| #262 | `page.test.tsx` | 3 → 2 | regression (fixed in #265) |
| **#246** | `deleteLane.test.ts` | 3 → 2 | **regression — this PR** |
| `2a2e908` | `seasonProgress.test.ts` | 3 → 2 | intentional (mine) |
| `2a2e908` | `weekStatuses.test.ts` | 3 → 2 | intentional (mine) |

The two intentional ones removed tests for scaffolding defaults deleted in the same commit. The guard would have flagged them and a human would have waved them through — the right shape for a check like this.

**Two genuine regressions in one campaign**, both shipped green, neither visible in any summary. That is the argument for the guard being deterministic rather than advisory.

216 tests green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3