### PR TITLE
feat(#320): story: lanes page is owner-scoped

### DIFF
--- a/src/app/lanes/page.test.tsx
+++ b/src/app/lanes/page.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Page from './page'
+import { requireUserId } from '@/lib/tenancy'
+import { prisma } from '@/lib/db'
+
+// next/font's loader only exists inside the Next build; under vitest
+// `Geist(...)` is not a function and the suite dies at module load.
+vi.mock('next/font/google', () => new Proxy({}, {
+  get: () => () => ({ variable: 'mock-font-variable', className: 'mock-font' }),
+}))
+
+vi.mock('@/lib/tenancy', () => ({
+  requireUserId: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    lane: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+describe('Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+  })
+
+  it('the lane list is scoped to the signed-in user', async () => {
+    const mockLanes = [
+      { id: 'l1', name: 'Running', emoji: '🏃', isActive: true, sortOrder: 1, targetPerWeek: 3, userId: 'u1' },
+      { id: 'l2', name: 'Reading', emoji: '📚', isActive: false, sortOrder: 2, targetPerWeek: 5, userId: 'u1' },
+    ]
+
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(mockLanes as any)
+
+    // We render the component. Since it's an async Server Component, 
+    // we await the component function call directly.
+    const ResolvedPage = await Page()
+    render(ResolvedPage)
+
+    expect(requireUserId).toHaveBeenCalled()
+    expect(prisma.lane.findMany).toHaveBeenCalledWith({
+      where: { userId: 'u1' },
+      orderBy: [{ isActive: 'desc' }, { sortOrder: 'asc' }],
+    })
+
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('Reading')).toBeInTheDocument()
+  })
+})

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db"
+import { requireUserId } from "@/lib/tenancy"
 import { createLane } from "@/app/actions/createLane"
 import { updateLane } from "@/app/actions/updateLane"
 import { setLaneActive } from "@/app/actions/setLaneActive"
@@ -11,7 +12,9 @@ import LaneForm from "@/components/LaneForm"
 export const dynamic = "force-dynamic"
 
 export default async function LanesPage() {
+  const userId = await requireUserId()
   const lanes = await prisma.lane.findMany({
+    where: { userId },
     orderBy: [{ isActive: "desc" }, { sortOrder: "asc" }],
   })
 


### PR DESCRIPTION
## Summary

Implements story #320: story: lanes page is owner-scoped

## Verified gates (auto-captured by dag-poc)

- `build` exit 0
- `typecheck` exit 2
- `lint` exit 1

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 32953
- Output tokens: 1612

Closes #320

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-21T20:56:35Z)
- lint: ✓ exit 0 (run at 2026-08-21T20:56:29Z)
- test: ✓ exit 0 (run at 2026-08-21T20:56:30Z)
