### PR TITLE
feat(#277): Story — History shows retired lanes, muted

### DIFF
--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Page from './page'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/font/google', () => new Proxy({}, {
+  get: () => () => ({ variable: 'mock-font-variable', className: 'mock-int' }),
+}))
+
+describe('Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('a retired lane with history renders muted with the tag', async () => {
+    const { prisma } = await import('@/lib/db')
+    const today = new Date()
+    const lanes = [
+      {
+        id: '1',
+        name: 'Active Lane',
+        emoji: '🚀',
+        isActive: true,
+        sortOrder: 1,
+        checkIns: [{ date: today, isRest: false } as any],
+      },
+      {
+        id: '2',
+        name: 'Retired Lane',
+        emoji: '💀',
+        isActive: false,
+        sortOrder: 2,
+        checkIns: [{ date: today, isRest: false } as any],
+      },
+    ] as any
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(lanes)
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText(/Active Lane/)).toBeInTheDocument()
+    expect(screen.getByText(/Retired Lane/)).toBeInTheDocument()
+    expect(screen.getByTestId('retired-tag')).toHaveTextContent('retired')
+  })
+
+  it('active lanes carry no tag', async () => {
+    const { prisma } = await import('@/lib/db')
+    const lanes = [
+      {
+        id: '1',
+        name: 'Active Lane',
+        emoji: '🚀',
+        isActive: true,
+        sortOrder: 1,
+        checkIns: [{ date: new Date(), isRest: false } as any],
+      },
+    ] as any
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(lanes)
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByTestId('retired-tag')).toBeNull()
+  })
+
+  it('an empty retired lane is skipped', async () => {
+    const { prisma } = await import('@/lib/db')
+    const lanes = [
+      {
+        id: '1',
+        name: 'Active Lane',
+        emoji: '🚀',
+        isActive: true,
+        sortOrder: 1,
+        checkIns: [{ date: new Date(), isRest: false } as any],
+      },
+      {
+        id: '2',
+        name: 'Empty Retired Lane',
+        emoji: '💀',
+        isActive: false,
+        sortOrder: 2,
+        checkIns: [],
+      },
+    ] as any
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(lanes)
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByText(/Empty Retired Lane/)).not.toBeInTheDocument()
+  })
+})

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -14,9 +14,11 @@ export default async function HistoryPage() {
   const today = getTrainingDay(new Date())
   const start = new Date(today.getTime() - 29 * DAY_MS)
 
-  const lanes = await prisma.lane.findMany({
-    where: { isActive: true },
-    orderBy: { sortOrder: "asc" },
+  const lanesRaw = await prisma.lane.findMany({
+    orderBy: [
+      { isActive: "desc" },
+      { sortOrder: "asc" },
+    ],
     include: {
       checkIns: {
         where: { date: { gte: start } },
@@ -24,6 +26,8 @@ export default async function HistoryPage() {
       },
     },
   })
+
+  const lanes = lanesRaw.filter((lane) => !( !lane.isActive && lane.checkIns.length === 0 ))
 
   const days = Array.from({ length: 30 }, (_, i) => new Date(start.getTime() + i * DAY_MS))
 
@@ -40,9 +44,17 @@ export default async function HistoryPage() {
           lane.checkIns.map((c) => [utcMidnight(c.date).getTime(), c])
         )
         return (
-          <section key={lane.id} className="space\nspace-y-2">
+          <section
+            key={lane.id}
+            className={`space-y-2 ${!lane.isActive ? "opacity-60" : ""}`}
+          >
             <h2 className="text-lg font-semibold">
               {lane.emoji} {lane.name} — {streak}🔥
+              {!lane.isActive && (
+                <span data-testid="retired-tag" className="ml-2 text-xs text-zinc-500">
+                  retired
+                </span>
+              )}
             </h2>
             <div className="grid grid-cols-10 gap-1">
               {days.map((d) => {


### PR DESCRIPTION
## Summary

Implements story #277: Story — History shows retired lanes, muted

## Verified gates (auto-captured by dag-poc)

- `smoke` exit 0
- `typecheck` exit 2
- `lint` exit 1

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 6
- Prompt tokens: 66658
- Output tokens: 20479

Closes #277

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-21T01:11:26Z)
- lint: ✓ exit 0 (run at 2026-08-21T01:11:20Z)
- test: ✓ exit 0 (run at 2026-08-21T01:11:22Z)
