### PR TITLE
feat(#269): SeasonStartButton renders nothing after start (restored)

### DIFF
--- a/src/components/SeasonResetButton.test.tsx
+++ b/src/components/SeasonResetButton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SeasonResetButton from './SeasonResetButton'
+import { resetSeason } from '@/app/actions/resetSeason'
+
+vi.mock('@/app/actions/resetSeason', () => ({ 
+  resetSeason: vi.fn() 
+}))
+
+describe('SeasonResetButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resetSeason).mockResolvedValue(undefined)
+  })
+
+  it('the modal is closed until asked for', async () => {
+    render(<SeasonResetButton />)
+    expect(screen.queryByTestId('season-reset-modal')).toBeNull()
+    expect(resetSeason).not.toHaveBeenCalled()
+  })
+
+  it('cancel keeps the season', async () => {
+    const user = userEvent.setup()
+    render(<SeasonResetButton />)
+    await user.click(screen.getByTestId('season-reset-open'))
+    await user.click(screen.getByTestId('season-reset-cancel'))
+    expect(resetSeason).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('season-reset-modal')).toBeNull()
+  })
+
+  it('confirm resets exactly once', async () => {
+    const user = userEvent.setup()
+    render(<SeasonResetButton />)
+    await user.click(screen.getByTestId('season-reset-open'))
+    await user.click(screen.getByTestId('season-reset-confirm'))
+    expect(resetSeason).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/SeasonResetButton.tsx
+++ b/src/components/SeasonResetButton.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { resetSeason } from '@/app/actions/resetSeason'
+
+export default function SeasonResetButton() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isPending, setIsPending] = useState(false)
+
+  const handleConfirm = async () => {
+    setIsPending(true)
+    try {
+      await resetSeason()
+      setIsOpen(false)
+    } catch (err) {
+      // Error handling as per project rules
+      console.error(err instanceof Error ? err.message : 'Failed to reset season')
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const handleCancel = () => {
+    setIsOpen(false)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="season-reset-open"
+        onClick={() => setIsOpen(true)}
+        className="text-sm text-zinc-500 underline-offset-2 hover:underline"
+      >
+        Reset my season
+      </button>
+
+      {isOpen && (
+        <div
+          data-testid="season-reset-modal"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+        >
+          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+            <h2 className="text-xl font-bold text-zinc-900">
+              Reset your season?
+            </h2>
+            <p className="mt-2 text-sm text-zinc-600">
+              This clears your season start date. Your check-ins and streaks are kept. The 13-week grid starts over when you press START again.
+            </p>
+
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                data-testid="season-reset-cancel"
+                onClick={handleCancel}
+                className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
+              >
+                Keep my season
+              </button>
+              <button
+                type="button"
+                data-testid="season-reset-confirm"
+                onClick={handleConfirm}
+                disabled={isPending}
+                className="rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+              >
+                {isPending ? 'Resetting...' : 'Yes, reset'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/SeasonStartButton.test.tsx
+++ b/src/components/SeasonStartButton.test.tsx
@@ -35,13 +35,10 @@ describe('SeasonStartButton', () => {
     expect(startSeason).toHaveBeenCalled()
   })
 
-  it('started renders the reset button and calls resetSeason when clicked', async () => {
-    const user = userEvent.setup()
+  it('renders nothing once the season has started', () => {
+    // Reset moved to the bottom of the page behind a confirmation modal
+    // (SeasonResetButton) — a started season renders nothing up here.
     render(<SeasonStartButton hasStarted={true} isReady={true} />)
-    const button = screen.getByTestId('season-reset')
-    expect(button).toBeInTheDocument()
-    expect(button).toHaveClass('bg-red-600')
-    await user.click(button)
-    expect(resetSeason).toHaveBeenCalled()
+    expect(screen.queryByTestId('season-reset')).toBeNull()
   })
 })

--- a/src/components/SeasonStartButton.tsx
+++ b/src/components/SeasonStartButton.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { startSeason } from '@/app/actions/startSeason'
-import { resetSeason } from '@/app/actions/resetSeason'
 
 interface SeasonStartButtonProps {
   hasStarted: boolean
@@ -24,18 +23,6 @@ export default function SeasonStartButton({ hasStarted, isReady }: SeasonStartBu
     }
   }
 
-  const handleReset = async () => {
-    setPending(true)
-    try {
-      await resetSeason()
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to reset season'
-      console.error(msg)
-    } finally {
-      setPending(false)
-    }
-  }
-
   if (!hasStarted) {
     return (
       <button
@@ -50,15 +37,7 @@ export default function SeasonStartButton({ hasStarted, isReady }: SeasonStartBu
     )
   }
 
-  return (
-    <button
-      type="button"
-      data-testid="season-reset"
-      disabled={pending}
-      onClick={handleReset}
-      className="w-full rounded-lg py-4 text-xl font-bold text-white bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
-    >
-      {pending ? 'Resetting...' : 'Reset my season'}
-    </button>
-  )
+  // Reset lives at the BOTTOM of the page behind a confirmation modal
+  // (SeasonResetButton) — a started season renders nothing up here.
+  return null
 }

--- a/src/lib/seasonTimeline.test.ts
+++ b/src/lib/seasonTimeline.test.ts
@@ -10,8 +10,8 @@ describe('describeSeason', () => {
     const s = describeSeason(null, FRIDAY)
 
     expect(s.phase).toBe('not-started')
-    expect(s.startsOn.toDateString()).toBe('Mon Aug 17 2026')
-    expect(s.endsOn.toDateString()).toBe('Mon Nov 16 2026')
+    expect(s.startsOn.toISOString()).toBe('2026-08-17T00:00:00.000Z')
+    expect(s.endsOn.toISOString()).toBe('2026-11-16T00:00:00.000Z')
   })
 
   it('says the season is scheduled once he presses, before it begins', () => {
@@ -19,7 +19,7 @@ describe('describeSeason', () => {
     const s = describeSeason(new Date('2026-08-17T00:00:00.000Z'), FRIDAY)
 
     expect(s.phase).toBe('scheduled')
-    expect(s.startsOn.toDateString()).toBe('Mon Aug 17 2026')
+    expect(s.startsOn.toISOString()).toBe('2026-08-17T00:00:00.000Z')
     expect(s.weekNumber).toBeNull()
   })
 
@@ -46,6 +46,6 @@ describe('describeSeason', () => {
   it('reports the last day of the final week, not the day it rolls over', () => {
     const s = describeSeason(null, FRIDAY)
     // 13 weeks from Mon 17 Aug: the season is done at the end of Sun 15 Nov.
-    expect(s.lastDay.toDateString()).toBe('Sun Nov 15 2026')
+    expect(s.lastDay.toISOString()).toBe('2026-11-15T00:00:00.000Z')
   })
 })


### PR DESCRIPTION
Restores #272, whose landed content was destroyed by an auto-close + branch-reset replay interaction (dispatcher done-detection skips CLOSED PRs). Spike fix incoming.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3