### PR TITLE
feat(#309): story: createReflection — per-user upsert, coach cap, player prompt

### DIFF
--- a/src/app/actions/createReflection.test.ts
+++ b/src/app/actions/createReflection.test.ts
@@ -3,19 +3,59 @@ import { prisma } from '@/lib/db'
 import { generate } from '@/lib/llm'
 import { revalidatePath } from 'next/cache'
 import { createReflection } from './createReflection'
+import { requireUserId } from '@/lib/tenancy'
 
-vi.mock('@/lib/db', () => ({ prisma: { weeklyReflection: { upsert: vi.fn() } } }))
+vi.mock('@/lib/db', () => ({ prisma: { weeklyReflection: { upsert: vi.fn(), count: vi.fn() } } }))
 vi.mock('@/lib/llm', () => ({ generate: vi.fn() }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
 
 const weekStarting = new Date(Date.UTC(2026, 0, 5))
 
 describe('createReflection', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+  })
+
+  it('the upsert is keyed to the signed-in user', async () => {
+    vi.mocked(generate).mockResolvedValue('Summary text')
+    vi.mocked(prisma.weeklyReflection.upsert).mockResolvedValue({ id: 'wr-1' } as never)
+    vi.mocked(prisma.weeklyReflection.count).mockResolvedValue(0)
+
+    await createReflection({
+      weekStarting,
+      playerNote: 'Trained four days.',
+    })
+
+    const arg = vi.mocked(prisma.weeklyReflection.upsert).mock.calls[0][0]
+    expect(arg.where).toEqual({
+      userId_weekStarting: {
+        userId: 'u1',
+        weekStarting,
+      },
+    })
+    expect(arg.create).toMatchObject({ userId: 'u1' })
+  })
+
+  it('over the daily cap returns coach-limit without calling generate', async () => {
+    vi.mocked(prisma.weeklyReflection.count).mockResolvedValue(10)
+    // Assuming COACH_DAILY_LIMIT is set to something like 5 in env for this test
+    process.env.COACH_DAILY_LIMIT = '5'
+
+    const result = await createReflection({
+      weekStarting,
+      playerNote: 'Trained four days.',
+    })
+
+    expect(result).toEqual({ ok: false, error: 'coach-limit' })
+    expect(generate).not.toHaveBeenCalled()
+  })
 
   it('valid input calls generate and upserts with coachSummary', async () => {
     vi.mocked(generate).mockResolvedValue('You stayed consistent all week — that is the habit taking hold.')
     vi.mocked(prisma.weeklyReflection.upsert).mockResolvedValue({ id: 'wr-1' } as never)
+    vi.mocked(prisma.weeklyReflection.count).mockResolvedValue(0)
 
     const result = await createReflection({
       weekStarting,
@@ -25,7 +65,12 @@ describe('createReflection', () => {
     expect(result).toEqual({ ok: true, id: 'wr-1', coachSummary: 'You stayed consistent all week — that is the habit taking hold.' })
     expect(generate).toHaveBeenCalledOnce()
     const arg = vi.mocked(prisma.weeklyReflection.upsert).mock.calls[0][0]
-    expect(arg.where).toEqual({ weekStarting })
+    expect(arg.where).toEqual({
+      userId_weekStarting: {
+        userId: 'u1',
+        weekStarting,
+      },
+    })
     expect(arg.create).toMatchObject({ coachSummary: 'You stayed consistent all week — that is the habit taking hold.' })
     expect(revalidatePath).toHaveBeenCalledWith('/reflection')
   })

--- a/src/app/actions/createReflection.ts
+++ b/src/app/actions/createReflection.ts
@@ -2,24 +2,39 @@ import { prisma } from "@/lib/db";
 import { reflectionSchema } from "@/lib/validation";
 import { generate } from "@/lib/llm";
 import { revalidatePath } from "next/cache";
+import { requireUserId } from "@/lib/tenancy";
+import { getTrainingDay } from "@/lib/trainingDay";
+import { coachCapExceeded } from "@/lib/llmCap";
 
 export async function createReflection(
   input: unknown
 ): Promise<{ ok: true; id: string; coachSummary: string } | { ok: false; error: string }> {
+  const userId = await requireUserId();
+
   const parsed = reflectionSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: "validation" };
   }
 
   const { weekStarting, playerNote } = parsed.data;
-  const prompt = `You are an effort-focused coach. Summarize Eddie's weekly reflection in 2-3 encouraging, process-framed sentences — never grades, never 'great job' filler: "${playerNote}".`;
+
+  const todayStart = getTrainingDay(new Date());
+  const todayCount = await prisma.weeklyReflection.count({
+    where: { userId, createdAt: { gte: todayStart } },
+  });
+
+  if (coachCapExceeded(todayCount, process.env.COACH_DAILY_LIMIT)) {
+    return { ok: false, error: "coach-limit" };
+  }
+
+  const prompt = `You are an effort-focused coach. Summarize the player's weekly reflection in 2-3 encouraging, process-framed sentences — never grades, never 'great job' filler: "${playerNote}".`;
   // If generate() throws, let it propagate — the caller handles it.
   const coachSummary = await generate(prompt);
 
   const reflection = await prisma.weeklyReflection.upsert({
-    where: { weekStarting },
+    where: { userId_weekStarting: { userId, weekStarting } },
     update: { playerNote, coachSummary },
-    create: { weekStarting, playerNote, coachSummary },
+    create: { userId, weekStarting, playerNote, coachSummary },
   });
 
   revalidatePath("/reflection");


### PR DESCRIPTION
## Summary

Implements story #309: story: createReflection — per-user upsert, coach cap, player prompt

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 4
- Prompt tokens: 34396
- Output tokens: 3144

Closes #309

Co-Authored-By: gemma4:26b (Spike coder) <noreply@spike.local>

## Verified gates *(auto-captured by spike-guard)*

- build: ✓ exit 0 (run at 2026-08-21T21:38:49Z)
- lint: ✓ exit 0 (run at 2026-08-21T21:38:43Z)
- test: ✓ exit 0 (run at 2026-08-21T21:38:44Z)
