### PR TITLE
Multi-user Phase 0: auth foundations

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "postinstall": "prisma generate"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^2.11.3",
     "@prisma/client": "^6.19.3",
     "@vercel/blob": "^2.6.1",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "next": "16.2.12",
+    "next-auth": "5.0.0-beta.32",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@auth/prisma-adapter':
+        specifier: ^2.11.3
+        version: 2.11.3(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
@@ -28,6 +31,9 @@ importers:
       next:
         specifier: 16.2.12
         version: 16.2.12(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth:
+        specifier: 5.0.0-beta.32
+        version: 5.0.0-beta.32(next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -103,6 +109,25 @@ packages:
   '@asamuzakjp/dom-selector@8.3.0':
     resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
     engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@auth/core@0.41.3':
+    resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7 || ^8.0.5
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.11.3':
+    resolution: {integrity: sha512-jZbpVAO6PTc9zNtdTWc0RLWG8qap4iMc54/3oWaWbuKdj92wHxzPrs3HivWB2mB9975GPW0l3YM/wFUWiUlTlg==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -555,6 +580,9 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@prisma/client@6.19.3':
     resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
@@ -1918,6 +1946,9 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
+  jose@6.2.9:
+    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2126,6 +2157,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.32:
+    resolution: {integrity: sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7 || ^8.0.5
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next@16.2.12:
     resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
     engines: {node: '>=20.9.0'}
@@ -2166,6 +2213,9 @@ packages:
     resolution: {integrity: sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  oauth4webapi@3.8.7:
+    resolution: {integrity: sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2275,6 +2325,14 @@ packages:
   postcss@8.5.24:
     resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2832,6 +2890,23 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
 
+  '@auth/core@0.41.3':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.9
+      oauth4webapi: 3.8.7
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/prisma-adapter@2.11.3(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@auth/core': 0.41.3
+      '@prisma/client': 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3238,6 +3313,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
@@ -4703,6 +4780,8 @@ snapshots:
 
   jose@5.10.0: {}
 
+  jose@6.2.9: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.1:
@@ -4877,6 +4956,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.32(next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@auth/core': 0.41.3
+      next: 16.2.12(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+
   next@16.2.12(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.12
@@ -4921,6 +5006,8 @@ snapshots:
       citty: 0.2.2
       pathe: 2.0.3
       tinyexec: 1.2.4
+
+  oauth4webapi@3.8.7: {}
 
   object-assign@4.1.1: {}
 
@@ -5035,6 +5122,12 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,10 @@ datasource db {
 // Lane — a skill domain Eddie trains (e.g. "Stick Skills", "Shooting", "Conditioning")
 model Lane {
   id            String   @id @default(cuid())
+  // Nullable during the two-phase rollout; tightened to required once the
+  // claim script has bound the pre-auth rows to their owner.
+  userId        String?
+  user          User?    @relation(fields: [userId], references: [id])
   name          String
   emoji         String   @default("🥍")
   targetPerWeek Int      @default(5) // days/week target frequency
@@ -17,17 +21,19 @@ model Lane {
   sortOrder     Int      @default(0)
   createdAt     DateTime @default(now())
 
-  checkIns    CheckIn[]
-  bossBattles BossBattle[]
+  checkIns      CheckIn[]
+  bossBattles   BossBattle[]
+  streakFreezes StreakFreeze[]
 
   @@index([isActive])
+  @@index([userId, isActive])
 }
 
 // CheckIn — Eddie's daily self-report for a lane session
 model CheckIn {
   id        String   @id @default(cuid())
   laneId    String
-  lane      Lane     @relation(fields: [laneId], references: [id])
+  lane      Lane     @relation(fields: [laneId], references: [id], onDelete: Cascade)
   date      DateTime // UTC midnight of the check-in day
   isRest    Boolean  @default(false) // true = rest/sleep entry (counts as a hit)
   note      String? // optional free-text (effort note, not a grade)
@@ -42,7 +48,7 @@ model CheckIn {
 model BossBattle {
   id           String   @id @default(cuid())
   laneId       String
-  lane         Lane     @relation(fields: [laneId], references: [id])
+  lane         Lane     @relation(fields: [laneId], references: [id], onDelete: Cascade)
   weekStarting DateTime // UTC midnight of the Monday starting the 2-week block
   selfReport   String // Eddie's free-text description of how it went
   coachNote    String? // AI-generated coach note (process-framed, never graded)
@@ -55,12 +61,17 @@ model BossBattle {
 // WeeklyReflection — Eddie's weekly free-text entry + AI summary
 model WeeklyReflection {
   id           String   @id @default(cuid())
+  userId       String?
+  user         User?    @relation(fields: [userId], references: [id])
   weekStarting DateTime // UTC midnight of the Monday
-  playerNote   String // Eddie's reflection
+  playerNote   String // the player's reflection
   coachSummary String? // AI-generated summary (effort-framed)
   createdAt    DateTime @default(now())
 
+  // The global unique survives the two-phase window (current code upserts by
+  // it); the tightening story drops it once every row carries a userId.
   @@unique([weekStarting])
+  @@unique([userId, weekStarting])
   @@index([weekStarting])
 }
 
@@ -68,21 +79,78 @@ model WeeklyReflection {
 model StreakFreeze {
   id        String    @id @default(cuid())
   laneId    String
+  lane      Lane      @relation(fields: [laneId], references: [id], onDelete: Cascade)
   usedDate  DateTime? // null = still available
   createdAt DateTime  @default(now())
 
   @@index([laneId])
 }
 
-// Prize — the single thing the player is training for.
-// id is a fixed singleton value and reasons is an ordered scalar list.
+// Prize — the single thing a player is training for. Doubles as the
+// per-user season-state row (seasonStart). The legacy row keeps its literal
+// "prize" id; new rows get cuids and every row binds to a user.
 model Prize {
-  id          String   @id @default("prize")
+  id          String    @id @default(cuid())
+  userId      String?   @unique
+  user        User?     @relation(fields: [userId], references: [id])
   title       String
   description String?
   reasons     String[]
   photoUrl    String?
   seasonStart DateTime?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+}
+// ---- Auth.js (next-auth v5 Prisma adapter) --------------------------------
+
+model User {
+  id            String    @id @default(cuid())
+  name          String?
+  email         String    @unique
+  emailVerified DateTime?
+  image         String?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  accounts    Account[]
+  sessions    Session[]
+  lanes       Lane[]
+  reflections WeeklyReflection[]
+  prize       Prize?
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
 }

--- a/scripts/claim-user.ts
+++ b/scripts/claim-user.ts
@@ -1,0 +1,36 @@
+/**
+ * Bind all pre-auth rows to their owner. Run ONCE at cutover, before the
+ * auth build deploys:
+ *
+ *   pnpm exec tsx scripts/claim-user.ts eddie@example.com "Eddie"
+ *
+ * Idempotent: rows that already carry a userId are never touched, and the
+ * User upsert is keyed on email.
+ */
+import { prisma } from "../src/lib/db"
+
+async function main() {
+  const [email, name] = process.argv.slice(2)
+  if (!email) {
+    console.error("usage: tsx scripts/claim-user.ts <email> [name]")
+    process.exit(1)
+  }
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    update: {},
+    create: { email, name: name ?? null },
+  })
+  console.log(`user ${user.id} (${email})`)
+
+  for (const model of ["lane", "weeklyReflection", "prize"] as const) {
+    // @ts-expect-error -- indexing the client by model name
+    const { count } = await prisma[model].updateMany({
+      where: { userId: null },
+      data: { userId: user.id },
+    })
+    console.log(`${model}: claimed ${count} row(s)`)
+  }
+}
+
+main().finally(() => prisma.$disconnect())

--- a/src/app/actions/resetSeason.test.ts
+++ b/src/app/actions/resetSeason.test.ts
@@ -20,7 +20,7 @@ describe('resetSeason', () => {
 
   it('it clears seasonStart on the prize row', async () => {
     vi.mocked(prisma.prize.update).mockResolvedValue(
-      { id: 'prize', title: 'Test', description: '', reasons: [], photoUrl: null, seasonStart: null, createdAt: new Date(0), updatedAt: new Date(0) }
+      { id: 'prize', userId: null, title: 'Test', description: '', reasons: [], photoUrl: null, seasonStart: null, createdAt: new Date(0), updatedAt: new Date(0) }
     )
 
     await resetSeason()

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth"
+
+export const { GET, POST } = handlers

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation"
+import { auth, signIn } from "@/auth"
+
+export const dynamic = "force-dynamic"
+
+export default async function SignInPage() {
+  const session = await auth()
+  if (session?.user) redirect("/")
+
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-sm flex-col items-center justify-center gap-6 p-6 text-center">
+      <h1 className="text-2xl font-bold">Lacrosse Grind</h1>
+      <p className="text-sm text-zinc-500">
+        Your season, your lanes, your boss battles. Sign in to start showing up.
+      </p>
+      <form
+        action={async () => {
+          "use server"
+          await signIn("google", { redirectTo: "/" })
+        }}
+      >
+        <button
+          type="submit"
+          className="rounded-lg bg-green-500 px-6 py-3 font-medium text-zinc-950 hover:bg-green-400"
+        >
+          Continue with Google
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,30 @@
+import NextAuth from "next-auth"
+import Google from "next-auth/providers/google"
+import { PrismaAdapter } from "@auth/prisma-adapter"
+import { prisma } from "@/lib/db"
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    // Email-linking is safe here (Google verifies emails) and load-bearing:
+    // the claim script pre-creates the owner's User row, and this lets the
+    // first Google sign-in attach to it instead of throwing
+    // OAuthAccountNotLinked.
+    Google({ allowDangerousEmailAccountLinking: true }),
+  ],
+  session: { strategy: "database" },
+  callbacks: {
+    authorized({ auth, request }) {
+      const { pathname } = request.nextUrl
+      if (pathname === "/signin") return true
+      return !!auth?.user
+    },
+    session({ session, user }) {
+      // Every scoped query keys off session.user.id — without this copy the
+      // id is undefined and scoping silently matches nothing.
+      session.user.id = user.id
+      return session
+    },
+  },
+  pages: { signIn: "/signin" },
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,11 @@
+import { auth } from "@/auth"
+
+// The `authorized` callback in src/auth.ts is the actual gate; wrapping an
+// empty handler makes NextAuth run it (redirecting signed-out visitors to
+// /signin) on every matched request.
+export default auth(() => {})
+
+export const config = {
+  // Everything except Auth.js's own routes, Next internals, and static assets.
+  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
+}


### PR DESCRIPTION
Hand-written per the design doc (`docs/design/multi-user-oauth.md`): schema (Auth.js models, two-phase nullable `userId`, Prize de-singleton, StreakFreeze FK, cascades), NextAuth v5 + Google wiring with the `authorized` gate and `session.user.id` plumbing, Next 16 `src/proxy.ts`, `/signin` page, and the idempotent `scripts/claim-user.ts` cutover binder.

**Nothing user-visible changes yet** — the proxy gate only activates once `AUTH_SECRET`/`AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET` exist on a deploy, and no page or action is scoped until the Phase 1–2 stories land on top of this.

Gates: 243 tests green under Kiritimati, tsc clean, lint 0 errors, `pnpm build` passes with the Proxy registered.

Once merged, ~26 stories (tenancy helper → 18 actions → 6 pages + LLM cap + polish) get filed and dispatched to Spike as one dependency DAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3