### PR TITLE
feat(#317): story: resetSeason is owner-scoped

### DIFF
--- a/src/app/actions/resetSeason.test.ts
+++ b/src/app/actions/resetSeason.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
+import { requireUserId } from '@/lib/tenancy'
 import { resetSeason } from './resetSeason'
 
 vi.mock('@/lib/db', () => ({
@@ -13,27 +14,42 @@ vi.mock('@/lib/db', () => ({
   },
 }))
 
+vi.mock('@/lib/tenancy', () => ({
+  requireUserId: vi.fn()
+}))
+
 describe('resetSeason', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
   })
 
-  it('it clears seasonStart on the prize row', async () => {
-    vi.mocked(prisma.prize.update).mockResolvedValue(
-      { id: 'prize', userId: null, title: 'Test', description: '', reasons: [], photoUrl: null, seasonStart: null, createdAt: new Date(0), updatedAt: new Date(0) }
-    )
+  it('the reset is scoped to the owner', async () => {
+    vi.mocked(prisma.prize.updateMany).mockResolvedValue({ count: 1 })
 
     await resetSeason()
 
-    expect(prisma.prize.update).toHaveBeenCalledWith({
-      where: { id: 'prize' },
+    expect(requireUserId).toHaveBeenCalled()
+    expect(prisma.prize.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'u1' },
+      data: { seasonStart: null }
+    })
+  })
+
+  it('it clears seasonStart on the prize row', async () => {
+    vi.mocked(prisma.prize.updateMany).mockResolvedValue({ count: 1 })
+
+    await resetSeason()
+
+    expect(prisma.prize.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'u1' },
       data: { seasonStart: null }
     })
   })
 
   it('a missing prize row surfaces the Prisma error unchanged', async () => {
     const error = new Error('Record to update not found.')
-    vi.mocked(prisma.prize.update).mockRejectedValue(error)
+    vi.mocked(prisma.prize.updateMany).mockRejectedValue(error)
 
     await expect(resetSeason()).rejects.toThrow('Record to update not found.')
   })

--- a/src/app/actions/resetSeason.ts
+++ b/src/app/actions/resetSeason.ts
@@ -1,10 +1,12 @@
 'use server'
 
 import { prisma } from '@/lib/db'
+import { requireUserId } from '@/lib/tenancy'
 
 export async function resetSeason(): Promise<void> {
-  await prisma.prize.update({
-    where: { id: 'prize' },
+  const userId = await requireUserId()
+  await prisma.prize.updateMany({
+    where: { userId },
     data: { seasonStart: null },
   })
 }


### PR DESCRIPTION
## Summary

Implements story #317: story: resetSeason is owner-scoped

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 16792
- Output tokens: 1059

Closes #317

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-21T21:11:21Z)
- lint: ✓ exit 0 (run at 2026-08-21T21:11:15Z)
- test: ✓ exit 0 (run at 2026-08-21T21:11:16Z)
