### PR TITLE
Release: History as the permanent record

### DIFF
--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Page from './page'
+import { getWeekStart } from '@/lib/weekUtils'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
@@ -29,6 +30,7 @@ describe('Page', () => {
         emoji: '🚀',
         isActive: true,
         sortOrder: 1,
+        bossBattles: [],
         checkIns: [{ date: today, isRest: false } as any],
       },
       {
@@ -37,6 +39,7 @@ describe('Page', () => {
         emoji: '💀',
         isActive: false,
         sortOrder: 2,
+        bossBattles: [],
         checkIns: [{ date: today, isRest: false } as any],
       },
     ] as any
@@ -59,6 +62,7 @@ describe('Page', () => {
         emoji: '🚀',
         isActive: true,
         sortOrder: 1,
+        bossBattles: [],
         checkIns: [{ date: new Date(), isRest: false } as any],
       },
     ] as any
@@ -79,6 +83,7 @@ describe('Page', () => {
         emoji: '🚀',
         isActive: true,
         sortOrder: 1,
+        bossBattles: [],
         checkIns: [{ date: new Date(), isRest: false } as any],
       },
       {
@@ -87,6 +92,7 @@ describe('Page', () => {
         emoji: '💀',
         isActive: false,
         sortOrder: 2,
+        bossBattles: [],
         checkIns: [],
       },
     ] as any
@@ -96,5 +102,56 @@ describe('Page', () => {
     render(PageComponent)
 
     expect(screen.queryByText(/Empty Retired Lane/)).not.toBeInTheDocument()
+  })
+
+  it('a session inside a battle week is purple', async () => {
+    const { prisma } = await import('@/lib/db')
+    const day = new Date('2026-08-18T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, sortOrder: 0,
+        bossBattles: [{ weekStarting: getWeekStart(day) }],
+        checkIns: [{ date: day, isRest: false }],
+      },
+    ] as never)
+
+    const { container } = render(await Page())
+
+    expect(container.querySelectorAll('.bg-purple-500')).toHaveLength(1)
+    expect(container.querySelectorAll('.bg-green-400')).toHaveLength(0)
+  })
+
+  it('a rest day inside a battle week stays blue', async () => {
+    const { prisma } = await import('@/lib/db')
+    const day = new Date('2026-08-18T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, sortOrder: 0,
+        bossBattles: [{ weekStarting: getWeekStart(day) }],
+        checkIns: [{ date: day, isRest: true }],
+      },
+    ] as never)
+
+    const { container } = render(await Page())
+
+    expect(container.querySelectorAll('.bg-blue-300')).toHaveLength(1)
+    expect(container.querySelectorAll('.bg-purple-500')).toHaveLength(0)
+  })
+
+  it('no battles means no purple', async () => {
+    const { prisma } = await import('@/lib/db')
+    const day = new Date('2026-08-18T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, sortOrder: 0,
+        bossBattles: [],
+        checkIns: [{ date: day, isRest: false }],
+      },
+    ] as never)
+
+    const { container } = render(await Page())
+
+    expect(container.querySelectorAll('.bg-purple-500')).toHaveLength(0)
+    expect(container.querySelectorAll('.bg-green-400')).toHaveLength(1)
   })
 })

--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Page from './page'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/font/google', () => new Proxy({}, {
+  get: () => () => ({ variable: 'mock-font-variable', className: 'mock-int' }),
+}))
+
+describe('Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('a retired lane with history renders muted with the tag', async () => {
+    const { prisma } = await import('@/lib/db')
+    const today = new Date()
+    const lanes = [
+      {
+        id: '1',
+        name: 'Active Lane',
+        emoji: '🚀',
+        isActive: true,
+        sortOrder: 1,
+        checkIns: [{ date: today, isRest: false } as any],
+      },
+      {
+        id: '2',
+        name: 'Retired Lane',
+        emoji: '💀',
+        isActive: false,
+        sortOrder: 2,
+        checkIns: [{ date: today, isRest: false } as any],
+      },
+    ] as any
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(lanes)
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText(/Active Lane/)).toBeInTheDocument()
+    expect(screen.getByText(/Retired Lane/)).toBeInTheDocument()
+    expect(screen.getByTestId('retired-tag')).toHaveTextContent('retired')
+  })
+
+  it('active lanes carry no tag', async () => {
+    const { prisma } = await import('@/lib/db')
+    const lanes = [
+      {
+        id: '1',
+        name: 'Active Lane',
+        emoji: '🚀',
+        isActive: true,
+        sortOrder: 1,
+        checkIns: [{ date: new Date(), isRest: false } as any],
+      },
+    ] as any
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(lanes)
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByTestId('retired-tag')).toBeNull()
+  })
+
+  it('an empty retired lane is skipped', async () => {
+    const { prisma } = await import('@/lib/db')
+    const lanes = [
+      {
+        id: '1',
+        name: 'Active Lane',
+        emoji: '🚀',
+        isActive: true,
+        sortOrder: 1,
+        checkIns: [{ date: new Date(), isRest: false } as any],
+      },
+      {
+        id: '2',
+        name: 'Empty Retired Lane',
+        emoji: '💀',
+        isActive: false,
+        sortOrder: 2,
+        checkIns: [],
+      },
+    ] as any
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(lanes)
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByText(/Empty Retired Lane/)).not.toBeInTheDocument()
+  })
+})

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -14,9 +14,11 @@ export default async function HistoryPage() {
   const today = getTrainingDay(new Date())
   const start = new Date(today.getTime() - 29 * DAY_MS)
 
-  const lanes = await prisma.lane.findMany({
-    where: { isActive: true },
-    orderBy: { sortOrder: "asc" },
+  const lanesRaw = await prisma.lane.findMany({
+    orderBy: [
+      { isActive: "desc" },
+      { sortOrder: "asc" },
+    ],
     include: {
       checkIns: {
         where: { date: { gte: start } },
@@ -24,6 +26,8 @@ export default async function HistoryPage() {
       },
     },
   })
+
+  const lanes = lanesRaw.filter((lane) => !( !lane.isActive && lane.checkIns.length === 0 ))
 
   const days = Array.from({ length: 30 }, (_, i) => new Date(start.getTime() + i * DAY_MS))
 
@@ -40,9 +44,17 @@ export default async function HistoryPage() {
           lane.checkIns.map((c) => [utcMidnight(c.date).getTime(), c])
         )
         return (
-          <section key={lane.id} className="space\nspace-y-2">
+          <section
+            key={lane.id}
+            className={`space-y-2 ${!lane.isActive ? "opacity-60" : ""}`}
+          >
             <h2 className="text-lg font-semibold">
               {lane.emoji} {lane.name} — {streak}🔥
+              {!lane.isActive && (
+                <span data-testid="retired-tag" className="ml-2 text-xs text-zinc-500">
+                  retired
+                </span>
+              )}
             </h2>
             <div className="grid grid-cols-10 gap-1">
               {days.map((d) => {

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db"
 import { computeStreak } from "@/lib/streak"
 import { getTrainingDay } from "@/lib/trainingDay"
+import { getWeekStart } from "@/lib/weekUtils"
 
 export const dynamic = "force-dynamic"
 
@@ -20,6 +21,7 @@ export default async function HistoryPage() {
       { sortOrder: "asc" },
     ],
     include: {
+      bossBattles: true,
       checkIns: {
         where: { date: { gte: start } },
         orderBy: { date: "asc" },
@@ -34,7 +36,7 @@ export default async function HistoryPage() {
   return (
     <main className="max-w-3xl mx-auto space-y-8 p-6">
       <h1 className="text-2xl font-bold">History</h1>
-      <p className="mt-1 text-sm text-zinc-500">Your last 30 days at a glance — green for a session, blue for a rest day. Watch the consistency stack up.</p>
+      <p className="mt-1 text-sm text-zinc-500">Your last 30 days at a glance — green for a session, blue for a rest day, purple for a boss-battle week. Watch the consistency stack up.</p>
       {lanes.map((lane) => {
         const streak = computeStreak(
           lane.checkIns.map((c) => ({ date: c.date, isRest: c.isRest })),
@@ -42,6 +44,10 @@ export default async function HistoryPage() {
         )
         const byDay = new Map(
           lane.checkIns.map((c) => [utcMidnight(c.date).getTime(), c])
+        )
+        // A boss battle marks its whole week: session squares turn purple.
+        const battleWeeks = new Set(
+          lane.bossBattles.map((b) => b.weekStarting.getTime())
         )
         return (
           <section
@@ -62,7 +68,9 @@ export default async function HistoryPage() {
                 const cls = c
                   ? c.isRest
                     ? "bg-blue-300"
-                    : "bg-green-400"
+                    : battleWeeks.has(getWeekStart(d).getTime())
+                      ? "bg-purple-500"
+                      : "bg-green-400"
                   : "bg-zinc-800"
                 return (
                   <div


### PR DESCRIPTION
PR #281 — retired lanes stay visible (muted), boss-battle weeks render purple.

⚠️ Merge with a merge commit, never squash. Manual deploy follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3