### PR TITLE
fix: JWT sessions — stay signed in across visits

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,19 +10,30 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // the claim script pre-creates the owner's User row, and this lets the
     // first Google sign-in attach to it instead of throwing
     // OAuthAccountNotLinked.
-    Google({ allowDangerousEmailAccountLinking: true }),
+    Google({
+      allowDangerousEmailAccountLinking: true,
+      // A returning user gets the one-tap account chooser, not the full
+      // consent screen (the provider default is prompt=consent).
+      authorization: { params: { prompt: "select_account" } },
+    }),
   ],
-  session: { strategy: "database" },
+  // JWT sessions: a signed 30-day rolling cookie the proxy can verify
+  // WITHOUT a database read. Database sessions were unreadable in the
+  // proxy layer, so every fresh visit bounced to /signin despite a valid
+  // cookie. The Prisma adapter still stores users/accounts; only session
+  // storage moves into the cookie.
+  session: { strategy: "jwt" },
   callbacks: {
     authorized({ auth, request }) {
       const { pathname } = request.nextUrl
       if (pathname === "/signin") return true
       return !!auth?.user
     },
-    session({ session, user }) {
+    session({ session, token }) {
       // Every scoped query keys off session.user.id — without this copy the
-      // id is undefined and scoping silently matches nothing.
-      session.user.id = user.id
+      // id is undefined and scoping silently matches nothing. With JWT
+      // sessions the id rides in token.sub.
+      if (token?.sub) session.user.id = token.sub
       return session
     },
   },


### PR DESCRIPTION
Database sessions can't be read reliably in the proxy layer, so every fresh visit challenged a validly signed-in user. JWT strategy moves the session into a signed 30-day rolling cookie the proxy verifies without touching the DB; `token.sub` carries the adapter user id so all owner scoping is unchanged. Bonus: `prompt=select_account` makes a re-login one tap instead of the full Google consent screen.

Gates: 269 tests green, tsc clean, lint 0 errors, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3