### PR TITLE
feat: BossBattle.rerollCount (schema for the levels-that-matter epic)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,8 @@ model BossBattle {
   // completedAt is set — by doing it, not describing it.
   challenge    String?
   completedAt  DateTime?
-  rerolled     Boolean  @default(false) // one re-roll per battle
+  rerolled     Boolean  @default(false) // legacy boolean (drop after rerollCount migration)
+  rerollCount  Int      @default(0) // re-rolls used; allowance scales with rank (knight+ gets 2)
   selfReport   String? // legacy free-text (pre-challenge battles)
   coachNote    String? // AI hype note, written at victory
   createdAt    DateTime @default(now())


### PR DESCRIPTION
Additive schema for the approved plan — re-roll allowance will scale with rank (knight+ gets 2). Merging this unblocks the 12-story grind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3