### PR TITLE
feat(#291): the running week reads 'This week' in history

### DIFF
--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Page from './page'
 import { getWeekStart, formatWeekLabel } from '@/lib/weekUtils'
+import { getTrainingDay } from '@/lib/trainingDay'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
@@ -168,8 +169,10 @@ describe('Page', () => {
 
   it('weeks render newest first with formatted headers', async () => {
     const { prisma } = await import('@/lib/db')
-    const early = new Date('2026-08-11T00:00:00.000Z')
-    const late = new Date('2026-08-18T00:00:00.000Z')
+    // anchored to the real current week so the newest section is always
+    // the running one ("This week") and the older one a plain past week
+    const late = getWeekStart(getTrainingDay(new Date()))
+    const early = new Date(late.getTime() - 7 * 24 * 60 * 60 * 1000)
     vi.mocked(prisma.lane.findMany).mockResolvedValue([
       {
         id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
@@ -185,7 +188,7 @@ describe('Page', () => {
 
     const headers = screen.getAllByRole('heading', { level: 2 })
     expect(headers).toHaveLength(2)
-    expect(headers[0]).toHaveTextContent(`Week of ${formatWeekLabel(getWeekStart(late))}`)
+    expect(headers[0]).toHaveTextContent(`This week — ${formatWeekLabel(getWeekStart(late))}`)
     expect(headers[1]).toHaveTextContent(`Week of ${formatWeekLabel(getWeekStart(early))}`)
   })
 
@@ -224,5 +227,43 @@ describe('Page', () => {
     render(await Page())
 
     expect(screen.getAllByText('⚔️ boss fought')).toHaveLength(1)
+  })
+
+  it('the current week is headed This week', async () => {
+    const { prisma } = await import('@/lib/db')
+    const thisWeekStart = getWeekStart(getTrainingDay(new Date()))
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        bossBattles: [],
+        checkIns: [{ date: thisWeekStart, isRest: false }],
+      },
+    ] as never)
+
+    render(await Page())
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: `This week — ${formatWeekLabel(thisWeekStart)}` })
+    ).toBeInTheDocument()
+  })
+
+  it('a past week keeps the Week of header', async () => {
+    const { prisma } = await import('@/lib/db')
+    const thisWeekStart = getWeekStart(getTrainingDay(new Date()))
+    const pastDay = new Date(thisWeekStart.getTime() - 7 * 24 * 60 * 60 * 1000)
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        bossBattles: [],
+        checkIns: [{ date: pastDay, isRest: false }],
+      },
+    ] as never)
+
+    render(await Page())
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: `Week of ${formatWeekLabel(getWeekStart(pastDay))}` })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/This week —/)).not.toBeInTheDocument()
   })
 })

--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -1,12 +1,15 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Page from './page'
-import { getWeekStart } from '@/lib/weekUtils'
+import { getWeekStart, formatWeekLabel } from '@/lib/weekUtils'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
     lane: {
       findMany: vi.fn(),
+    },
+    prize: {
+      findUnique: vi.fn(),
     },
   },
 }))
@@ -16,8 +19,11 @@ vi.mock('next/font/google', () => new Proxy({}, {
 }))
 
 describe('Page', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+    const { prisma } = await import('@/lib/db')
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([])
   })
 
   it('a retired lane with history renders muted with the tag', async () => {
@@ -29,6 +35,7 @@ describe('Page', () => {
         name: 'Active Lane',
         emoji: '🚀',
         isActive: true,
+        targetPerWeek: 5,
         sortOrder: 1,
         bossBattles: [],
         checkIns: [{ date: today, isRest: false } as any],
@@ -38,6 +45,7 @@ describe('Page', () => {
         name: 'Retired Lane',
         emoji: '💀',
         isActive: false,
+        targetPerWeek: 5,
         sortOrder: 2,
         bossBattles: [],
         checkIns: [{ date: today, isRest: false } as any],
@@ -61,6 +69,7 @@ describe('Page', () => {
         name: 'Active Lane',
         emoji: '🚀',
         isActive: true,
+        targetPerWeek: 5,
         sortOrder: 1,
         bossBattles: [],
         checkIns: [{ date: new Date(), isRest: false } as any],
@@ -82,6 +91,7 @@ describe('Page', () => {
         name: 'Active Lane',
         emoji: '🚀',
         isActive: true,
+        targetPerWeek: 5,
         sortOrder: 1,
         bossBattles: [],
         checkIns: [{ date: new Date(), isRest: false } as any],
@@ -91,6 +101,7 @@ describe('Page', () => {
         name: 'Empty Retired Lane',
         emoji: '💀',
         isActive: false,
+        targetPerWeek: 5,
         sortOrder: 2,
         bossBattles: [],
         checkIns: [],
@@ -109,7 +120,7 @@ describe('Page', () => {
     const day = new Date('2026-08-18T00:00:00.000Z')
     vi.mocked(prisma.lane.findMany).mockResolvedValue([
       {
-        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, sortOrder: 0,
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
         bossBattles: [{ weekStarting: getWeekStart(day) }],
         checkIns: [{ date: day, isRest: false }],
       },
@@ -126,7 +137,7 @@ describe('Page', () => {
     const day = new Date('2026-08-18T00:00:00.000Z')
     vi.mocked(prisma.lane.findMany).mockResolvedValue([
       {
-        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, sortOrder: 0,
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
         bossBattles: [{ weekStarting: getWeekStart(day) }],
         checkIns: [{ date: day, isRest: true }],
       },
@@ -143,7 +154,7 @@ describe('Page', () => {
     const day = new Date('2026-08-18T00:00:00.000Z')
     vi.mocked(prisma.lane.findMany).mockResolvedValue([
       {
-        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, sortOrder: 0,
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
         bossBattles: [],
         checkIns: [{ date: day, isRest: false }],
       },
@@ -153,5 +164,65 @@ describe('Page', () => {
 
     expect(container.querySelectorAll('.bg-purple-500')).toHaveLength(0)
     expect(container.querySelectorAll('.bg-green-400')).toHaveLength(1)
+  })
+
+  it('weeks render newest first with formatted headers', async () => {
+    const { prisma } = await import('@/lib/db')
+    const early = new Date('2026-08-11T00:00:00.000Z')
+    const late = new Date('2026-08-18T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        bossBattles: [],
+        checkIns: [
+          { date: early, isRest: false },
+          { date: late, isRest: false },
+        ],
+      },
+    ] as never)
+
+    render(await Page())
+
+    const headers = screen.getAllByRole('heading', { level: 2 })
+    expect(headers).toHaveLength(2)
+    expect(headers[0]).toHaveTextContent(`Week of ${formatWeekLabel(getWeekStart(late))}`)
+    expect(headers[1]).toHaveTextContent(`Week of ${formatWeekLabel(getWeekStart(early))}`)
+  })
+
+  it('no empty squares render', async () => {
+    const { prisma } = await import('@/lib/db')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        bossBattles: [],
+        checkIns: [{ date: new Date('2026-08-18T00:00:00.000Z'), isRest: false }],
+      },
+    ] as never)
+
+    const { container } = render(await Page())
+
+    expect(container.querySelectorAll('.bg-zinc-800')).toHaveLength(0)
+    // exactly one square: the single checked day
+    expect(container.querySelectorAll('.h-6.w-6')).toHaveLength(1)
+  })
+
+  it('the boss fought label appears only in the battle week', async () => {
+    const { prisma } = await import('@/lib/db')
+    const battleDay = new Date('2026-08-11T00:00:00.000Z')
+    const plainDay = new Date('2026-08-18T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        bossBattles: [{ weekStarting: getWeekStart(battleDay) }],
+        checkIns: [
+          { date: battleDay, isRest: false },
+          { date: plainDay, isRest: false },
+        ],
+      },
+    ] as never)
+
+    render(await Page())
+
+    expect(screen.getAllByText('⚔️ boss fought')).toHaveLength(1)
   })
 })

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db"
 import { buildWeekRecaps } from "@/lib/weekRecap"
-import { formatWeekLabel } from "@/lib/weekUtils"
+import { formatWeekLabel, getWeekStart } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 
 export const dynamic = "force-dynamic"
 
@@ -21,6 +22,7 @@ export default async function HistoryPage() {
   })
 
   const recaps = buildWeekRecaps(lanes)
+  const thisWeekStart = getWeekStart(getTrainingDay(new Date()))
 
   return (
     <main className="max-w-3xl mx-auto space-y-8 p-6">
@@ -28,7 +30,11 @@ export default async function HistoryPage() {
       <p className="mt-1 text-sm text-zinc-500">Your season, week by week — green for a session, blue for a rest day, purple for a boss-battle week. Only days you showed up are here.</p>
       {recaps.map((recap) => (
         <section key={recap.weekStart.getTime()} className="space-y-3">
-          <h2 className="text-lg font-semibold">Week of {formatWeekLabel(recap.weekStart)}</h2>
+          <h2 className="text-lg font-semibold">
+            {recap.weekStart.getTime() === thisWeekStart.getTime()
+              ? <>This week — {formatWeekLabel(recap.weekStart)}</>
+              : <>Week of {formatWeekLabel(recap.weekStart)}</>}
+          </h2>
           {recap.lanes.map((lane) => (
             <div
               key={lane.id}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,21 +1,12 @@
 import { prisma } from "@/lib/db"
-import { computeStreak } from "@/lib/streak"
-import { getTrainingDay } from "@/lib/trainingDay"
-import { getWeekStart } from "@/lib/weekUtils"
+import { buildWeekRecaps } from "@/lib/weekRecap"
+import { formatWeekLabel } from "@/lib/weekUtils"
 
 export const dynamic = "force-dynamic"
 
-const DAY_MS = 24 * 60 * 60 * 1000
-
-function utcMidnight(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
-
 export default async function HistoryPage() {
-  const today = getTrainingDay(new Date())
-  const start = new Date(today.getTime() - 29 * DAY_MS)
-
-  const lanesRaw = await prisma.lane.findMany({
+  const prize = await prisma.prize.findUnique({ where: { id: "prize" } })
+  const lanes = await prisma.lane.findMany({
     orderBy: [
       { isActive: "desc" },
       { sortOrder: "asc" },
@@ -23,67 +14,57 @@ export default async function HistoryPage() {
     include: {
       bossBattles: true,
       checkIns: {
-        where: { date: { gte: start } },
+        ...(prize?.seasonStart ? { where: { date: { gte: prize.seasonStart } } } : {}),
         orderBy: { date: "asc" },
       },
     },
   })
 
-  const lanes = lanesRaw.filter((lane) => !( !lane.isActive && lane.checkIns.length === 0 ))
-
-  const days = Array.from({ length: 30 }, (_, i) => new Date(start.getTime() + i * DAY_MS))
+  const recaps = buildWeekRecaps(lanes)
 
   return (
     <main className="max-w-3xl mx-auto space-y-8 p-6">
       <h1 className="text-2xl font-bold">History</h1>
-      <p className="mt-1 text-sm text-zinc-500">Your last 30 days at a glance — green for a session, blue for a rest day, purple for a boss-battle week. Watch the consistency stack up.</p>
-      {lanes.map((lane) => {
-        const streak = computeStreak(
-          lane.checkIns.map((c) => ({ date: c.date, isRest: c.isRest })),
-          today
-        )
-        const byDay = new Map(
-          lane.checkIns.map((c) => [utcMidnight(c.date).getTime(), c])
-        )
-        // A boss battle marks its whole week: session squares turn purple.
-        const battleWeeks = new Set(
-          lane.bossBattles.map((b) => b.weekStarting.getTime())
-        )
-        return (
-          <section
-            key={lane.id}
-            className={`space-y-2 ${!lane.isActive ? "opacity-60" : ""}`}
-          >
-            <h2 className="text-lg font-semibold">
-              {lane.emoji} {lane.name} — {streak}🔥
-              {!lane.isActive && (
-                <span data-testid="retired-tag" className="ml-2 text-xs text-zinc-500">
-                  retired
-                </span>
-              )}
-            </h2>
-            <div className="grid grid-cols-10 gap-1">
-              {days.map((d) => {
-                const c = byDay.get(d.getTime())
-                const cls = c
-                  ? c.isRest
-                    ? "bg-blue-300"
-                    : battleWeeks.has(getWeekStart(d).getTime())
-                      ? "bg-purple-500"
-                      : "bg-green-400"
-                  : "bg-zinc-800"
-                return (
+      <p className="mt-1 text-sm text-zinc-500">Your season, week by week — green for a session, blue for a rest day, purple for a boss-battle week. Only days you showed up are here.</p>
+      {recaps.map((recap) => (
+        <section key={recap.weekStart.getTime()} className="space-y-3">
+          <h2 className="text-lg font-semibold">Week of {formatWeekLabel(recap.weekStart)}</h2>
+          {recap.lanes.map((lane) => (
+            <div
+              key={lane.id}
+              className={`flex items-center gap-3 ${!lane.isActive ? "opacity-60" : ""}`}
+            >
+              <span className="w-48 truncate">
+                {lane.emoji} {lane.name}
+                {!lane.isActive && (
+                  <span data-testid="retired-tag" className="ml-2 text-xs text-zinc-500">
+                    retired
+                  </span>
+                )}
+              </span>
+              <div className="flex gap-1">
+                {lane.days.map((d) => (
                   <div
-                    key={d.getTime()}
-                    className={`h-6 w-6 rounded ${cls}`}
-                    title={d.toISOString().slice(0, 10)}
+                    key={d.date.getTime()}
+                    className={`h-6 w-6 rounded ${
+                      d.isRest
+                        ? "bg-blue-300"
+                        : lane.battleFought
+                          ? "bg-purple-500"
+                          : "bg-green-400"
+                    }`}
+                    title={d.date.toISOString().slice(0, 10)}
                   />
-                )
-              })}
+                ))}
+              </div>
+              <span className="text-sm text-zinc-600">
+                {lane.hits} / {lane.target} days
+              </span>
+              {lane.battleFought && <span className="text-sm">⚔️ boss fought</span>}
             </div>
-          </section>
-        )
-      })}
+          ))}
+        </section>
+      ))}
     </main>
   )
 }

--- a/src/lib/weekRecap.test.ts
+++ b/src/lib/weekRecap.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { buildWeekRecaps, type RecapLaneInput } from './weekRecap'
+
+describe('weekRecap', () => {
+  it('groups check-ins into weeks newest first', () => {
+    const week1Start = new Date(Date.UTC(2024, 0, 1)); // Jan 1
+    const week2Start = new Date(Date.UTC(2024, 0, 8)); // Jan 8
+    
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+      checkIns: [
+        { date: new Date(Date.UTC(2024, 0, 2)), isRest: false },
+        { date: new Date(Date.UTC(2024, 0, 9)), isRest: false }
+      ],
+      bossBattles: []
+    }];
+
+    const result = buildWeekRecaps(input);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].weekStart.toISOString()).toBe(week2Start.toISOString());
+    expect(result[1].weekStart.toISOString()).toBe(week1Start.toISOString());
+  });
+
+  it('a lane with no check-ins that week is absent', () => {
+    const input: RecapLaneInput[] = [
+      {
+        id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+        checkIns: [{ date: new Date(Date.UTC(2024, 0, 1)), isRest: false }],
+        bossBattles: []
+      },
+      {
+        id: '2', name: 'L2', emoji: '💧', targetPerWeek: 5, isActive: true, sortOrder: 2,
+        checkIns: [],
+        bossBattles: []
+      }
+    ];
+
+    const result = buildWeekRecaps(input);
+    expect(result[0].lanes).toHaveLength(1);
+    expect(result[0].lanes[0].id).toBe('1');
+  });
+
+  it('a retired lane keeps its record', () => {
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: false, sortOrder: 1,
+      checkIns: [{ date: new Date(Date.UTC(2024, 0, 1)), isRest: false }],
+      bossBattles: []
+    }];
+
+    const result = buildWeekRecaps(input);
+    expect(result[0].lanes[0].isActive).toBe(false);
+    expect(result[0].lanes[0].hits).toBe(1);
+  });
+
+  it("battleFought marks only the battle's week", () => {
+    const week1Start = new Date(Date.UTC(2024, 0, 1));
+    const week2Start = new Date(Date.UTC(2024, 0, 8));
+
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+      // the battle's week must have check-ins — a week with none never renders
+      checkIns: [
+        { date: new Date(Date.UTC(2024, 0, 2)), isRest: false },
+        { date: new Date(Date.UTC(2024, 0, 9)), isRest: false }
+      ],
+      bossBattles: [{ weekStarting: week2Start }]
+    }];
+
+    const result = buildWeekRecaps(input);
+    
+    // Week 2 (Newest first)
+    const week2 = result.find(w => w.weekStart.toISOString() === week2Start.toISOString());
+    const week1 = result.find(w => w.weekStart.toISOString() === week1Start.toISOString());
+
+    expect(week2?.lanes[0].battleFought).toBe(true);
+    expect(week1?.lanes[0].battleFought).toBe(false);
+  });
+
+  it('hits count rest days and days stay chronological', () => {
+    const input: RecapLaneInput[] = [{
+      id: '1', name: 'L1', emoji: '🔥', targetPerWeek: 5, isActive: true, sortOrder: 1,
+      checkIns: [
+        { date: new Date(Date.UTC(2024, 0, 5)), isRest: false },
+        { date: new Date(Date.UTC(2024, 0, 2)), isRest: true },
+        { date: new Date(Date.UTC(2024, 0, 3)), isRest: false }
+      ],
+      bossBattles: []
+    }];
+
+    const result = buildWeekRecaps(input);
+    const laneWeek = result[0].lanes[0];
+
+    expect(laneWeek.hits).toBe(3);
+    expect(laneWeek.days).toHaveLength(3);
+    // Check chronological order
+    expect(laneWeek.days[0].date.getUTCDate()).toBe(2);
+    expect(laneWeek.days[1].date.getUTCDate()).toBe(3);
+    expect(laneWeek.days[2].date.getUTCDate()).toBe(5);
+    // Check rest day property
+    expect(laneWeek.days[0].isRest).toBe(true);
+    expect(laneWeek.days[1].isRest).toBe(false);
+  });
+});

--- a/src/lib/weekRecap.ts
+++ b/src/lib/weekRecap.ts
@@ -1,0 +1,121 @@
+import { getWeekStart } from "@/lib/weekUtils";
+
+export interface RecapLaneInput {
+  id: string;
+  name: string;
+  emoji: string;
+  targetPerWeek: number;
+  isActive: boolean;
+  sortOrder: number;
+  checkIns: { date: Date; isRest: boolean }[];
+  bossBattles: { weekStarting: Date }[];
+}
+
+export interface RecapDay {
+  date: Date;
+  isRest: boolean;
+}
+
+export interface RecapLaneWeek {
+  id: string;
+  name: string;
+  emoji: string;
+  isActive: boolean;
+  hits: number;
+  target: number;
+  battleFought: boolean;
+  days: RecapDay[];
+}
+
+export interface WeekRecap {
+  weekStart: Date;
+  lanes: RecapLaneWeek[];
+}
+
+export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
+  type LaneWeekInternal = Omit<RecapLaneWeek, "target" | "days"> & {
+    sortOrder: number;
+    hits: number;
+    days: RecapDay[];
+  };
+
+  const weekMap = new Map<string, { weekStart: Date; laneData: Map<string, LaneWeekInternal> }>();
+
+  // 1. Process all check-ins to identify weeks and populate lane data
+  for (const lane of lanes) {
+    for (const checkIn of lane.checkIns) {
+      const weekStart = getWeekStart(checkIn.date);
+      const weekKey = weekStart.toISOString();
+
+      if (!weekMap.has(weekKey)) {
+        weekMap.set(weekKey, { weekStart, laneData: new Map() });
+      }
+
+      const weekEntry = weekMap.get(weekKey)!;
+      if (!weekEntry.laneData.has(lane.id)) {
+        weekEntry.laneData.set(lane.id, {
+          id: lane.id,
+          name: lane.name,
+          emoji: lane.emoji,
+          isActive: lane.isActive,
+          hits: 0,
+          days: [],
+          battleFought: false,
+          sortOrder: lane.sortOrder
+        });
+      }
+
+      const laneWeek = weekEntry.laneData.get(lane.id)!;
+      laneWeek.hits += 1;
+      laneWeek.days.push({ date: checkIn.date, isRest: checkIn.isRest });
+    }
+  }
+
+  // 2. Process Boss Battles to mark battles fought in specific weeks
+  for (const lane of lanes) {
+    for (const battle of lane.bossBattles) {
+      const weekStart = getWeekStart(battle.weekStarting);
+      const weekKey = weekStart.toISOString();
+
+      if (weekMap.has(weekKey)) {
+        const weekEntry = weekMap.get(weekKey)!;
+        if (weekEntry.laneData.has(lane.id)) {
+          const laneWeek = weekEntry.laneData.get(lane.id)!;
+          laneWeek.battleFought = true;
+        }
+      }
+    }
+  }
+
+  // 3. Transform the map into the final WeekRecap[] structure
+  const recaps: WeekRecap[] = Array.from(weekMap.values())
+    .map((entry) => {
+      const lanesArray = Array.from(entry.laneData.values())
+        .map((ld) => ({
+          id: ld.id,
+          name: ld.name,
+          emoji: ld.emoji,
+          isActive: ld.isActive,
+          hits: ld.hits,
+          target: lanes.find((l) => l.id === ld.id)!.targetPerWeek,
+          battleFought: ld.battleFought,
+          days: ld.days.sort((a: RecapDay, b: RecapDay) => a.date.getTime() - b.date.getTime())
+        }))
+        .sort((a, b) => {
+          // Sort by isActive (true first) then sortOrder ascending
+          // We need to find the original sortOrder from the input lanes
+          const aSort = lanes.find(l => l.id === a.id)?.sortOrder ?? 0;
+          const bSort = lanes.find(l => l.id === b.id)?.sortOrder ?? 0;
+          if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
+          return aSort - bSort;
+        });
+
+      return {
+        weekStart: entry.weekStart,
+        lanes: lanesArray
+      };
+    })
+    .sort((a: WeekRecap, b: WeekRecap) => b.weekStart.getTime() - a.weekStart.getTime()); // Newest first
+
+  return recaps;
+}


### PR DESCRIPTION
Hand-finished — the grinder emitted the vacuous double-arrow test on all 3 attempts and the new red-gate check (spikes-workspace #54) refused each one with the named diagnosis. First live catch for that gate.

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3