### PR TITLE
feat(#299): tenancy — requireUserId helper

### DIFF
--- a/src/app/actions/signOutAction.test.ts
+++ b/src/app/actions/signOutAction.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+import { signOutAction } from './signOutAction'
+import { signOut } from '@/auth'
+
+vi.mock('@/auth', () => ({
+  signOut: vi.fn(),
+}))
+
+describe('signOutAction', () => {
+  it('it signs out to the signin page', async () => {
+    const mockSignOut = vi.mocked(signOut)
+    mockSignOut.mockResolvedValue(undefined as any)
+
+    await signOutAction()
+
+    expect(mockSignOut).toHaveBeenCalledWith({
+      redirectTo: '/signin',
+    })
+  })
+})

--- a/src/app/actions/signOutAction.ts
+++ b/src/app/actions/signOutAction.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { signOut } from '@/auth'
+
+export async function signOutAction(): Promise<void> {
+  await signOut({ redirectTo: '/signin' })
+}

--- a/src/lib/tenancy.test.ts
+++ b/src/lib/tenancy.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { requireUserId } from './tenancy'
+
+import { auth } from '@/auth'
+import { redirect } from 'next/navigation'
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => { throw new Error('REDIRECT') }),
+}))
+
+// `auth` is overloaded in Auth.js, so vi.mocked(auth) resolves the
+// middleware overload and rejects a session. Drive it through this:
+//   mockAuth.mockResolvedValue({ user: { id: 'u1' } })
+//   mockAuth.mockResolvedValue(null)
+const mockAuth = vi.mocked(auth as unknown as () => Promise<unknown>)
+const mockRedirect = vi.mocked(redirect)
+
+describe('tenancy', () => {
+  it('a session returns its user id', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1' } } as never)
+
+    const userId = await requireUserId()
+
+    expect(userId).toBe('u1')
+    expect(mockAuth).toHaveBeenCalled()
+  })
+
+  it('no session redirects to signin', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    await expect(requireUserId()).rejects.toThrow('REDIRECT')
+    expect(mockRedirect).toHaveBeenCalledWith('/signin')
+  })
+
+  it('a session without an id redirects to signin', async () => {
+    // Session exists but user object is missing id
+    mockAuth.mockResolvedValue({ user: {} } as never)
+
+    await expect(requireUserId()).rejects.toThrow('REDIRECT')
+    expect(mockRedirect).toHaveBeenCalledWith('/signin')
+  })
+})

--- a/src/lib/tenancy.ts
+++ b/src/lib/tenancy.ts
@@ -1,0 +1,12 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+
+export async function requireUserId(): Promise<string> {
+  const session = await auth();
+  if (session?.user?.id) {
+    return session.user.id;
+  }
+  redirect("/signin");
+  // The redirect function throws, so this line is unreachable.
+  throw new Error("Redirected");
+}


### PR DESCRIPTION
Hand-finished from wip residue (one unawaited rejects assertion).

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3