### PR TITLE
Release: Boss Battles current-week unlock + last-week grace

### DIFF
--- a/src/app/boss-battles/page.test.tsx
+++ b/src/app/boss-battles/page.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Page from './page'
 import { prisma as db } from '@/lib/db'
+import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from '@/lib/weekUtils'
+import { getTrainingDay } from '@/lib/trainingDay'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
@@ -30,6 +32,87 @@ describe('Page', () => {
     // (i.e. the second, inactive-lanes call) resolves empty. A Once here
     // would be consumed FIFO by the FIRST (active) call instead.
     vi.mocked(db.lane.findMany).mockResolvedValue([])
+  })
+
+  it('an unfought last-week victory stays fightable', async () => {
+    const trainingDay = getTrainingDay(new Date())
+    const thisWeekStart = getWeekStart(trainingDay)
+    const lastWeekStart = getLastCompletedWeekStart(trainingDay)
+
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 2,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(lastWeekStart.getTime() + 86400000), laneId: 'l1', isRest: false },
+        { date: new Date(lastWeekStart.getTime() + 172800000), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText(`Last week's unfought boss — ${formatWeekLabel(lastWeekStart)}`)).toBeInTheDocument()
+    // the lane appears twice: its current-week card AND the grace section
+    expect(screen.getAllByText(/💪 Strength/)).toHaveLength(2)
+  })
+
+  it('a fought last week stays quiet', async () => {
+    const trainingDay = getTrainingDay(new Date())
+    const lastWeekStart = getLastCompletedWeekStart(trainingDay)
+
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 2,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(lastWeekStart.getTime() + 86400000), laneId: 'l1', isRest: false },
+        { date: new Date(lastWeekStart.getTime() + 172800000), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [{ weekStarting: lastWeekStart, selfReport: 'Done', coachNote: 'Good' }],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByText(/Last week's unfought boss/)).not.toBeInTheDocument()
+  }
+  )
+
+  it('a missed last week stays quiet', async () => {
+    const trainingDay = getTrainingDay(new Date())
+    const lastWeekStart = getLastCompletedWeekStart(trainingDay)
+
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 2,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(lastWeekStart.getTime() + 86400000), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByText(/Last week's unfought boss/)).not.toBeInTheDocument()
   })
 
   it('a lane below target shows the unlock nudge', async () => {
@@ -87,6 +170,8 @@ describe('Page', () => {
   })
 
   it('the header names the current week', async () => {
+    const trainingDay = getTrainingDay(new Date())
+    const thisWeekStart = getWeekStart(trainingDay)
     const lane = {
       id: 'l1',
       name: 'Strength',
@@ -103,6 +188,6 @@ describe('Page', () => {
     const PageComponent = await Page()
     render(PageComponent)
 
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/Boss Battles — week of/)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(`Boss Battles — week of ${formatWeekLabel(thisWeekStart)}`)
   })
 })

--- a/src/app/boss-battles/page.test.tsx
+++ b/src/app/boss-battles/page.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Page from './page'
+import { prisma as db } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      findMany: vi.fn(),
+    },
+    checkIn: {
+      findMany: vi.fn(),
+    },
+    bossBattle: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+// next/font's loader only exists inside the Next build; under vitest
+// `Geist(...)` is not a function and the suite dies at module load.
+vi.mock('next/font/google', () => new Proxy({}, {
+  get: () => () => ({ variable: 'mock-font-variable', className: 'mock-font' }),
+}))
+
+describe('Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Persistent default: any call not overridden by a test's Once
+    // (i.e. the second, inactive-lanes call) resolves empty. A Once here
+    // would be consumed FIFO by the FIRST (active) call instead.
+    vi.mocked(db.lane.findMany).mockResolvedValue([])
+  })
+
+  it('a lane below target shows the unlock nudge', async () => {
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 5,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText((_, el) => el?.textContent === '3 / 5 days')).toBeInTheDocument()
+    expect(screen.getByTestId('battle-locked')).toHaveTextContent('Hit your target to unlock this week\'s boss.')
+    expect(screen.queryByText('✅ Target hit')).not.toBeInTheDocument()
+  })
+
+  it('a lane at target unlocks the battle', async () => {
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 5,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+        { date: new Date(), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByText((_, el) => el?.textContent === '5 / 5 days')).toBeInTheDocument()
+    expect(screen.getByText('✅ Target hit')).toBeInTheDocument()
+    expect(screen.queryByTestId('battle-locked')).not.toBeInTheDocument()
+  })
+
+  it('the header names the current week', async () => {
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 5,
+      isActive: true,
+      sortOrder: 1,
+      checkIns: [],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/Boss Battles — week of/)
+  })
+})

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,5 +1,5 @@
 import { prisma as db } from "@/lib/db"
-import { getLastCompletedWeekStart, getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
@@ -11,7 +11,6 @@ export const dynamic = "force-dynamic"
 
 export default async function BossBattlesPage() {
   const trainingDay = getTrainingDay(new Date())
-  const weekStart = getLastCompletedWeekStart(trainingDay)
   const thisWeekStart = getWeekStart(trainingDay)
 
   const lanes = await db.lane.findMany({
@@ -20,11 +19,11 @@ export default async function BossBattlesPage() {
     include: {
       checkIns: {
         where: {
-          date: { gte: weekStart, lt: thisWeekStart },
+          date: { gte: thisWeekStart },
         },
       },
       bossBattles: {
-        where: { weekStarting: weekStart },
+        where: { weekStarting: thisWeekStart },
       },
     },
   })
@@ -39,7 +38,7 @@ export default async function BossBattlesPage() {
   return (
     <main className="max-w-2xl mx-auto space-y-8 p-6">
       <h1 className="text-2xl font-bold">
-        Boss Battles — week of {formatWeekLabel(weekStart)}
+        Boss Battles — week of {formatWeekLabel(thisWeekStart)}
       </h1>
       <p className="mt-1 text-sm text-zinc-500">
         Finish a lane's weekly target and you unlock its boss battle — describe how the week went. The coach note is about your process, never a grade.
@@ -73,7 +72,7 @@ export default async function BossBattlesPage() {
                 <BossBattleForm
                   laneId={lane.id}
                   laneName={lane.name}
-                  weekStarting={weekStart}
+                  weekStarting={thisWeekStart}
                   existingReport={existing?.selfReport}
                   existingCoachNote={existing?.coachNote ?? undefined}
                   createBossBattle={async (data) => {
@@ -95,7 +94,9 @@ export default async function BossBattlesPage() {
                 )}
               </div>
             ) : (
-              <p className="text-zinc-500 text-sm">No battle this week — target missed.</p>
+              <p className="text-zinc-500 text-sm" data-testid="battle-locked">
+                Hit your target to unlock this week's boss.
+              </p>
             )}
           </section>
         )

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -1,5 +1,5 @@
 import { prisma as db } from "@/lib/db"
-import { getWeekStart, formatWeekLabel } from "@/lib/weekUtils"
+import { getWeekStart, formatWeekLabel, getLastCompletedWeekStart } from "@/lib/weekUtils"
 import { getTrainingDay } from "@/lib/trainingDay"
 import { createBossBattle } from "@/app/actions/createBossBattle"
 import BossBattleForm from "@/components/BossBattleForm"
@@ -12,6 +12,7 @@ export const dynamic = "force-dynamic"
 export default async function BossBattlesPage() {
   const trainingDay = getTrainingDay(new Date())
   const thisWeekStart = getWeekStart(trainingDay)
+  const lastWeekStart = getLastCompletedWeekStart(trainingDay)
 
   const lanes = await db.lane.findMany({
     where: { isActive: true },
@@ -19,11 +20,13 @@ export default async function BossBattlesPage() {
     include: {
       checkIns: {
         where: {
-          date: { gte: thisWeekStart },
+          date: { gte: lastWeekStart },
         },
       },
       bossBattles: {
-        where: { weekStarting: thisWeekStart },
+        where: {
+          weekStarting: { in: [lastWeekStart, thisWeekStart] },
+        },
       },
     },
   })
@@ -49,9 +52,11 @@ export default async function BossBattlesPage() {
       )}
 
       {lanes.map((lane) => {
-        const hits = lane.checkIns.length
-        const hitTarget = hits >= lane.targetPerWeek
-        const existing = lane.bossBattles[0]
+        const currentHits = lane.checkIns.filter((c) => c.date >= thisWeekStart).length
+        const lastWeekHits = lane.checkIns.filter((c) => c.date >= lastWeekStart && c.date < thisWeekStart).length
+        const hitTarget = currentHits >= lane.targetPerWeek
+        const existing = lane.bossBattles.find((b) => b.weekStarting.getTime() === thisWeekStart.getTime())
+        const lastWeekBattle = lane.bossBattles.find((b) => b.weekStarting.getTime() === lastWeekStart.getTime())
 
         return (
           <section key={lane.id} className="space-y-3 rounded-lg border p-4">
@@ -60,7 +65,7 @@ export default async function BossBattlesPage() {
                 {lane.emoji} {lane.name}
               </h2>
               <span className="text-sm text-zinc-600">
-                {hits} / {lane.targetPerWeek} days
+                {currentHits} / {lane.targetPerWeek} days
               </span>
             </div>
 
@@ -76,7 +81,7 @@ export default async function BossBattlesPage() {
                   existingReport={existing?.selfReport}
                   existingCoachNote={existing?.coachNote ?? undefined}
                   createBossBattle={async (data) => {
-                      "use server"
+                    "use server"
                     const r = await createBossBattle(data)
                     return { coachNote: r.ok ? r.coachNote : undefined }
                   }}
@@ -101,6 +106,69 @@ export default async function BossBattlesPage() {
           </section>
         )
       })}
+
+      {lanes
+        .filter((lane) => {
+          const lastWeekHits = lane.checkIns.filter(
+            (c) => c.date >= lastWeekStart && c.date < thisWeekStart
+          ).length
+          const lastWeekBattle = lane.bossBattles.find(
+            (b) => b.weekStarting.getTime() === lastWeekStart.getTime()
+          )
+          return lastWeekHits >= lane.targetPerWeek && !lastWeekBattle
+        })
+        .map((lane) => (
+          <div key={lane.id} className="rounded-lg border p-4">
+            <div className="mb-3 font-medium">
+              {lane.emoji} {lane.name}
+            </div>
+            <BossBattleForm
+              laneId={lane.id}
+              laneName={lane.name}
+              weekStarting={lastWeekStart}
+              createBossBattle={async (data) => {
+                "use server"
+                const r = await createBossBattle(data)
+                return { coachNote: r.ok ? r.coachNote : undefined }
+              }}
+            />
+          </div>
+        )).length > 0 && (
+          <section className="space-y-4">
+            <h2 className="text-xl font-bold">
+              Last week's unfought boss — {formatWeekLabel(lastWeekStart)}
+            </h2>
+            <div className="grid gap-4">
+              {lanes
+                .filter((lane) => {
+                  const lastWeekHits = lane.checkIns.filter(
+                    (c) => c.date >= lastWeekStart && c.date < thisWeekStart
+                  ).length
+                  const lastWeekBattle = lane.bossBattles.find(
+                    (b) => b.weekStarting.getTime() === lastWeekStart.getTime()
+                  )
+                  return lastWeekHits >= lane.targetPerWeek && !lastWeekBattle
+                })
+                .map((lane) => (
+                  <div key={lane.id} className="rounded-lg border p-4">
+                    <div className="mb-3 font-medium">
+                      {lane.emoji} {lane.name}
+                    </div>
+                    <BossBattleForm
+                      laneId={lane.id}
+                      laneName={lane.name}
+                      weekStarting={lastWeekStart}
+                      createBossBattle={async (data) => {
+                        "use server"
+                        const r = await createBossBattle(data)
+                        return { coachNote: r.ok ? r.coachNote : undefined }
+                      }}
+                    />
+                  </div>
+                ))}
+            </div>
+          </section>
+        )}
     </main>
   )
 }


### PR DESCRIPTION
- Boss Battles page grades the current week, never a completed pre-season week (#283)
- Below-target lanes show the unlock nudge instead of a false 'target missed' (#283)
- A hit-but-unfought boss from last week stays fightable for one grace week (#284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3