### PR TITLE
feat(#283): boss battles unlock in the current week

### DIFF
--- a/src/app/boss-battles/page.test.tsx
+++ b/src/app/boss-battles/page.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Page from './page'
+import { prisma as db } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      findMany: vi.fn(),
+    },
+    checkIn: {
+      findMany: vi.fn(),
+    },
+    bossBattle: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+// next/font's loader only exists inside the Next build; under vitest
+// `Geist(...)` is not a function and the suite dies at module load.
+vi.mock('next/font/google', () => new Proxy({}, {
+  get: () => () => ({ variable: 'mock-font-variable', className: 'mock-font' }),
+}))
+
+describe('Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Persistent default: any call not overridden by a test's Once
+    // (i.e. the second, inactive-lanes call) resolves empty. A Once here
+    // would be consumed FIFO by the FIRST (active) call instead.
+    vi.mocked(db.lane.findMany).mockResolvedValue([])
+  })
+
+  it('a lane below target shows the unlock nudge', async () => {
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 5,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText((_, el) => el?.textContent === '3 / 5 days')).toBeInTheDocument()
+    expect(screen.getByTestId('battle-locked')).toHaveTextContent('Hit your target to unlock this week\'s boss.')
+    expect(screen.queryByText('✅ Target hit')).not.toBeInTheDocument()
+  })
+
+  it('a lane at target unlocks the battle', async () => {
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 5,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText((_, el) => el?.textContent === '5 / 5 days')).toBeInTheDocument()
+    expect(screen.getByText('✅ Target hit')).toBeInTheDocument()
+    expect(screen.queryByTestId('battle-locked')).not.toBeInTheDocument()
+  })
+
+  it('the header names the current week', async () => {
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 5,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/Boss Battles — week of/)
+  })
+})

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,5 +1,5 @@
 import { prisma as db } from "@/lib/db"
-import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
@@ -11,7 +11,6 @@ export const dynamic = "force-dynamic"
 
 export default async function BossBattlesPage() {
   const trainingDay = getTrainingDay(new Date())
-  const weekStart = getLastCompletedWeekStart(trainingDay)
   const thisWeekStart = getWeekStart(trainingDay)
 
   const lanes = await db.lane.findMany({
@@ -20,11 +19,11 @@ export default async function BossBattlesPage() {
     include: {
       checkIns: {
         where: {
-          date: { gte: weekStart, lt: thisWeekStart },
+          date: { gte: thisWeekStart },
         },
       },
       bossBattles: {
-        where: { weekStarting: weekStart },
+        where: { weekStarting: thisWeekStart },
       },
     },
   })
@@ -39,7 +38,7 @@ export default async function BossBattlesPage() {
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
       <h1 className="text-2xl font-bold">
-        Boss Battles — week of {formatWeekLabel(weekStart)}
+        Boss Battles — week of {formatWeekLabel(thisWeekStart)}
       </h1>
       <p className="mt-1 text-sm text-zinc-500">
         Finish a lane's weekly target and you unlock its boss battle — describe how the week went. The coach note is about your process, never a grade.
@@ -73,7 +72,7 @@ export default async function BossBattlesPage() {
                 <BossBattleForm
                   laneId={lane.id}
                   laneName={lane.name}
-                  weekStarting={weekStart}
+                  weekStarting={thisWeekStart}
                   existingReport={existing?.selfReport}
                   existingCoachNote={existing?.coachNote ?? undefined}
                   createBossBattle={async (data) => {
@@ -95,7 +94,9 @@ export default async function BossBattlesPage() {
                 )}
               </div>
             ) : (
-              <p className="text-zinc-500 text-sm">No battle this week — target missed.</p>
+              <p className="text-zinc-500 text-sm" data-testid="battle-locked">
+                Hit your target to unlock this week's boss.
+              </p>
             )}
           </section>
         )


### PR DESCRIPTION
Hand-finished from the grinder's wip residue (tdd-failed-green → typecheck truncation, then a FIFO once-queue mock bug in the test).

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3