### PR TITLE
feat(#289): weekRecap — pure season-recap aggregation

### DIFF
--- a/src/lib/weekRecap.test.ts
+++ b/src/lib/weekRecap.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { buildWeekRecaps, type RecapLaneInput } from './weekRecap'
+
+describe('weekRecap', () => {
+  it('groups check-ins into weeks newest first', () => {
+    const week1Start = new Date(Date.UTC(2024, 0, 1)); // Jan 1
+    const week2Start = new Date(Date.UTC(2024, 0, 8)); // Jan 8
+    
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+      checkIns: [
+        { date: new Date(Date.UTC(2024, 0, 2)), isRest: false },
+        { date: new Date(Date.UTC(2024, 0, 9)), isRest: false }
+      ],
+      bossBattles: []
+    }];
+
+    const result = buildWeekRecaps(input);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].weekStart.toISOString()).toBe(week2Start.toISOString());
+    expect(result[1].weekStart.toISOString()).toBe(week1Start.toISOString());
+  });
+
+  it('a lane with no check-ins that week is absent', () => {
+    const input: RecapLaneInput[] = [
+      {
+        id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+        checkIns: [{ date: new Date(Date.UTC(2024, 0, 1)), isRest: false }],
+        bossBattles: []
+      },
+      {
+        id: '2', name: 'L2', emoji: '💧', targetPerWeek: 5, isActive: true, sortOrder: 2,
+        checkIns: [],
+        bossBattles: []
+      }
+    ];
+
+    const result = buildWeekRecaps(input);
+    expect(result[0].lanes).toHaveLength(1);
+    expect(result[0].lanes[0].id).toBe('1');
+  });
+
+  it('a retired lane keeps its record', () => {
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: false, sortOrder: 1,
+      checkIns: [{ date: new Date(Date.UTC(2024, 0, 1)), isRest: false }],
+      bossBattles: []
+    }];
+
+    const result = buildWeekRecaps(input);
+    expect(result[0].lanes[0].isActive).toBe(false);
+    expect(result[0].lanes[0].hits).toBe(1);
+  });
+
+  it("battleFought marks only the battle's week", () => {
+    const week1Start = new Date(Date.UTC(2024, 0, 1));
+    const week2Start = new Date(Date.UTC(2024, 0, 8));
+
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+      // the battle's week must have check-ins — a week with none never renders
+      checkIns: [
+        { date: new Date(Date.UTC(2024, 0, 2)), isRest: false },
+        { date: new Date(Date.UTC(2024, 0, 9)), isRest: false }
+      ],
+      bossBattles: [{ weekStarting: week2Start }]
+    }];
+
+    const result = buildWeekRecaps(input);
+    
+    // Week 2 (Newest first)
+    const week2 = result.find(w => w.weekStart.toISOString() === week2Start.toISOString());
+    const week1 = result.find(w => w.weekStart.toISOString() === week1Start.toISOString());
+
+    expect(week2?.lanes[0].battleFought).toBe(true);
+    expect(week1?.lanes[0].battleFought).toBe(false);
+  });
+
+  it('hits count rest days and days stay chronological', () => {
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+      checkIns: [
+        { date: new Date(Date.UTC(2024, 0, 5)), isRest: false },
+        { date: new Date(Date.UTC(2024, 0, 2)), isRest: true },
+        { date: new Date(Date.UTC(2024, 0, 3)), isRest: false }
+      ],
+      bossBattles: []
+    }];
+
+    const result = buildWeekRecaps(input);
+    const laneWeek = result[0].lanes[0];
+
+    expect(laneWeek.hits).toBe(3);
+    expect(laneWeek.days).toHaveLength(3);
+    // Check chronological order
+    expect(laneWeek.days[0].date.getUTCDate()).toBe(2);
+    expect(laneWeek.days[1].date.getUTCDate()).toBe(3);
+    expect(laneWeek.days[2].date.getUTCDate()).toBe(5);
+    // Check rest day property
+    expect(laneWeek.days[0].isRest).toBe(true);
+    expect(laneWeek.days[1].isRest).toBe(false);
+  });
+});

--- a/src/lib/weekRecap.ts
+++ b/src/lib/weekRecap.ts
@@ -1,0 +1,121 @@
+import { getWeekStart } from "@/lib/weekUtils";
+
+export interface RecapLaneInput {
+  id: string;
+  name: string;
+  emoji: string;
+  targetPerWeek: number;
+  isActive: boolean;
+  sortOrder: number;
+  checkIns: { date: Date; isRest: boolean }[];
+  bossBattles: { weekStarting: Date }[];
+}
+
+export interface RecapDay {
+  date: Date;
+  isRest: boolean;
+}
+
+export interface RecapLaneWeek {
+  id: string;
+  name: string;
+  emoji: string;
+  isActive: boolean;
+  hits: number;
+  target: number;
+  battleFought: boolean;
+  days: RecapDay[];
+}
+
+export interface WeekRecap {
+  weekStart: Date;
+  lanes: RecapLaneWeek[];
+}
+
+export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
+  type LaneWeekInternal = Omit<RecapLaneWeek, "target" | "days"> & {
+    sortOrder: number;
+    hits: number;
+    days: RecapDay[];
+  };
+
+  const weekMap = new Map<string, { weekStart: Date; laneData: Map<string, LaneWeekInternal> }>();
+
+  // 1. Process all check-ins to identify weeks and populate lane data
+  for (const lane of lanes) {
+    for (const checkIn of lane.checkIns) {
+      const weekStart = getWeekStart(checkIn.date);
+      const weekKey = weekStart.toISOString();
+
+      if (!weekMap.has(weekKey)) {
+        weekMap.set(weekKey, { weekStart, laneData: new Map() });
+      }
+
+      const weekEntry = weekMap.get(weekKey)!;
+      if (!weekEntry.laneData.has(lane.id)) {
+        weekEntry.laneData.set(lane.id, {
+          id: lane.id,
+          name: lane.name,
+          emoji: lane.emoji,
+          isActive: lane.isActive,
+          hits: 0,
+          days: [],
+          battleFought: false,
+          sortOrder: lane.sortOrder
+        });
+      }
+
+      const laneWeek = weekEntry.laneData.get(lane.id)!;
+      laneWeek.hits += 1;
+      laneWeek.days.push({ date: checkIn.date, isRest: checkIn.isRest });
+    }
+  }
+
+  // 2. Process Boss Battles to mark battles fought in specific weeks
+  for (const lane of lanes) {
+    for (const battle of lane.bossBattles) {
+      const weekStart = getWeekStart(battle.weekStarting);
+      const weekKey = weekStart.toISOString();
+
+      if (weekMap.has(weekKey)) {
+        const weekEntry = weekMap.get(weekKey)!;
+        if (weekEntry.laneData.has(lane.id)) {
+          const laneWeek = weekEntry.laneData.get(lane.id)!;
+          laneWeek.battleFought = true;
+        }
+      }
+    }
+  }
+
+  // 3. Transform the map into the final WeekRecap[] structure
+  const recaps: WeekRecap[] = Array.from(weekMap.values())
+    .map((entry) => {
+      const lanesArray = Array.from(entry.laneData.values())
+        .map((ld) => ({
+          id: ld.id,
+          name: ld.name,
+          emoji: ld.emoji,
+          isActive: ld.isActive,
+          hits: ld.hits,
+          target: lanes.find((l) => l.id === ld.id)!.targetPerWeek,
+          battleFought: ld.battleFought,
+          days: ld.days.sort((a: RecapDay, b: RecapDay) => a.date.getTime() - b.date.getTime())
+        }))
+        .sort((a, b) => {
+          // Sort by isActive (true first) then sortOrder ascending
+          // We need to find the original sortOrder from the input lanes
+          const aSort = lanes.find(l => l.id === a.id)?.sortOrder ?? 0;
+          const bSort = lanes.find(l => l.id === b.id)?.sortOrder ?? 0;
+          if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
+          return aSort - bSort;
+        });
+
+      return {
+        weekStart: entry.weekStart,
+        lanes: lanesArray
+      };
+    })
+    .sort((a: WeekRecap, b: WeekRecap) => b.weekStart.getTime() - a.weekStart.getTime()); // Newest first
+
+  return recaps;
+}


### PR DESCRIPTION
Hand-finished from wip residue — the implementation was green; the last red was the test's own unsatisfiable fixture (a battle in a week with zero check-ins).

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3