### PR TITLE
feat(#306): story: createCheckIn verifies lane ownership

### DIFF
--- a/src/app/actions/createCheckIn.test.ts
+++ b/src/app/actions/createCheckIn.test.ts
@@ -1,20 +1,57 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
+import { requireUserId } from '@/lib/tenancy'
 import { createCheckIn } from './createCheckIn'
 
-vi.mock('@/lib/db', () => ({ prisma: { checkIn: { upsert: vi.fn() } } }))
+vi.mock('@/lib/db', () => ({ prisma: { checkIn: { upsert: vi.fn() }, lane: { findFirst: vi.fn() } } }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
 
 const date = new Date(Date.UTC(2026, 0, 5))
 
 describe('createCheckIn', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+  })
+
+  it('a foreign lane returns not-found before writing', async () => {
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue(null)
+
+    const result = await createCheckIn({
+      laneId: 'lane-foreign',
+      date,
+      isRest: false,
+      note: 'test'
+    })
+
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+    expect(prisma.checkIn.upsert).not.toHaveBeenCalled()
+  })
 
   it('valid check-in upserts and returns ok', async () => {
-    vi.mocked(prisma.checkIn.upsert).mockResolvedValue({ id: 'ci-1' } as never)
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue({
+      id: 'lane-1',
+      userId: 'u1',
+      name: 'Test Lane',
+      emoji: '🚀',
+      targetPerWeek: 3,
+      isActive: true,
+      sortOrder: 1,
+      createdAt: new Date(0),
+      checkIns: [],
+      bossBattles: [],
+      streakFreezes: []
+    } as any)
+    vi.mocked(prisma.checkIn.upsert).mockResolvedValue({ id: 'ci-1' } as any)
 
-    const result = await createCheckIn({ laneId: 'lane-1', date, isRest: false })
+    const result = await createCheckIn({
+      laneId: 'lane-1',
+      date,
+      isRest: false,
+      note: 'test'
+    })
 
     expect(result).toEqual({ ok: true, id: 'ci-1' })
     expect(prisma.checkIn.upsert).toHaveBeenCalledOnce()
@@ -25,7 +62,7 @@ describe('createCheckIn', () => {
   })
 
   it('missing laneId returns validation error without db call', async () => {
-    const result = await createCheckIn({ date, isRest: false })
+    const result = await createCheckIn({ date, iserm: false })
 
     expect(result).toEqual({ ok: false, error: 'validation' })
     expect(prisma.checkIn.upsert).not.toHaveBeenCalled()

--- a/src/app/actions/createCheckIn.ts
+++ b/src/app/actions/createCheckIn.ts
@@ -1,16 +1,28 @@
 import { prisma } from "@/lib/db";
 import { checkInSchema } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
+import { requireUserId } from "@/lib/tenancy";
 
 export async function createCheckIn(
   input: unknown
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const userId = await requireUserId();
+
   const parsed = checkInSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: "validation" };
   }
 
   const { laneId, date, isRest, note } = parsed.data;
+
+  const lane = await prisma.lane.findFirst({
+    where: { id: laneId, userId },
+  });
+
+  if (!lane) {
+    return { ok: false, error: "not-found" };
+  }
+
   const checkIn = await prisma.checkIn.upsert({
     where: { laneId_date: { laneId, date } },
     update: { isRest, note },


### PR DESCRIPTION
## Summary

Implements story #306: story: createCheckIn verifies lane ownership

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 23530
- Output tokens: 1855

Closes #306

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-21T21:24:14Z)
- lint: ✓ exit 0 (run at 2026-08-21T21:24:04Z)
- test: ✓ exit 0 (run at 2026-08-21T21:24:05Z)
