### PR TITLE
feat(#307): story: deleteCheckIn is owner-scoped

### DIFF
--- a/src/app/actions/deleteCheckIn.test.ts
+++ b/src/app/actions/deleteCheckIn.test.ts
@@ -1,32 +1,52 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
+import { requireUserId } from '@/lib/tenancy'
 import { deleteCheckIn } from './deleteCheckIn'
 
-vi.mock('@/lib/db', () => ({ prisma: { checkIn: { delete: vi.fn() } } }))
+vi.mock('@/lib/db', () => ({ prisma: { checkIn: { deleteMany: vi.fn() } } }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
 
 const date = new Date(Date.UTC(2026, 0, 5))
 
 describe('deleteCheckIn', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+  })
 
   it('valid laneId and date deletes and returns ok', async () => {
-    vi.mocked(prisma.checkIn.delete).mockResolvedValue({ id: 'ci-1' } as never)
+    vi.mocked(prisma.checkIn.deleteMany).mockResolvedValue({ count: 1 })
 
     const result = await deleteCheckIn('lane-1', date)
 
     expect(result).toEqual({ ok: true })
-    expect(prisma.checkIn.delete).toHaveBeenCalledWith({
-      where: { laneId_date: { laneId: 'lane-1', date } },
+    expect(prisma.checkIn.deleteMany).toHaveBeenCalledWith({
+      where: {
+        laneId: 'lane-1',
+        date,
+        lane: { userId: 'u1' },
+      },
     })
     expect(revalidatePath).toHaveBeenCalledWith('/')
   })
 
   it('prisma not-found error returns not-found error', async () => {
-    vi.mocked(prisma.checkIn.delete).mockRejectedValue(new Error('Record to delete does not exist.'))
+    vi.mocked(prisma.checkIn.deleteMany).mockResolvedValue({ count: 0 })
 
     const result = await deleteCheckIn('lane-1', date)
+
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it("a foreign lane's check-in returns not-found", async () => {
+    // If the deleteMany count is 0, it means the record didn't match the criteria
+    // (e.g. the lane belongs to a different user or the date/laneId is wrong)
+    vi.mocked(prisma.checkIn.deleteMany).mockResolvedValue({ count: 0 })
+
+    const result = await deleteCheckIn('foreign-lane', date)
 
     expect(result).toEqual({ ok: false, error: 'not-found' })
     expect(revalidatePath).not.toHaveBeenCalled()

--- a/src/app/actions/deleteCheckIn.ts
+++ b/src/app/actions/deleteCheckIn.ts
@@ -1,16 +1,22 @@
 import { prisma } from "@/lib/db";
 import { revalidatePath } from "next/cache";
+import { requireUserId } from "@/lib/tenancy";
 
 export async function deleteCheckIn(
   laneId: string,
   date: Date
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  try {
-    await prisma.checkIn.delete({
-      where: { laneId_date: { laneId, date } },
-    });
-  } catch {
-    // Prisma throws when the record doesn't exist.
+  const userId = await requireUserId();
+
+  const { count } = await prisma.checkIn.deleteMany({
+    where: {
+      laneId,
+      date,
+      lane: { userId },
+    },
+  });
+
+  if (count !== 1) {
     return { ok: false, error: "not-found" };
   }
 


### PR DESCRIPTION
## Summary

Implements story #307: story: deleteCheckIn is owner-scoped

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 2
- Prompt tokens: 16300
- Output tokens: 871

Closes #307

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-21T21:20:24Z)
- lint: ✓ exit 0 (run at 2026-08-21T21:20:15Z)
- test: ✓ exit 0 (run at 2026-08-21T21:20:16Z)
