### PR TITLE
fix: lanes start in the coming week, not mid-week

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,24 +9,46 @@ datasource db {
 
 // Lane — a skill domain Eddie trains (e.g. "Stick Skills", "Shooting", "Conditioning")
 model Lane {
-  id            String   @id @default(cuid())
+  id            String    @id @default(cuid())
   // Nullable during the two-phase rollout; tightened to required once the
   // claim script has bound the pre-auth rows to their owner.
   userId        String?
-  user          User?    @relation(fields: [userId], references: [id])
+  user          User?     @relation(fields: [userId], references: [id])
   name          String
-  emoji         String   @default("🥍")
-  targetPerWeek Int      @default(5) // days/week target frequency
-  isActive      Boolean  @default(true)
-  sortOrder     Int      @default(0)
-  createdAt     DateTime @default(now())
+  emoji         String    @default("🥍")
+  targetPerWeek Int       @default(5) // days/week target frequency
+  isActive      Boolean   @default(true)
+  sortOrder     Int       @default(0)
+  // The Monday this lane begins counting. A lane added or activated mid-week
+  // starts on the NEXT Monday, so it is never scored against a partial week it
+  // could not have hit. NULL = pre-existing lane, in effect since the season began.
+  startsOn      DateTime?
+  createdAt     DateTime  @default(now())
 
   checkIns      CheckIn[]
   bossBattles   BossBattle[]
   streakFreezes StreakFreeze[]
+  targetChanges LaneTarget[]
 
   @@index([isActive])
   @@index([userId, isActive])
+}
+
+// LaneTarget — a weekly target that takes effect from a given Monday.
+// Targets are effective-dated instead of overwritten because the season grid
+// re-scores every finished week on each render: a single mutable number would
+// let a change made today un-qualify weeks already earned. `Lane.targetPerWeek`
+// remains the original target and the fallback for weeks before any change.
+model LaneTarget {
+  id            String   @id @default(cuid())
+  laneId        String
+  lane          Lane     @relation(fields: [laneId], references: [id], onDelete: Cascade)
+  target        Int
+  effectiveFrom DateTime // UTC midnight of the Monday it takes effect
+  createdAt     DateTime @default(now())
+
+  @@unique([laneId, effectiveFrom])
+  @@index([laneId, effectiveFrom])
 }
 
 // CheckIn — Eddie's daily self-report for a lane session
@@ -46,20 +68,20 @@ model CheckIn {
 
 // BossBattle — every 2-week skill test for a lane
 model BossBattle {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   laneId       String
-  lane         Lane     @relation(fields: [laneId], references: [id], onDelete: Cascade)
+  lane         Lane      @relation(fields: [laneId], references: [id], onDelete: Cascade)
   weekStarting DateTime // UTC midnight of the Monday starting the 2-week block
   // The boss IS a generated real-world challenge derived from the lane
   // ("3 sets of 5 pushups" spawns "3 sets of 5 burpees"). Defeated when
   // completedAt is set — by doing it, not describing it.
   challenge    String?
   completedAt  DateTime?
-  rerolled     Boolean  @default(false) // legacy boolean (drop after rerollCount migration)
-  rerollCount  Int      @default(0) // re-rolls used; allowance scales with rank (knight+ gets 2)
+  rerolled     Boolean   @default(false) // legacy boolean (drop after rerollCount migration)
+  rerollCount  Int       @default(0) // re-rolls used; allowance scales with rank (knight+ gets 2)
   selfReport   String? // legacy free-text (pre-challenge battles)
   coachNote    String? // AI hype note, written at victory
-  createdAt    DateTime @default(now())
+  createdAt    DateTime  @default(now())
 
   @@unique([laneId, weekStarting])
   @@index([weekStarting])
@@ -91,6 +113,7 @@ model Prize {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 }
+
 // ---- Auth.js (next-auth v5 Prisma adapter) --------------------------------
 
 model User {
@@ -102,10 +125,10 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  accounts    Account[]
-  sessions    Session[]
-  lanes       Lane[]
-  prize       Prize?
+  accounts Account[]
+  sessions Session[]
+  lanes    Lane[]
+  prize    Prize?
 }
 
 model Account {

--- a/src/app/actions/createLane.test.ts
+++ b/src/app/actions/createLane.test.ts
@@ -35,9 +35,48 @@ describe('createLane', () => {
       data: {
         ...input,
         sortOrder: 0,
-        userId: 'u1'
+        userId: 'u1',
+        startsOn: expect.any(Date)
       }
     })
+  })
+
+  it('a lane added mid-week starts on the coming Monday', async () => {
+    vi.useFakeTimers()
+    // Sunday — the last day of the week, when a fresh 5-a-week target would
+    // otherwise be unreachable the moment it is created.
+    vi.setSystemTime(new Date('2026-08-23T18:00:00.000Z'))
+    vi.mocked(prisma.lane.create).mockResolvedValue({ id: 'lane-1' } as any)
+
+    await createLane({ name: 'Squats', emoji: '🏋', targetPerWeek: 5 })
+
+    const data = vi.mocked(prisma.lane.create).mock.calls[0][0].data as {
+      startsOn: Date
+    }
+    expect(data.startsOn.toISOString()).toBe('2026-08-24T00:00:00.000Z')
+    vi.useRealTimers()
+  })
+
+  it('a lane added on a Monday starts that same Monday', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-24T18:00:00.000Z'))
+    vi.mocked(prisma.lane.create).mockResolvedValue({ id: 'lane-1' } as any)
+
+    await createLane({ name: 'Squats', emoji: '🏋', targetPerWeek: 5 })
+
+    const data = vi.mocked(prisma.lane.create).mock.calls[0][0].data as {
+      startsOn: Date
+    }
+    expect(data.startsOn.toISOString()).toBe('2026-08-24T00:00:00.000Z')
+    vi.useRealTimers()
+  })
+
+  it('adding a lane refreshes Today, not just the Lanes page', async () => {
+    vi.mocked(prisma.lane.create).mockResolvedValue({ id: 'lane-1' } as any)
+
+    await createLane({ name: 'Squats', emoji: '🏋', targetPerWeek: 5 })
+
+    expect(revalidatePath).toHaveBeenCalledWith('/')
   })
 
   it('valid input creates lane and returns ok', async () => {

--- a/src/app/actions/createLane.ts
+++ b/src/app/actions/createLane.ts
@@ -2,6 +2,8 @@ import { prisma } from "@/lib/db";
 import { laneSchema } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
 import { requireUserId } from "@/lib/tenancy";
+import { resolveSeasonStart } from "@/lib/seasonAnchor";
+import { getTrainingDay } from "@/lib/trainingDay";
 
 export async function createLane(
   input: unknown
@@ -12,10 +14,17 @@ export async function createLane(
     return { ok: false, error: "validation" };
   }
 
+  // A new lane begins on the Monday on or after today, so it always gets a
+  // whole week to hit its target rather than being scored against the days
+  // that happen to be left.
+  const startsOn = resolveSeasonStart(getTrainingDay(new Date()));
+
   const lane = await prisma.lane.create({
-    data: { ...parsed.data, sortOrder: 0, userId },
+    data: { ...parsed.data, sortOrder: 0, userId, startsOn },
   });
 
   revalidatePath("/lanes");
+  // Today lists the active lanes, so it goes stale the moment one is added.
+  revalidatePath("/");
   return { ok: true, id: lane.id };
 }

--- a/src/app/actions/setLaneActive.test.ts
+++ b/src/app/actions/setLaneActive.test.ts
@@ -8,8 +8,9 @@ import { requiredLanes } from '@/lib/laneRequirement'
 
 vi.mock('@/lib/db', () => ({ 
   prisma: { 
-    lane: { updateMany: vi.fn(), count: vi.fn() },
-    bossBattle: { count: vi.fn() }
+    lane: { updateMany: vi.fn(), count: vi.fn(), findFirst: vi.fn() },
+    bossBattle: { count: vi.fn() },
+    checkIn: { count: vi.fn() }
   } 
 }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
@@ -21,6 +22,10 @@ describe('setLaneActive', () => {
     vi.mocked(requireUserId).mockResolvedValue('u1')
     vi.mocked(prisma.lane.count).mockResolvedValue(4)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
+    // Default: the lane is retired and untouched this week, so switching it
+    // on is a genuine return from retirement.
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue({ isActive: false } as never)
+    vi.mocked(prisma.checkIn.count).mockResolvedValue(0)
   })
 
   it('deactivating below the demand floor is blocked', async () => {
@@ -46,7 +51,7 @@ describe('setLaneActive', () => {
     expect(result).toEqual({ ok: true })
     expect(prisma.lane.updateMany).toHaveBeenCalledWith({
       where: { id: 'lane-to-activate', userId: 'u1' },
-      data: { isActive: true },
+      data: { isActive: true, startsOn: expect.any(Date) },
     })
   })
 
@@ -64,6 +69,54 @@ describe('setLaneActive', () => {
     expect(revalidatePath).toHaveBeenCalledWith('/')
   })
 
+  it('reactivating a lane restarts it on the coming Monday', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-19T18:00:00.000Z')) // Wednesday
+    vi.mocked(prisma.lane.updateMany).mockResolvedValue({ count: 1 })
+
+    await setLaneActive('lane-back', true)
+
+    const data = vi.mocked(prisma.lane.updateMany).mock.calls[0][0].data as {
+      startsOn: Date
+    }
+    expect(data.startsOn.toISOString()).toBe('2026-08-24T00:00:00.000Z')
+    vi.useRealTimers()
+  })
+
+  it('retiring a lane never touches its start stamp', async () => {
+    vi.mocked(prisma.lane.updateMany).mockResolvedValue({ count: 1 })
+    vi.mocked(prisma.lane.count).mockResolvedValue(9)
+
+    await setLaneActive('lane-1', false)
+
+    const data = vi.mocked(prisma.lane.updateMany).mock.calls[0][0].data
+    expect(data).not.toHaveProperty('startsOn')
+  })
+
+  it('switching on a lane that is already active never benches it', async () => {
+    // A no-op call must not push a running lane's start into next week.
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue({ isActive: true } as never)
+    vi.mocked(prisma.lane.updateMany).mockResolvedValue({ count: 1 })
+
+    await setLaneActive('lane-running', true)
+
+    const data = vi.mocked(prisma.lane.updateMany).mock.calls[0][0].data
+    expect(data).not.toHaveProperty('startsOn')
+  })
+
+  it('an off-and-on mis-tap keeps a lane already trained this week running', async () => {
+    // Restarting it would hide check-ins from Today that the season grid
+    // still counts, so the two screens would disagree.
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue({ isActive: false } as never)
+    vi.mocked(prisma.checkIn.count).mockResolvedValue(3)
+    vi.mocked(prisma.lane.updateMany).mockResolvedValue({ count: 1 })
+
+    await setLaneActive('lane-mistap', true)
+
+    const data = vi.mocked(prisma.lane.updateMany).mock.calls[0][0].data
+    expect(data).not.toHaveProperty('startsOn')
+  })
+
   it('empty id returns missing-id without a db call', async () => {
     const result = await setLaneActive('', true)
     expect(result).toEqual({ ok: false, error: 'missing-id' })
@@ -78,7 +131,7 @@ describe('setLaneActive', () => {
     expect(result).toEqual({ ok: false, error: 'not-found' })
     expect(prisma.lane.updateMany).toHaveBeenCalledWith({
       where: { id: 'other-lane-id', userId: 'u1' },
-      data: { isActive: true },
+      data: { isActive: true, startsOn: expect.any(Date) },
     })
   })
 })

--- a/src/app/actions/setLaneActive.ts
+++ b/src/app/actions/setLaneActive.ts
@@ -3,6 +3,31 @@ import { revalidatePath } from "next/cache"
 import { requireUserId } from "@/lib/tenancy"
 import { playerLevel } from "@/lib/playerLevel"
 import { requiredLanes } from "@/lib/laneRequirement"
+import { resolveSeasonStart } from "@/lib/seasonAnchor"
+import { getTrainingDay } from "@/lib/trainingDay"
+import { getWeekStart } from "@/lib/weekUtils"
+
+/**
+ * Should switching this lane on push its start to the coming Monday?
+ *
+ * Only a lane genuinely returning from retirement restarts. Two cases must
+ * not: a lane that is already active (the call is a no-op, and re-stamping
+ * would bench a running lane), and a lane already trained this week — an
+ * off-and-on mis-tap would otherwise hide check-ins the season still counts,
+ * leaving the dashboard and the season grid telling different stories.
+ */
+async function shouldRestart(id: string, userId: string): Promise<boolean> {
+  const lane = await prisma.lane.findFirst({
+    where: { id, userId },
+    select: { isActive: true },
+  })
+  if (!lane || lane.isActive) return false
+
+  const hitsThisWeek = await prisma.checkIn.count({
+    where: { laneId: id, date: { gte: getWeekStart(getTrainingDay(new Date())) } },
+  })
+  return hitsThisWeek === 0
+}
 
 export async function setLaneActive(
   id: string,
@@ -31,9 +56,18 @@ export async function setLaneActive(
   }
 
   try {
+    const data: { isActive: boolean; startsOn?: Date } = { isActive }
+
+    if (isActive && (await shouldRestart(id, userId))) {
+      // Coming back into play restarts the clock: the lane gets its first
+      // whole week rather than the remainder of this one. Retiring leaves the
+      // stamp alone — there is nothing to schedule.
+      data.startsOn = resolveSeasonStart(getTrainingDay(new Date()))
+    }
+
     const { count } = await prisma.lane.updateMany({
       where: { id, userId },
-      data: { isActive },
+      data,
     })
 
     if (count !== 1) {

--- a/src/app/actions/swapLane.test.ts
+++ b/src/app/actions/swapLane.test.ts
@@ -90,7 +90,33 @@ describe('swapLane', () => {
     })
     expect(prisma.lane.update).toHaveBeenCalledWith({
       where: { id: 'lane-9' },
-      data: { isActive: true },
+      data: { isActive: true, startsOn: expect.any(Date) },
+    })
+  })
+
+  it('the lane swapped in starts on the coming Monday, not mid-week', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-23T18:00:00.000Z')) // Sunday
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+
+    await swapLane({ outLaneId: 'lane-2', inLaneId: 'lane-9' })
+
+    const inCall = vi
+      .mocked(prisma.lane.update)
+      .mock.calls.find((c) => c[0].where.id === 'lane-9')!
+    const data = inCall[0].data as { startsOn: Date }
+    expect(data.startsOn.toISOString()).toBe('2026-08-24T00:00:00.000Z')
+    vi.useRealTimers()
+  })
+
+  it('retiring a lane leaves its start stamp alone', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(4)
+
+    await swapLane({ outLaneId: 'lane-2' })
+
+    expect(prisma.lane.update).toHaveBeenCalledWith({
+      where: { id: 'lane-2' },
+      data: { isActive: false },
     })
   })
 

--- a/src/app/actions/swapLane.ts
+++ b/src/app/actions/swapLane.ts
@@ -7,6 +7,8 @@ import { validateSwap } from '@/lib/validateSwap'
 import { requireUserId } from '@/lib/tenancy'
 import { playerLevel } from '@/lib/playerLevel'
 import { requiredLanes } from '@/lib/laneRequirement'
+import { resolveSeasonStart } from '@/lib/seasonAnchor'
+import { getTrainingDay } from '@/lib/trainingDay'
 
 type SwapResult = { ok: true } | { ok: false; error: string }
 
@@ -61,9 +63,15 @@ export async function swapLane(input: unknown): Promise<SwapResult> {
   }
 
   if (inLaneId) {
+    // The lane coming in starts on the Monday on or after today. Swapping on a
+    // Friday must not hand it a two-day week it cannot win.
+    const startsOn = resolveSeasonStart(getTrainingDay(new Date()))
     await prisma.$transaction([
       prisma.lane.update({ where: { id: outLaneId }, data: { isActive: false } }),
-      prisma.lane.update({ where: { id: inLaneId }, data: { isActive: true } }),
+      prisma.lane.update({
+        where: { id: inLaneId },
+        data: { isActive: true, startsOn },
+      }),
     ])
   } else {
     await prisma.lane.update({

--- a/src/app/actions/updateLane.test.ts
+++ b/src/app/actions/updateLane.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { prisma as db } from '@/lib/db'
 import type { Lane } from '@prisma/client'
 import { updateLane } from './updateLane'
@@ -61,6 +61,10 @@ vi.mock('@/lib/db', () => ({
       upsert: vi.fn(),
       count: vi.fn(),
     },
+    laneTarget: {
+      upsert: vi.fn(),
+      findMany: vi.fn(),
+    },
     streakFreeze: {
       create: vi.fn(),
       createMany: vi.fn(),
@@ -113,6 +117,9 @@ describe('updateLane', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(db.lane.findFirst).mockResolvedValue(
+      makeLane({ id: 'lane-123', targetPerWeek: 3, targetChanges: [] } as never)
+    )
   })
 
   it('valid patch updates lane and returns ok', async () => {
@@ -138,10 +145,9 @@ describe('updateLane', () => {
     const result = await updateLane(id, patch)
 
     expect(result).toEqual({ ok: true })
-    expect(db.lane.updateMany).toHaveBeenCalledWith({
-      where: { id, userId: 'u1' },
-      data: {},
-    })
+    // Nothing to write, so the row is left alone rather than issued an
+    // empty update — which real Prisma reports as zero rows matched.
+    expect(db.lane.updateMany).not.toHaveBeenCalled()
     expect(revalidatePath).toHaveBeenCalledWith('/lanes')
   })
 
@@ -166,11 +172,12 @@ describe('updateLane', () => {
   })
 
   it("another user's lane id returns not-found", async () => {
-    vi.mocked(db.lane.updateMany).mockResolvedValue({ count: 0 })
+    vi.mocked(db.lane.findFirst).mockResolvedValue(null)
 
     const result = await updateLane('foreign-lane', { name: 'X' })
 
     expect(result).toEqual({ ok: false, error: 'not-found' })
+    expect(db.lane.updateMany).not.toHaveBeenCalled()
     expect(revalidatePath).not.toHaveBeenCalled()
   })
 
@@ -183,5 +190,143 @@ describe('updateLane', () => {
       where: { id: 'lane-1', userId: 'u1' },
       data: { name: 'X' },
     })
+  })
+})
+
+describe('updateLane — a new target starts next week', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(db.lane.updateMany).mockResolvedValue({ count: 1 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('schedules the target for the coming Monday instead of writing it now', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-19T18:00:00.000Z')) // Wednesday
+    vi.mocked(db.lane.findFirst).mockResolvedValue(
+      makeLane({ id: 'lane-1', targetPerWeek: 3, targetChanges: [] } as never)
+    )
+
+    const result = await updateLane('lane-1', { targetPerWeek: 5 })
+
+    expect(result).toEqual({ ok: true })
+    // The column itself is never touched — that is what would re-score history
+    // — and with nothing else in the patch the row is not written at all.
+    expect(db.lane.updateMany).not.toHaveBeenCalled()
+    expect(db.laneTarget.upsert).toHaveBeenCalledWith({
+      where: {
+        laneId_effectiveFrom: {
+          laneId: 'lane-1',
+          effectiveFrom: new Date('2026-08-24T00:00:00.000Z'),
+        },
+      },
+      update: { target: 5 },
+      create: {
+        laneId: 'lane-1',
+        target: 5,
+        effectiveFrom: new Date('2026-08-24T00:00:00.000Z'),
+      },
+    })
+  })
+
+  it('applies a rename at once while deferring the target', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-19T18:00:00.000Z'))
+    vi.mocked(db.lane.findFirst).mockResolvedValue(
+      makeLane({ id: 'lane-1', targetPerWeek: 3, targetChanges: [] } as never)
+    )
+
+    await updateLane('lane-1', { name: 'Wall ball', targetPerWeek: 5 })
+
+    expect(db.lane.updateMany).toHaveBeenCalledWith({
+      where: { id: 'lane-1', userId: 'u1' },
+      data: { name: 'Wall ball' },
+    })
+    expect(db.laneTarget.upsert).toHaveBeenCalled()
+  })
+
+  it('a rename that resubmits the same target schedules nothing', async () => {
+    // The edit form always posts all three fields, so an unchanged number must
+    // not litter the lane with no-op scheduled changes.
+    vi.mocked(db.lane.findFirst).mockResolvedValue(
+      makeLane({ id: 'lane-1', targetPerWeek: 3, targetChanges: [] } as never)
+    )
+
+    await updateLane('lane-1', { name: 'Renamed', targetPerWeek: 3 })
+
+    expect(db.laneTarget.upsert).not.toHaveBeenCalled()
+  })
+
+  it('a second edit before Monday replaces the queued change', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-19T18:00:00.000Z'))
+    const effectiveFrom = new Date('2026-08-24T00:00:00.000Z')
+    vi.mocked(db.lane.findFirst).mockResolvedValue(
+      makeLane({
+        id: 'lane-1',
+        targetPerWeek: 3,
+        targetChanges: [{ target: 5, effectiveFrom }],
+      } as never)
+    )
+
+    await updateLane('lane-1', { targetPerWeek: 7 })
+
+    // Same key, so it upserts over the pending row rather than stacking a
+    // second change for the same Monday.
+    expect(db.laneTarget.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { laneId_effectiveFrom: { laneId: 'lane-1', effectiveFrom } },
+        update: { target: 7 },
+      })
+    )
+  })
+
+  it("a foreign lane never reaches the target schedule", async () => {
+    vi.mocked(db.lane.findFirst).mockResolvedValue(null)
+
+    const result = await updateLane('foreign', { targetPerWeek: 7 })
+
+    expect(result).toEqual({ ok: false, error: 'not-found' })
+    expect(db.laneTarget.upsert).not.toHaveBeenCalled()
+  })
+})
+
+describe('updateLane — ownership is never proved by an empty update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(db.lane.findFirst).mockResolvedValue(
+      makeLane({ id: 'lane-1', targetPerWeek: 3, targetChanges: [] } as never)
+    )
+    vi.mocked(db.lane.updateMany).mockResolvedValue({ count: 1 })
+  })
+
+  // Real Prisma returns { count: 0 } for updateMany with an empty `data`, even
+  // for a row that exists and is owned. Gating not-found on that count made
+  // every target-only edit report "not-found" and silently drop the change.
+  // Mocks cannot reproduce that, so the contract is asserted instead: an
+  // update is only ever issued when there is something to write.
+  it.each([
+    ['target only', { targetPerWeek: 5 }],
+    ['empty patch', {}],
+    ['name only', { name: 'Renamed' }],
+    ['name and target', { name: 'Renamed', targetPerWeek: 5 }],
+  ])('%s never issues an update with nothing to write', async (_label, patch) => {
+    await updateLane('lane-1', patch)
+
+    for (const call of vi.mocked(db.lane.updateMany).mock.calls) {
+      expect(Object.keys(call[0].data as object).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('a target-only edit still schedules the change', async () => {
+    const result = await updateLane('lane-1', { targetPerWeek: 5 })
+
+    expect(result).toEqual({ ok: true })
+    expect(db.laneTarget.upsert).toHaveBeenCalled()
   })
 })

--- a/src/app/actions/updateLane.ts
+++ b/src/app/actions/updateLane.ts
@@ -2,10 +2,18 @@ import { prisma as db } from "@/lib/db";
 import { laneSchema } from "@/lib/validation";
 import { requireUserId } from "@/lib/tenancy";
 import { revalidatePath } from "next/cache";
+import { resolveSeasonStart } from "@/lib/seasonAnchor";
+import { getTrainingDay } from "@/lib/trainingDay";
+import { effectiveTarget } from "@/lib/effectiveTarget";
 
 /**
  * Updates a lane with a partial patch.
  * Validates the patch using laneSchema.partial().
+ *
+ * Name and emoji apply at once — they carry no score. A new weekly target does
+ * not: it is scheduled for the Monday on or after today, so the week in
+ * progress is judged by the target it was started under and finished weeks can
+ * never be re-scored by a later edit.
  */
 export async function updateLane(id: string, patch: unknown): Promise<{ ok: true } | { ok: false; error: string }> {
   const userId = await requireUserId();
@@ -17,17 +25,49 @@ export async function updateLane(id: string, patch: unknown): Promise<{ ok: true
       return { ok: false, error: "validation" };
     }
 
-    // Owner-scoped: updateMany matches zero rows for a foreign lane.
-    const { count } = await db.lane.updateMany({
+    const { targetPerWeek, ...immediate } = parsed.data;
+
+    // Ownership is proved by the read, not by an update's row count: a
+    // target-only edit has nothing to write to the row, and `updateMany` with
+    // an empty `data` reports count 0 even for a row that exists and is owned
+    // — which would read as "not-found" and drop the edit on the floor.
+    const lane = await db.lane.findFirst({
       where: { id, userId },
-      data: parsed.data,
+      include: { targetChanges: true },
     });
-    if (count !== 1) {
+    if (!lane) {
       return { ok: false, error: "not-found" };
     }
 
-    // Revalidate the lanes path to ensure the UI reflects the change
+    if (Object.keys(immediate).length > 0) {
+      await db.lane.updateMany({ where: { id, userId }, data: immediate });
+    }
+
+    if (targetPerWeek !== undefined) {
+      const effectiveFrom = resolveSeasonStart(getTrainingDay(new Date()));
+
+      // Saving the edit form resubmits the target even when only the name
+      // changed, so only schedule a row when the number actually moves.
+      const alreadyScheduled = effectiveTarget(
+        lane.targetChanges,
+        effectiveFrom,
+        lane.targetPerWeek
+      );
+
+      if (alreadyScheduled !== targetPerWeek) {
+        await db.laneTarget.upsert({
+          where: { laneId_effectiveFrom: { laneId: id, effectiveFrom } },
+          update: { target: targetPerWeek },
+          create: { laneId: id, target: targetPerWeek, effectiveFrom },
+        });
+      }
+    }
+
     revalidatePath("/lanes");
+    // A renamed lane or a rescheduled target changes what Today and the boss
+    // hub render, so neither may keep a cached copy.
+    revalidatePath("/");
+    revalidatePath("/boss-battles");
 
     return { ok: true };
   } catch (err) {

--- a/src/app/boss-battles/page.test.tsx
+++ b/src/app/boss-battles/page.test.tsx
@@ -75,6 +75,69 @@ describe('Page', () => {
     }))
   })
 
+  it('a lane that only started this Monday wakes no boss for last week', async () => {
+    // The swap case: a lane traded back in mid-week starts the coming Monday,
+    // and check-ins left over from an earlier stint must not wake a grace
+    // boss for a week it spent retired. `startsOn` equals this week's Monday,
+    // so a guard tested against THIS week would let it through.
+    const trainingDay = getTrainingDay(new Date())
+    const thisWeekStart = getWeekStart(trainingDay)
+    const lastWeekStart = getLastCompletedWeekStart(trainingDay)
+
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 2,
+      isActive: true,
+      sortOrder: 1,
+      startsOn: thisWeekStart,
+      checkIns: [
+        { date: new Date(lastWeekStart.getTime() + 86400000), laneId: 'l1', isRest: false },
+        { date: new Date(lastWeekStart.getTime() + 172800000), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(screen.queryByText(/Last week's unfought boss/)).not.toBeInTheDocument()
+  })
+
+  it('a lane running last week still gets its grace boss', async () => {
+    // The control for the test above: same data, but the lane started before
+    // last week, so the guard must not swallow a boss it genuinely earned.
+    const trainingDay = getTrainingDay(new Date())
+    const lastWeekStart = getLastCompletedWeekStart(trainingDay)
+
+    const lane = {
+      id: 'l1',
+      name: 'Strength',
+      emoji: '💪',
+      targetPerWeek: 2,
+      isActive: true,
+      sortOrder: 1,
+      startsOn: new Date(lastWeekStart.getTime() - 7 * 86400000),
+      checkIns: [
+        { date: new Date(lastWeekStart.getTime() + 86400000), laneId: 'l1', isRest: false },
+        { date: new Date(lastWeekStart.getTime() + 172800000), laneId: 'l1', isRest: false },
+      ],
+      bossBattles: [],
+    } as any
+
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([lane])
+
+    const PageComponent = await Page()
+    render(PageComponent)
+
+    expect(
+      screen.getByText(`Last week's unfought boss — ${formatWeekLabel(lastWeekStart)}`)
+    ).toBeInTheDocument()
+  })
+
   it('an unfought last-week victory stays fightable', async () => {
     const trainingDay = getTrainingDay(new Date())
     const thisWeekStart = getWeekStart(trainingDay)

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -11,6 +11,8 @@ import { swapLane } from "@/app/actions/swapLane"
 import { validateSwap } from "@/lib/validateSwap"
 import { playerLevel } from "@/lib/playerLevel"
 import { requiredLanes } from "@/lib/laneRequirement"
+import { isLanePending } from "@/lib/lanePending"
+import { effectiveTarget } from "@/lib/effectiveTarget"
 
 export const dynamic = "force-dynamic"
 
@@ -70,6 +72,7 @@ export default async function BossBattlesPage() {
           weekStarting: { in: [lastWeekStart, thisWeekStart] },
         },
       },
+      targetChanges: true,
     },
   })
 
@@ -88,13 +91,24 @@ export default async function BossBattlesPage() {
   // A last-week boss stays fightable for one grace week when its target was
   // hit but the boss was never DEFEATED.
   const graceLanes = lanes.filter((lane) => {
+    // Tested against LAST week, the week being judged — not against this one.
+    // A lane that only started this Monday was not running then, and a
+    // swapped-in lane can still carry check-ins from an earlier stint that
+    // would otherwise wake a boss for a week it sat retired.
+    if (isLanePending(lane.startsOn, lastWeekStart)) return false
     const lastWeekHits = lane.checkIns.filter(
       (c) => c.date >= lastWeekStart && c.date < thisWeekStart
     ).length
     const lastWeekBattle = lane.bossBattles.find(
       (b) => b.weekStarting.getTime() === lastWeekStart.getTime()
     )
-    return lastWeekHits >= lane.targetPerWeek && !lastWeekBattle?.completedAt
+    // Judged by last week's target, which a mid-week edit may since have moved.
+    const lastWeekTarget = effectiveTarget(
+      lane.targetChanges,
+      lastWeekStart,
+      lane.targetPerWeek
+    )
+    return lastWeekHits >= lastWeekTarget && !lastWeekBattle?.completedAt
   })
 
   return (
@@ -113,8 +127,14 @@ export default async function BossBattlesPage() {
       )}
 
       {lanes.map((lane) => {
+        const pending = isLanePending(lane.startsOn, thisWeekStart)
         const currentHits = lane.checkIns.filter((c) => c.date >= thisWeekStart).length
-        const hitTarget = currentHits >= lane.targetPerWeek
+        const target = effectiveTarget(
+          lane.targetChanges,
+          thisWeekStart,
+          lane.targetPerWeek
+        )
+        const hitTarget = currentHits >= target
         const battle = lane.bossBattles.find(
           (b) => b.weekStarting.getTime() === thisWeekStart.getTime()
         )
@@ -125,12 +145,22 @@ export default async function BossBattlesPage() {
               <h2 className="text-lg font-semibold">
                 {lane.emoji} {lane.name}
               </h2>
-              <span className="text-sm text-zinc-600">
-                {currentHits} / {lane.targetPerWeek} days
-              </span>
+              {/* A lane that has not started owes no tally — printing "0 / 5
+                  days" for a week it was not in is the same deficit the
+                  dashboard refuses to show. */}
+              {!pending && (
+                <span className="text-sm text-zinc-600">
+                  {currentHits} / {target} days
+                </span>
+              )}
             </div>
 
-            {hitTarget ? (
+            {pending ? (
+              <p className="text-sm text-purple-300" data-testid="battle-pending">
+                ⏳ New lane — its first boss wakes{" "}
+                {formatWeekLabel(lane.startsOn!)}.
+              </p>
+            ) : hitTarget ? (
               <div className="space-y-3">
                 <div className="text-sm font-medium text-green-600">
                   ✅ Target hit

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -17,6 +17,7 @@ export default async function HistoryPage() {
     ],
     include: {
       bossBattles: true,
+      targetChanges: true,
       checkIns: {
         ...(prize?.seasonStart ? { where: { date: { gte: prize.seasonStart } } } : {}),
         orderBy: { date: "asc" },

--- a/src/app/lanes/page.test.tsx
+++ b/src/app/lanes/page.test.tsx
@@ -56,6 +56,7 @@ describe('Page', () => {
     expect(prisma.lane.findMany).toHaveBeenCalledWith({
       where: { userId: 'u1' },
       orderBy: [{ isActive: 'desc' }, { sortOrder: 'asc' }],
+      include: { targetChanges: true },
     })
 
     expect(screen.getByText('Running')).toBeInTheDocument()

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -10,15 +10,22 @@ import { playerLevel } from "@/lib/playerLevel"
 import { requiredLanes } from "@/lib/laneRequirement"
 import LaneList from "@/components/LaneList"
 import LaneForm from "@/components/LaneForm"
+import { getWeekStart } from "@/lib/weekUtils"
+import { getTrainingDay } from "@/lib/trainingDay"
 
 export const dynamic = "force-dynamic"
 
 export default async function LanesPage() {
   const userId = await requireUserId()
+  const weekStart = getWeekStart(getTrainingDay(new Date()))
   const lanes = await prisma.lane.findMany({
     where: { userId },
     orderBy: [{ isActive: "desc" }, { sortOrder: "asc" }],
+    include: { targetChanges: true },
   })
+  // A running season refuses lane deletes, so the page says so up front rather
+  // than letting the confirm button do nothing.
+  const prize = await prisma.prize.findUnique({ where: { userId } })
 
   // The floor of three governs every lane change, so the page decides once
   // what is legal right now and hands the answer down.
@@ -41,6 +48,8 @@ export default async function LanesPage() {
       </p>
       <LaneList
         lanes={lanes}
+        weekStart={weekStart}
+        seasonRunning={Boolean(prize?.seasonStart)}
         updateLane={async (id, patch) => {
           "use server"
           return updateLane(id, patch)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,9 @@ import { getTrainingDay } from "@/lib/trainingDay"
 import { createCheckIn } from "@/app/actions/createCheckIn"
 import { deleteCheckIn } from "@/app/actions/deleteCheckIn"
 import CheckInCard from "@/components/CheckInCard"
+import LanePendingCard from "@/components/LanePendingCard"
+import { isLanePending } from "@/lib/lanePending"
+import { effectiveTarget } from "@/lib/effectiveTarget"
 import { WeeklyProgress } from "@/components/WeeklyProgress"
 import SeasonStartButton from "@/components/SeasonStartButton"
 import SeasonResetButton from "@/components/SeasonResetButton"
@@ -44,13 +47,19 @@ export default async function DashboardPage() {
   const freezesByLane = new Map(freezeRows.map((r) => [r.laneId, r._count._all]))
   const hasStarted = Boolean(prize?.seasonStart)
 
-  const lanes = await prisma.lane.findMany({
+  const allLanes = await prisma.lane.findMany({
     where: { isActive: true, userId },
     orderBy: { sortOrder: "asc" },
     include: {
       checkIns: { where: { date: { gte: weekStart } }, orderBy: { date: "asc" } },
+      targetChanges: true,
     },
   })
+
+  // Lanes that haven't reached their first week sort below the live ones, so
+  // the set he can actually train today reads first.
+  const lanes = allLanes.filter((l) => !isLanePending(l.startsOn, weekStart))
+  const pendingLanes = allLanes.filter((l) => isLanePending(l.startsOn, weekStart))
 
   return (
     <main className="max-w-2xl mx-auto space-y-6 p-6">
@@ -87,7 +96,7 @@ export default async function DashboardPage() {
 
       <h1 className="text-2xl font-bold">Today</h1>
       <p className="mt-1 text-sm text-zinc-500">Your daily check-in. Show up for each lane — effort and consistency are the only score, and rest days count too.</p>
-      {lanes.length === 0 && (
+      {allLanes.length === 0 && (
         <p className="text-zinc-500">No lanes yet — add one on the Lanes page.</p>
       )}
       {lanes.map((lane) => {
@@ -119,7 +128,14 @@ export default async function DashboardPage() {
             />
             <div className="flex items-center justify-between gap-3">
               <div className="flex-1">
-                <WeeklyProgress hits={weeklyHits} target={lane.targetPerWeek} />
+                <WeeklyProgress
+                  hits={weeklyHits}
+                  target={effectiveTarget(
+                    lane.targetChanges,
+                    weekStart,
+                    lane.targetPerWeek
+                  )}
+                />
               </div>
               {(freezesByLane.get(lane.id) ?? 0) > 0 && (
                 <FreezeBadge availableFreezes={freezesByLane.get(lane.id) ?? 0} />
@@ -128,6 +144,15 @@ export default async function DashboardPage() {
           </div>
         )
       })}
+
+      {pendingLanes.map((lane) => (
+        <LanePendingCard
+          key={lane.id}
+          lane={{ name: lane.name, emoji: lane.emoji }}
+          startsOn={lane.startsOn!}
+        />
+      ))}
+
       {hasStarted && <SeasonResetButton />}
     </main>
   )

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -49,6 +49,11 @@ export default async function PrizePage() {
     where: { userId },
     select: {
       targetPerWeek: true,
+      // Each week is scored against the target that was in force THAT week, so
+      // raising a target now cannot un-qualify a week already earned.
+      targetChanges: {
+        select: { target: true, effectiveFrom: true },
+      },
       checkIns: {
         where: checkInWhere,
         select: {

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -7,6 +7,13 @@ interface ConfirmModalProps {
   confirmLabel?: string
   onConfirm: () => void
   onCancel: () => void
+  /** The action cannot proceed; the destructive button is withheld. */
+  blocked?: boolean
+  /** Why it cannot proceed — shown in place of `message`. */
+  blockedMessage?: string
+  /** Optional way forward offered instead of confirming. */
+  altLabel?: string
+  onAlt?: () => void
 }
 
 export default function ConfirmModal({
@@ -16,6 +23,10 @@ export default function ConfirmModal({
   confirmLabel = "Confirm",
   onConfirm,
   onCancel,
+  blocked = false,
+  blockedMessage,
+  altLabel,
+  onAlt,
 }: ConfirmModalProps) {
   if (!open) return null
 
@@ -32,7 +43,13 @@ export default function ConfirmModal({
       />
       <div className="relative w-full max-w-sm rounded-2xl border border-zinc-800 bg-zinc-900 p-6 shadow-2xl">
         <h3 className="text-lg font-semibold text-zinc-100">{title}</h3>
-        {message && <p className="mt-2 text-sm text-zinc-400">{message}</p>}
+        {blocked ? (
+          <p data-testid="confirm-blocked" className="mt-2 text-sm text-amber-300">
+            {blockedMessage}
+          </p>
+        ) : (
+          message && <p className="mt-2 text-sm text-zinc-400">{message}</p>
+        )}
         <div className="mt-6 flex justify-end gap-3">
           <button
             onClick={onCancel}
@@ -40,12 +57,24 @@ export default function ConfirmModal({
           >
             Cancel
           </button>
-          <button
-            onClick={onConfirm}
-            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
-          >
-            {confirmLabel}
-          </button>
+          {blocked
+            ? altLabel && (
+                <button
+                  data-testid="confirm-alt"
+                  onClick={onAlt}
+                  className="rounded-lg bg-zinc-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-600"
+                >
+                  {altLabel}
+                </button>
+              )
+            : (
+                <button
+                  onClick={onConfirm}
+                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
+                >
+                  {confirmLabel}
+                </button>
+              )}
         </div>
       </div>
     </div>

--- a/src/components/LaneList.test.tsx
+++ b/src/components/LaneList.test.tsx
@@ -13,6 +13,8 @@ const LANES = [
 const SWAP_OK = { mustPickReplacement: false, canRetire: true, blocked: false }
 const INACTIVE = [{ id: '2', name: 'Swimming', emoji: '🏊' }]
 
+const WEEK_START = new Date('2026-08-17T00:00:00.000Z')
+
 const actions = () => ({
   updateLane: vi.fn(),
   setActive: vi.fn(),
@@ -20,6 +22,7 @@ const actions = () => ({
   onSwapLane: vi.fn(),
   swapState: SWAP_OK,
   inactiveLanes: INACTIVE,
+  weekStart: WEEK_START,
 })
 
 describe('LaneList', () => {
@@ -128,5 +131,98 @@ describe('LaneList', () => {
 
     expect(a.onSwapLane).toHaveBeenCalledWith('1')
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('LaneList — a lane that has not started yet', () => {
+  const NEXT_MONDAY = new Date('2026-08-24T00:00:00.000Z')
+
+  it('says when a queued lane starts instead of scoring it', async () => {
+    const lanes = [
+      { ...LANES[0], startsOn: NEXT_MONDAY },
+      LANES[1],
+      LANES[2],
+    ]
+    render(<LaneList lanes={lanes} {...actions()} />)
+
+    expect(screen.getByTestId('lane-starts-1')).toHaveTextContent(
+      'starts Mon 24 Aug 2026'
+    )
+  })
+
+  it('says nothing for a lane already running', async () => {
+    render(<LaneList lanes={LANES} {...actions()} />)
+
+    expect(screen.queryByTestId('lane-starts-1')).not.toBeInTheDocument()
+  })
+
+  it('shows a scheduled target change with the date it lands', async () => {
+    const lanes = [
+      {
+        ...LANES[0],
+        targetChanges: [{ target: 5, effectiveFrom: NEXT_MONDAY }],
+      },
+      LANES[1],
+      LANES[2],
+    ]
+    render(<LaneList lanes={lanes} {...actions()} />)
+
+    expect(screen.getByTestId('lane-target-scheduled-1')).toHaveTextContent(
+      '→ 5×/week from Mon 24 Aug 2026'
+    )
+  })
+})
+
+describe('LaneList — deleting during a running season', () => {
+  it('explains the refusal and offers Swap instead of a dead button', async () => {
+    const user = userEvent.setup()
+    const props = actions()
+    render(<LaneList lanes={LANES} {...props} seasonRunning />)
+
+    await user.click(screen.getByLabelText('Delete Running'))
+
+    expect(screen.getByTestId('confirm-blocked')).toHaveTextContent(
+      /Can't delete during a running season/
+    )
+    expect(screen.getByTestId('confirm-alt')).toHaveTextContent('Use Swap')
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+  })
+
+  it('never calls the delete action while a season is running', async () => {
+    const user = userEvent.setup()
+    const props = actions()
+    render(<LaneList lanes={LANES} {...props} seasonRunning />)
+
+    await user.click(screen.getByLabelText('Delete Running'))
+    await user.click(screen.getByTestId('confirm-alt'))
+
+    expect(props.deleteLane).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeInTheDocument() // the swap modal
+  })
+
+  it('still deletes when no season is running', async () => {
+    const user = userEvent.setup()
+    const props = actions()
+    props.deleteLane.mockResolvedValue({ ok: true })
+    render(<LaneList lanes={LANES} {...props} />)
+
+    await user.click(screen.getByLabelText('Delete Running'))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(props.deleteLane).toHaveBeenCalledWith('1')
+  })
+
+  it('surfaces a refusal that only the server knew about', async () => {
+    const user = userEvent.setup()
+    const props = actions()
+    props.deleteLane.mockResolvedValue({ ok: false, error: 'season-running' })
+    render(<LaneList lanes={LANES} {...props} />)
+
+    await user.click(screen.getByLabelText('Delete Running'))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(await screen.findByTestId('confirm-blocked')).toHaveTextContent(
+      /Can't delete during a running season/
+    )
   })
 })

--- a/src/components/LaneList.tsx
+++ b/src/components/LaneList.tsx
@@ -2,6 +2,9 @@
 
 import { useState } from "react"
 import { LANES_REQUIRED } from "@/lib/season"
+import { isLanePending } from "@/lib/lanePending"
+import { formatWeekLabel } from "@/lib/weekUtils"
+import { effectiveTarget } from "@/lib/effectiveTarget"
 import ToggleSwitch from "@/components/ToggleSwitch"
 import ConfirmModal from "@/components/ConfirmModal"
 import LaneSwapModal from "@/components/LaneSwapModal"
@@ -13,6 +16,10 @@ interface Lane {
   emoji: string
   isActive: boolean
   targetPerWeek: number
+  /** Absent or null means the lane has always been running. */
+  startsOn?: Date | null
+  /** Effective-dated target changes; a future one is shown as scheduled. */
+  targetChanges?: { target: number; effectiveFrom: Date }[]
 }
 
 interface LaneListProps {
@@ -27,6 +34,22 @@ interface LaneListProps {
   requiredLanes?: number
   swapState: { mustPickReplacement: boolean; canRetire: boolean; blocked: boolean }
   inactiveLanes: { id: string; name: string; emoji: string }[]
+  /** Monday of the current week — decides which lanes are still queued. */
+  weekStart: Date
+  /** A running season refuses deletes; the lane must be retired via Swap. */
+  seasonRunning?: boolean
+}
+
+/** The soonest target change that has not taken effect yet, if any. */
+function nextChange(lane: Lane, weekStart: Date) {
+  const upcoming = (lane.targetChanges ?? [])
+    .filter((c) => c.effectiveFrom.getTime() > weekStart.getTime())
+    .sort((a, b) => a.effectiveFrom.getTime() - b.effectiveFrom.getTime())
+  return upcoming[0] ?? null
+}
+
+function scheduledTarget(lane: Lane, weekStart: Date) {
+  return nextChange(lane, weekStart)?.target ?? null
 }
 
 const EMOJI_OPTIONS: { cp: number; label: string }[] = [
@@ -52,16 +75,28 @@ export default function LaneList({
   swapState,
   inactiveLanes,
   requiredLanes,
+  weekStart,
+  seasonRunning = false,
 }: LaneListProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draft, setDraft] = useState({ name: "", emoji: "", targetPerWeek: 5 })
   const [confirmLane, setConfirmLane] = useState<Lane | null>(null)
+  // Set only when the server refuses a delete we thought was allowed.
+  const [deleteBlocked, setDeleteBlocked] = useState<Lane | null>(null)
   // One modal shared by every row: `swapLane` is the lane being traded out.
   const [swapLane, setSwapLane] = useState<Lane | null>(null)
 
   function startEdit(lane: Lane) {
     setEditingId(lane.id)
-    setDraft({ name: lane.name, emoji: lane.emoji, targetPerWeek: lane.targetPerWeek })
+    setDraft({
+      name: lane.name,
+      emoji: lane.emoji,
+      // Seed with the queued target if one is waiting, so reopening the form
+      // shows what the lane is becoming rather than what it is leaving behind.
+      targetPerWeek:
+        scheduledTarget(lane, weekStart) ??
+        effectiveTarget(lane.targetChanges, weekStart, lane.targetPerWeek),
+    })
   }
 
   async function saveEdit(id: string) {
@@ -153,7 +188,27 @@ export default function LaneList({
                   </span>
                   <div>
                     <div className="font-medium text-zinc-100">{lane.name}</div>
-                    <div className="text-xs text-zinc-500">{lane.targetPerWeek}×/week</div>
+                    <div className="text-xs text-zinc-500">
+                      {effectiveTarget(lane.targetChanges, weekStart, lane.targetPerWeek)}
+                      ×/week
+                    </div>
+                    {scheduledTarget(lane, weekStart) !== null && (
+                      <div
+                        data-testid={`lane-target-scheduled-${lane.id}`}
+                        className="text-xs text-purple-300"
+                      >
+                        → {scheduledTarget(lane, weekStart)}×/week from{" "}
+                        {formatWeekLabel(nextChange(lane, weekStart)!.effectiveFrom)}
+                      </div>
+                    )}
+                    {lane.isActive && isLanePending(lane.startsOn, weekStart) && (
+                      <div
+                        data-testid={`lane-starts-${lane.id}`}
+                        className="text-xs text-purple-300"
+                      >
+                        starts {formatWeekLabel(lane.startsOn!)}
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
@@ -198,11 +253,48 @@ export default function LaneList({
         title={confirmLane ? `Delete "${confirmLane.name}"?` : ""}
         message="This also removes its check-ins and boss battles."
         confirmLabel="Delete"
-        onConfirm={() => {
-          if (confirmLane) deleteLane(confirmLane.id)
+        blocked={seasonRunning}
+        blockedMessage={
+          "Can't delete during a running season — its check-ins are part of " +
+          "your season record. Use Swap to retire it instead."
+        }
+        altLabel="Use Swap"
+        onAlt={() => {
+          setSwapLane(confirmLane)
           setConfirmLane(null)
         }}
+        onConfirm={async () => {
+          const lane = confirmLane
+          setConfirmLane(null)
+          if (!lane) return
+          // The pre-emptive block above can go stale if a season starts in
+          // another tab, so the action's own refusal is honoured too rather
+          // than the click quietly doing nothing.
+          const result = (await deleteLane(lane.id)) as
+            | { ok: boolean; error?: string }
+            | undefined
+          if (result && !result.ok && result.error === "season-running") {
+            setDeleteBlocked(lane)
+          }
+        }}
         onCancel={() => setConfirmLane(null)}
+      />
+
+      <ConfirmModal
+        open={deleteBlocked !== null}
+        title={deleteBlocked ? `Delete "${deleteBlocked.name}"?` : ""}
+        blocked
+        blockedMessage={
+          "Can't delete during a running season — its check-ins are part of " +
+          "your season record. Use Swap to retire it instead."
+        }
+        altLabel="Use Swap"
+        onAlt={() => {
+          setSwapLane(deleteBlocked)
+          setDeleteBlocked(null)
+        }}
+        onConfirm={() => setDeleteBlocked(null)}
+        onCancel={() => setDeleteBlocked(null)}
       />
 
       {swapLane && (

--- a/src/components/LanePendingCard.test.tsx
+++ b/src/components/LanePendingCard.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import LanePendingCard from "@/components/LanePendingCard"
+
+const lane = { name: "10lbs weight squats 3 sets of 8", emoji: "🏋" }
+
+describe("LanePendingCard", () => {
+  it("names the lane and the Monday it starts", () => {
+    render(
+      <LanePendingCard lane={lane} startsOn={new Date("2026-08-24T00:00:00.000Z")} />
+    )
+
+    expect(screen.getByText(lane.name)).toBeInTheDocument()
+    expect(screen.getByText(/Starts Mon 24 Aug 2026/)).toBeInTheDocument()
+  })
+
+  it("offers no check-in and states no score for a week it was not in", () => {
+    render(
+      <LanePendingCard lane={lane} startsOn={new Date("2026-08-24T00:00:00.000Z")} />
+    )
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    expect(screen.queryByText(/days this week/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/LanePendingCard.tsx
+++ b/src/components/LanePendingCard.tsx
@@ -1,0 +1,31 @@
+import { formatWeekLabel } from "@/lib/weekUtils"
+
+interface LanePendingCardProps {
+  lane: { name: string; emoji: string }
+  startsOn: Date
+}
+
+/**
+ * A lane that is queued but not yet counting.
+ *
+ * Deliberately has no check-in buttons, no progress bar and no streak: every
+ * one of those would state a score for a week the lane was not part of. All it
+ * owes the player is the date it wakes up.
+ */
+export default function LanePendingCard({ lane, startsOn }: LanePendingCardProps) {
+  return (
+    <div
+      data-testid="lane-pending"
+      className="flex flex-col gap-2 rounded-xl border border-dashed border-zinc-700 bg-zinc-900/60 p-4"
+    >
+      <div className="flex items-center gap-2 text-lg font-bold text-zinc-300">
+        <span aria-hidden="true">{lane.emoji}</span>
+        <span>{lane.name}</span>
+      </div>
+      <p className="text-sm text-purple-300">
+        <span aria-hidden="true">⏳</span> Starts {formatWeekLabel(startsOn)} — you
+        get the whole week for this one.
+      </p>
+    </div>
+  )
+}

--- a/src/lib/effectiveTarget.test.ts
+++ b/src/lib/effectiveTarget.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { effectiveTarget } from "@/lib/effectiveTarget";
+
+const week = (iso: string) => new Date(iso + "T00:00:00.000Z");
+
+const AUG_10 = week("2026-08-10");
+const AUG_17 = week("2026-08-17");
+const AUG_24 = week("2026-08-24");
+const AUG_31 = week("2026-08-31");
+
+describe("effectiveTarget", () => {
+  it("falls back to the lane's original target when nothing is scheduled", () => {
+    expect(effectiveTarget([], AUG_17, 5)).toBe(5);
+    expect(effectiveTarget(undefined, AUG_17, 5)).toBe(5);
+  });
+
+  it("ignores a change that has not taken effect yet", () => {
+    const changes = [{ target: 3, effectiveFrom: AUG_24 }];
+    expect(effectiveTarget(changes, AUG_17, 5)).toBe(5);
+  });
+
+  it("applies a change from the week it takes effect", () => {
+    const changes = [{ target: 3, effectiveFrom: AUG_24 }];
+    expect(effectiveTarget(changes, AUG_24, 5)).toBe(3);
+    expect(effectiveTarget(changes, AUG_31, 5)).toBe(3);
+  });
+
+  it("picks the latest change at or before the week, whatever the order", () => {
+    const changes = [
+      { target: 7, effectiveFrom: AUG_31 },
+      { target: 3, effectiveFrom: AUG_17 },
+      { target: 4, effectiveFrom: AUG_24 },
+    ];
+
+    expect(effectiveTarget(changes, AUG_10, 5)).toBe(5);
+    expect(effectiveTarget(changes, AUG_17, 5)).toBe(3);
+    expect(effectiveTarget(changes, AUG_24, 5)).toBe(4);
+    expect(effectiveTarget(changes, AUG_31, 5)).toBe(7);
+  });
+
+  it("keeps a finished week's verdict fixed when a later change lands", () => {
+    // The whole point: raising the target next week must not re-score the
+    // week Eddie already earned at the old one.
+    const before = effectiveTarget([], AUG_17, 3);
+    const after = effectiveTarget([{ target: 5, effectiveFrom: AUG_24 }], AUG_17, 3);
+
+    expect(before).toBe(3);
+    expect(after).toBe(3);
+  });
+});

--- a/src/lib/effectiveTarget.ts
+++ b/src/lib/effectiveTarget.ts
@@ -1,0 +1,28 @@
+/**
+ * The weekly target a lane was being scored against in a given week.
+ *
+ * Targets are effective-dated rather than overwritten, because the season grid
+ * re-reads every finished week each time it renders. If a target were a single
+ * mutable number, raising a lane from 3×/week to 5×/week would re-score weeks
+ * Eddie already earned and could silently un-qualify them — a change to the
+ * future rewriting the past.
+ *
+ * `changes` need not be sorted. A week earlier than every change falls back to
+ * the lane's original target.
+ */
+export function effectiveTarget(
+  changes: { target: number; effectiveFrom: Date }[] | undefined,
+  weekStart: Date,
+  fallback: number
+): number {
+  let best: { target: number; effectiveFrom: Date } | null = null;
+
+  for (const change of changes ?? []) {
+    if (change.effectiveFrom.getTime() > weekStart.getTime()) continue;
+    if (best === null || change.effectiveFrom.getTime() > best.effectiveFrom.getTime()) {
+      best = change;
+    }
+  }
+
+  return best === null ? fallback : best.target;
+}

--- a/src/lib/isQualifyingWeek.test.ts
+++ b/src/lib/isQualifyingWeek.test.ts
@@ -72,3 +72,31 @@ describe('isQualifyingWeek', () => {
     expect(isQualifyingWeek(lanes, WEEK_START)).toBe(false)
   })
 })
+
+describe('isQualifyingWeek — a lane added mid-season', () => {
+  // Eddie's real shape: three lanes carrying the week, plus a fourth he only
+  // just added. The fourth has no check-ins because it has not started yet.
+  const threeCarrying = [
+    { targetPerWeek: 1, checkIns: [{ date: CHECK_IN_DATE, isRest: false }] },
+    { targetPerWeek: 1, checkIns: [{ date: CHECK_IN_DATE, isRest: false }] },
+    { targetPerWeek: 1, checkIns: [{ date: CHECK_IN_DATE, isRest: false }] },
+  ]
+
+  it('cannot drag down a week the established lanes already earned', () => {
+    const withNewLane = [...threeCarrying, { targetPerWeek: 5, checkIns: [] }]
+
+    expect(isQualifyingWeek(threeCarrying, WEEK_START)).toBe(true)
+    expect(isQualifyingWeek(withNewLane, WEEK_START)).toBe(true)
+  })
+
+  it('leaves the verdict unchanged however many empty lanes are added', () => {
+    const withThreeNewLanes = [
+      ...threeCarrying,
+      { targetPerWeek: 5, checkIns: [] },
+      { targetPerWeek: 5, checkIns: [] },
+      { targetPerWeek: 5, checkIns: [] },
+    ]
+
+    expect(isQualifyingWeek(withThreeNewLanes, WEEK_START)).toBe(true)
+  })
+})

--- a/src/lib/isQualifyingWeek.ts
+++ b/src/lib/isQualifyingWeek.ts
@@ -1,4 +1,5 @@
 import { countQualifyingHits } from "@/lib/qualifyingWeek";
+import { effectiveTarget } from "@/lib/effectiveTarget";
 import { LANES_REQUIRED } from "@/lib/season";
 
 interface CheckIn {
@@ -9,6 +10,8 @@ interface CheckIn {
 interface Lane {
   targetPerWeek: number;
   checkIns: CheckIn[];
+  /** Effective-dated target changes; absent means the lane never changed. */
+  targetChanges?: { target: number; effectiveFrom: Date }[];
 }
 
 /**
@@ -20,7 +23,10 @@ export function isQualifyingWeek(lanes: Lane[], weekStart: Date): boolean {
 
   for (const lane of lanes) {
     const hits = countQualifyingHits(lane.checkIns, weekStart);
-    if (hits >= lane.targetPerWeek) {
+    // The target as it stood in THIS week, not as it stands today — a later
+    // edit must not re-score a week already finished.
+    const target = effectiveTarget(lane.targetChanges, weekStart, lane.targetPerWeek);
+    if (hits >= target) {
       qualifyingLanesCount++;
     }
   }

--- a/src/lib/lanePending.test.ts
+++ b/src/lib/lanePending.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isLanePending } from "@/lib/lanePending";
+
+const monday = new Date("2026-08-17T00:00:00.000Z");
+const nextMonday = new Date("2026-08-24T00:00:00.000Z");
+
+describe("isLanePending", () => {
+  it("treats a lane with no stamp as already started", () => {
+    expect(isLanePending(null, monday)).toBe(false);
+  });
+
+  it("treats an unselected stamp as already started", () => {
+    expect(isLanePending(undefined, monday)).toBe(false);
+  });
+
+  it("is pending when it starts after this week", () => {
+    expect(isLanePending(nextMonday, monday)).toBe(true);
+  });
+
+  it("has started once the week it starts on has arrived", () => {
+    expect(isLanePending(monday, monday)).toBe(false);
+  });
+
+  it("has started for any week after the one it began in", () => {
+    expect(isLanePending(monday, nextMonday)).toBe(false);
+  });
+});

--- a/src/lib/lanePending.ts
+++ b/src/lib/lanePending.ts
@@ -1,0 +1,19 @@
+/**
+ * Has this lane not started counting yet?
+ *
+ * A lane added or swapped in mid-week is stamped with the Monday it begins, so
+ * it is never measured against days it did not exist for. Adding a lane on a
+ * Sunday against a 5-a-week target would otherwise read "0 / 5 days this week"
+ * — a score it cannot reach — which is exactly the deficit framing this app
+ * refuses to use.
+ *
+ * A lane with no stamp — null from a row that predates the column, undefined
+ * from a caller that never selected it — has always been running.
+ */
+export function isLanePending(
+  startsOn: Date | null | undefined,
+  weekStart: Date
+): boolean {
+  if (!startsOn) return false;
+  return startsOn.getTime() > weekStart.getTime();
+}

--- a/src/lib/seasonProgress.test.ts
+++ b/src/lib/seasonProgress.test.ts
@@ -31,3 +31,70 @@ describe('seasonProgress', () => {
     expect(progress.missesRemaining).toBe(missedAllowed)
   })
 })
+
+describe('seasonProgress — a target raised mid-season', () => {
+  const SEASON_START = new Date(Date.UTC(2026, 5, 1)) // Monday 1 Jun 2026
+  const WEEK_2 = new Date(Date.UTC(2026, 5, 8))
+  const TODAY = new Date(Date.UTC(2026, 5, 22)) // during week 4
+
+  // Three lanes that each hit 3 days in weeks 1 and 2 — enough for a target of
+  // three, not enough for a target of five.
+  const laneHitting3 = (targetChanges: any[] = []) => ({
+    targetPerWeek: 3,
+    targetChanges,
+    checkIns: [
+      { date: new Date(Date.UTC(2026, 5, 1)), isRest: false },
+      { date: new Date(Date.UTC(2026, 5, 2)), isRest: false },
+      { date: new Date(Date.UTC(2026, 5, 3)), isRest: false },
+      { date: new Date(Date.UTC(2026, 5, 8)), isRest: false },
+      { date: new Date(Date.UTC(2026, 5, 9)), isRest: false },
+      { date: new Date(Date.UTC(2026, 5, 10)), isRest: false },
+    ],
+  })
+
+  it('leaves already-earned weeks qualified', () => {
+    const before = getSeasonProgress(
+      [laneHitting3(), laneHitting3(), laneHitting3()],
+      TODAY,
+      SEASON_START
+    )
+
+    // Raising every lane to 5×/week from week 4 onward.
+    const raiseFrom = new Date(Date.UTC(2026, 5, 22))
+    const change = [{ target: 5, effectiveFrom: raiseFrom }]
+    const after = getSeasonProgress(
+      [laneHitting3(change), laneHitting3(change), laneHitting3(change)],
+      TODAY,
+      SEASON_START
+    )
+
+    expect(before.qualified).toBe(2)
+    expect(after.qualified).toBe(2)
+  })
+
+  it('would have un-qualified those weeks if the target applied retroactively', () => {
+    // Proves the guard is load-bearing: back-dating the same change to the
+    // season start does drop both weeks, which is exactly what a plain
+    // mutable targetPerWeek used to do on every edit.
+    const backdated = [{ target: 5, effectiveFrom: SEASON_START }]
+    const retro = getSeasonProgress(
+      [laneHitting3(backdated), laneHitting3(backdated), laneHitting3(backdated)],
+      TODAY,
+      SEASON_START
+    )
+
+    expect(retro.qualified).toBe(0)
+  })
+
+  it('scores the week a change takes effect at the new target', () => {
+    const change = [{ target: 5, effectiveFrom: WEEK_2 }]
+    const progress = getSeasonProgress(
+      [laneHitting3(change), laneHitting3(change), laneHitting3(change)],
+      TODAY,
+      SEASON_START
+    )
+
+    // Week 1 still qualifies at 3; week 2 now needs 5 and only has 3.
+    expect(progress.qualified).toBe(1)
+  })
+})

--- a/src/lib/seasonProgress.ts
+++ b/src/lib/seasonProgress.ts
@@ -20,6 +20,7 @@ export function getSeasonProgress(
       date: Date;
       isRest: boolean;
     }>;
+    targetChanges?: Array<{ target: number; effectiveFrom: Date }>;
   }>,
   today: Date,
   seasonStart: Date | null

--- a/src/lib/weekRecap.ts
+++ b/src/lib/weekRecap.ts
@@ -1,10 +1,13 @@
 import { getWeekStart } from "@/lib/weekUtils";
+import { effectiveTarget } from "@/lib/effectiveTarget";
 
 export interface RecapLaneInput {
   id: string;
   name: string;
   emoji: string;
   targetPerWeek: number;
+  /** Effective-dated target changes; absent means the lane never changed. */
+  targetChanges?: { target: number; effectiveFrom: Date }[];
   isActive: boolean;
   sortOrder: number;
   checkIns: { date: Date; isRest: boolean }[];
@@ -99,7 +102,15 @@ export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
           emoji: ld.emoji,
           isActive: ld.isActive,
           hits: ld.hits,
-          target: lanes.find((l) => l.id === ld.id)!.targetPerWeek,
+          // History shows each week judged by its own target, not today's.
+          target: (() => {
+            const source = lanes.find((l) => l.id === ld.id)!;
+            return effectiveTarget(
+              source.targetChanges,
+              entry.weekStart,
+              source.targetPerWeek
+            );
+          })(),
           battleFought: ld.battleFought,
           days: ld.days.sort((a: RecapDay, b: RecapDay) => a.date.getTime() - b.date.getTime())
         }))

--- a/src/lib/weekStatuses.ts
+++ b/src/lib/weekStatuses.ts
@@ -6,6 +6,8 @@ export type WeekStatus = "qualified" | "missed" | "current" | "upcoming";
 interface LaneData {
   targetPerWeek: number;
   checkIns: { date: Date; isRest: boolean }[];
+  /** Effective-dated target changes, passed through to isQualifyingWeek. */
+  targetChanges?: { target: number; effectiveFrom: Date }[];
 }
 
 export function getWeekStatuses(


### PR DESCRIPTION
## The bug

Eddie finished his lanes and battles, then swapped a lane and added `🏋️ 10lbs weight squats 3 sets of 8`. On Today it rendered as:

```
🏋️ 10lbs weight squats 3 sets of 8   🟢 Start your streak
[ I showed up ] [ Rest day ]
0 / 5 days this week
▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
```

It was **Sunday — day 7 of 7**. `0 / 5` was arithmetically impossible; even checking in right then could only reach 1/5. A lane he had just started was presented as a lane he was failing, sitting under three completed ones — the deficit framing this app exists to avoid.

**Root cause:** there was no concept of a lane's *start week*. Every active lane was scored against a full-week target from the instant it became active, however many days were left.

## What changed

**A lane begins on the Monday on or after it becomes active.** New nullable `Lane.startsOn`, stamped by `createLane`, `setLaneActive(…, true)` and the in-lane side of `swapLane`, reusing the existing `resolveSeasonStart()` (Monday returns itself; any other day returns next Monday). Today shows a queued lane as `⏳ Starts Mon 24 Aug 2026` with no buttons, bar or streak; the boss hub says when its first boss wakes; the Lanes page agrees. Retiring never touches the stamp, and a lane restarts only if it was genuinely inactive **and** untrained this week — so an off-and-on mis-tap can't bench a running lane.

**An edited target takes effect the coming Monday.** `isQualifyingWeek` was comparing every *finished* week against the lane's *current* `targetPerWeek`, so going 3×→5× could silently un-qualify weeks already earned. Targets are now effective-dated `LaneTarget` rows and each week is scored at the target in force that week. A second edit before Monday upserts over the pending row; resubmitting an unchanged number schedules nothing (the edit form always posts all three fields).

**Delete stops failing silently.** `deleteLane` returns `season-running` mid-season, but `LaneList` fired it without awaiting or checking — confirm did nothing, with no message. The dialog now opens pre-empted with the reason and a "Use Swap" button, and the action's own refusal is honoured too.

## Three defects caught in review

- **`updateLane` was silently dropping target changes.** It proved ownership via `updateMany`'s row count, but real Prisma returns `{count: 0}` for an empty `data` — verified against Postgres — so every target-only edit returned `not-found` and discarded the edit. Mocks returning `count: 1` hid it completely. Ownership now comes from the owner-scoped read it was already doing.
- **The grace-week guard tested the wrong week.** It checked `thisWeekStart` while judging *last* week, so a lane that started this Monday could wake a boss for a week it sat retired. Now tested against `lastWeekStart`, with a paired control test so it can't over-fire.
- **`createLane`/`updateLane` never revalidated `/`.** Every sibling action already did, so Today kept a stale copy after a lane was added or renamed.

## Safety

Both schema changes are additive — a nullable column and a new model — so the `vercel-build` → `db push` applies them without data loss. **Eddie's live season needs no backfill:** his existing lanes have `startsOn = NULL`, which reads as "already running", and with no `LaneTarget` rows every target falls back to `targetPerWeek` exactly as before.

Verified against a real Postgres (project's `docker-compose`): `db push` applies cleanly, `startsOn` round-trips, the compound-key upsert replaces rather than stacks, and `onDelete: Cascade` removes scheduled targets with the lane.

## Verification

- **346 tests pass** (68 files, up from 301/65); `tsc --noEmit` clean; eslint 0 errors with no warnings in any new file; `next build` succeeds.
- The grace-week regression test was confirmed to **fail against the pre-fix code** and pass once restored.
- Season-safety regressions added: a pending 4th lane can't drag down an earned week, and a raised target leaves finished weeks alone — with a companion test that back-dates the same change to prove the guard is load-bearing.

## Known gaps

- Today's bar counts raw check-ins while season qualification uses rest-capped `countQualifyingHits`, so `5 / 3 ✓` on Today can contribute fewer qualifying hits to the Prize grid. Pre-existing, deliberately out of scope.
- `AGENTS.md` mandates that actions mock Prisma and never hit Postgres, which is exactly why a silently-broken write passed a fully green suite. A contract test now asserts an update is never issued with empty `data`, but that guards only this instance — a thin integration tier for write paths is worth considering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)