### PR TITLE
release: restore six tests that stories silently deleted

### DIFF
--- a/src/app/actions/deleteLane.test.ts
+++ b/src/app/actions/deleteLane.test.ts
@@ -63,4 +63,31 @@ describe('deleteLane', () => {
     expect(revalidatePath).toHaveBeenCalledWith('/lanes')
     expect(revalidatePath).toHaveBeenCalledWith('/')
   })
+
+  it('deletes the lane and its children in a transaction, returns ok', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null as never)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+
+    const result = await deleteLane('lane-1')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.$transaction).toHaveBeenCalledOnce()
+    expect(revalidatePath).toHaveBeenCalledWith('/lanes')
+  })
+
+  it('empty id returns missing-id without a db call', async () => {
+    const result = await deleteLane('')
+
+    expect(result).toEqual({ ok: false, error: 'missing-id' })
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+
+  it('db error returns not-found', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null as never)
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('nope'))
+
+    const result = await deleteLane('lane-1')
+
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+  })
 })

--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import { formatWeekLabel } from '@/lib/weekUtils'
 import { SEASON_WEEKS } from '@/lib/season'
 import PrizePage from './page'
@@ -24,9 +24,60 @@ const PRIZE = {
   updatedAt: new Date(0),
 }
 
-describe('Page', () => {
+describe('PrizePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([] as never)
+  })
+
+  it('titles the first week cell from the stored season start', async () => {
+    // An arbitrary Monday: the grid must follow the stored date, which is
+    // now the only source of truth for when the season began.
+    const started = new Date('2026-09-07T00:00:00.000Z')
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: started,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells[0].getAttribute('title')).toBe(formatWeekLabel(started))
+  })
+
+  it('marks every week upcoming before the season starts', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: null,
+    } as never)
+
+    render(await PrizePage())
+
+    const cells = screen.getAllByTestId('season-week')
+    expect(cells).toHaveLength(SEASON_WEEKS)
+    expect(cells.map((c) => c.getAttribute('data-status'))).toEqual(
+      Array(SEASON_WEEKS).fill('upcoming')
+    )
+  })
+
+  it('does not exclude retired lanes from the season grid', async () => {
+    // The grid answers "what happened this season". A lane Eddie retired
+    // still earned its check-ins, so filtering the query by isActive would
+    // erase them from weeks he already qualified.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      ...PRIZE,
+      seasonStart: new Date('2026-09-07T00:00:00.000Z'),
+    } as never)
+
+    render(await PrizePage())
+
+    // `where` may be absent entirely once the filter is gone — both that
+    // and a where-clause without isActive are correct.
+    const where = vi.mocked(prisma.lane.findMany).mock.calls[0][0]?.where as
+      | { isActive?: boolean }
+      | undefined
+    expect(where?.isActive).toBeUndefined()
   })
 
   it('the timeline note renders above the season grid', async () => {


### PR DESCRIPTION
`main` is currently missing six tests that protect live behaviour. Two stories in this campaign replaced their test files with only their own cases.

**#262** took three from `page.test.tsx`, including `does not exclude retired lanes from the season grid` — the guard on the invariant the entire lane-swap epic turned on: retiring a lane must not erase the check-ins it earned, or weeks Eddie already qualified flip to missed.

**#246** took three from `deleteLane.test.ts`, including `deletes the lane and its children in a transaction` — `deleteLane` is the most destructive action in the app, and the proof that it removes check-ins, boss battles and freezes atomically was gone.

Both sets are restored and both were verified to still **bite**: reintroduce `where: { isActive: true }` on the lane query, or remove the `missing-id` guard, and the relevant test fails.

Found by sweeping all 33 commits of the campaign through a new deterministic check, not by reading diffs. Both regressions had shipped green — passing suite, passing CI, clean-looking PRs. A test file that quietly got smaller leaves no trace in any summary.

`tsc` clean · `next build` clean · **216 tests** · 0 lint errors · CI green on `09c9b1f`.

Merge with a **merge commit, not squash**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3