### PR TITLE
fix: dependabot vulnerabilities (deepmerge-ts override)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "overrides": {
       "nanoid": "^3.3.17",
       "postcss": "^8.5.23",
-      "js-yaml": "^4.3.1"
+      "js-yaml": "^4.3.1",
+      "deepmerge-ts": "^8.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   nanoid: ^3.3.17
   postcss: ^8.5.23
   js-yaml: ^4.3.1
+  deepmerge-ts: ^8.0.0
 
 importers:
 
@@ -1368,9 +1369,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
+  deepmerge-ts@8.0.2:
+    resolution: {integrity: sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==}
+    engines: {node: '>=16.9.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -3324,7 +3325,7 @@ snapshots:
   '@prisma/config@6.19.3':
     dependencies:
       c12: 3.1.0
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.2
       effect: 3.21.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -4051,7 +4052,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.2: {}
 
   define-data-property@1.1.4:
     dependencies:


### PR DESCRIPTION
Closes the one genuinely unpatched alert: `deepmerge-ts` 7.x (high — stack exhaustion) forced to 8.0.2 via pnpm override, since `@prisma/config` pins 7.x. Prisma validate/generate fine, 301 tests green, build passes.

The other three alerts (nanoid, js-yaml, postcss) are already at patched versions in the lockfile — they should auto-close when Dependabot re-scans after this merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgUuHL6M6pBwuwozBPFph3