### PR TITLE
feat: evolution pips replace the avatar progress bar

### DIFF
--- a/src/components/PlayerAvatarCard.test.tsx
+++ b/src/components/PlayerAvatarCard.test.tsx
@@ -10,33 +10,79 @@ vi.mock('@/components/PlayerAvatar', () => ({
 // Render them for real; mocking a collaborator makes the test assert against
 // its own mock and pass whatever the component does.
 
+const earned = () => screen.queryAllByTestId('pip-earned').length
+const locked = () => screen.queryAllByTestId('pip-locked').length
+
 describe('PlayerAvatarCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('the knight band renders name, level, and distance to next', async () => {
+  it('the knight band renders name and level', async () => {
     render(<PlayerAvatarCard defeats={8} />)
-    
+
     const levelName = screen.getByTestId('avatar-level-name')
     expect(levelName).toHaveTextContent(/Knight · Level 5/)
-    
+
     expect(screen.queryByText(/defeats/)).not.toBeInTheDocument()
   })
 
-  it('the cap renders a full bar', async () => {
+  it('the cap lights every evolution', async () => {
     render(<PlayerAvatarCard defeats={99999} />)
-    
-    const bar = screen.getByTestId('avatar-progress-bar')
-    expect(bar).toHaveStyle({ width: '100%' })
+
+    // Pinned to nine on purpose: it is a product fact the art assets and the
+    // landing page both commit to, so adding a rank should break this test.
+    expect(earned()).toBe(9)
+    expect(locked()).toBe(0)
   })
 
   it('level zero renders the baby stage', async () => {
     render(<PlayerAvatarCard defeats={0} />)
-    
+
     expect(screen.getByTestId('avatar-level-name')).toHaveTextContent(/Level 0/)
     // The zero state stays quiet — no defeat arithmetic until the first win.
     expect(screen.queryByText(/0 defeats/)).not.toBeInTheDocument()
     expect(screen.queryByText(/to next/)).not.toBeInTheDocument()
+  })
+
+  it('shows something from the very first rank', async () => {
+    // The whole point of the change: a bar measuring distance-to-next-rank sat
+    // at zero for baby, toddler and tween, because those bands are one boss
+    // wide. A pip is lit at every rank, including the very first.
+    render(<PlayerAvatarCard defeats={0} />)
+
+    expect(earned()).toBe(1)
+  })
+
+  it('lights one more pip at each evolution', async () => {
+    for (const [defeats, expected] of [[0, 1], [1, 2], [2, 3], [3, 4], [5, 5], [8, 6], [13, 7], [21, 8], [34, 9]] as const) {
+      const { unmount } = render(<PlayerAvatarCard defeats={defeats} />)
+      expect(earned(), `defeats=${defeats}`).toBe(expected)
+      unmount()
+    }
+  })
+
+  it('does not light a pip part-way through a band', async () => {
+    // 4 defeats is still squire — the rank has not changed, so nor has the row.
+    render(<PlayerAvatarCard defeats={4} />)
+    expect(earned()).toBe(4)
+  })
+
+  it('always draws the full ladder, lit or not', async () => {
+    const { unmount } = render(<PlayerAvatarCard defeats={0} />)
+    const total = earned() + locked()
+    unmount()
+
+    render(<PlayerAvatarCard defeats={13} />)
+    expect(earned() + locked()).toBe(total)
+  })
+
+  it('names the evolution reached for screen readers', async () => {
+    render(<PlayerAvatarCard defeats={8} />)
+
+    expect(screen.getByTestId('avatar-pips')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Evolution 6 of 9: knight')
+    )
   })
 })

--- a/src/components/PlayerAvatarCard.tsx
+++ b/src/components/PlayerAvatarCard.tsx
@@ -5,25 +5,46 @@ interface PlayerAvatarCardProps {
   defeats: number;
 }
 
+// How many evolutions the ladder holds, asked of the ladder itself so adding a
+// rank never needs a matching edit here.
+const EVOLUTIONS = playerLevel(Number.MAX_SAFE_INTEGER).level + 1;
+
+/**
+ * The monster, its rank, and one pip per evolution.
+ *
+ * Pips rather than a progress bar: the first three ranks are a single boss
+ * wide, so a bar measuring distance-to-next-rank was pinned at zero for every
+ * new player — empty at exactly the moment someone is deciding whether this
+ * app is worth anything. A pip row always shows where you are, and draws the
+ * nine-evolution journey the game is actually about.
+ */
 export default function PlayerAvatarCard({ defeats }: PlayerAvatarCardProps) {
-  const { level, name, progress } = playerLevel(defeats);
+  const { level, name } = playerLevel(defeats);
+  const earned = level + 1;
 
   return (
     <div className="flex flex-row items-center gap-4 rounded-lg border p-4">
       <PlayerAvatar level={level} name={name} />
       <div className="flex flex-col gap-1">
-        <div 
-          data-testid="avatar-level-name" 
-          className="text-sm font-medium"
-        >
+        <div data-testid="avatar-level-name" className="text-sm font-medium">
           {name.charAt(0).toUpperCase() + name.slice(1)} · Level {level}
         </div>
-        <div className="h-2 w-full rounded-full bg-zinc-700">
-          <div
-            data-testid="avatar-progress-bar"
-            className="h-full rounded-full bg-emerald-500"
-            style={{ width: `${Math.round(progress * 100)}%` }}
-          />
+        <div
+          data-testid="avatar-pips"
+          className="flex items-center gap-1.5"
+          role="img"
+          aria-label={`Evolution ${earned} of ${EVOLUTIONS}: ${name}`}
+        >
+          {Array.from({ length: EVOLUTIONS }, (_, i) => (
+            <span
+              key={i}
+              data-testid={i < earned ? "pip-earned" : "pip-locked"}
+              aria-hidden="true"
+              className={`h-2.5 w-2.5 rounded-full ${
+                i < earned ? "bg-emerald-500" : "bg-zinc-700"
+              }`}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/PlayerAvatarCard.tsx
+++ b/src/components/PlayerAvatarCard.tsx
@@ -5,8 +5,10 @@ interface PlayerAvatarCardProps {
   defeats: number;
 }
 
-// How many evolutions the ladder holds, asked of the ladder itself so adding a
-// rank never needs a matching edit here.
+// How many evolutions the ladder holds, asked of the ladder itself so a tenth
+// rank renders here without an edit. The test still pins nine deliberately: a
+// new rank needs new art, so it should fail until someone has decided about
+// that rather than quietly drawing an unlit pip with no monster behind it.
 const EVOLUTIONS = playerLevel(Number.MAX_SAFE_INTEGER).level + 1;
 
 /**

--- a/src/lib/playerLevel.ts
+++ b/src/lib/playerLevel.ts
@@ -3,6 +3,12 @@ export type PlayerLevel = {
   name: string;
   defeats: number;
   nextAt: number | null;
+  /**
+   * Fraction through the CURRENT band. Nothing renders this, on purpose: the
+   * first three bands are one boss wide, so it is pinned at 0 for every new
+   * player. The avatar card draws a pip per evolution instead. Wiring this to
+   * a progress bar puts back a bar that cannot fill until squire.
+   */
   progress: number;
 };
 


### PR DESCRIPTION
## The problem

The bar under the rank measured **distance to the next rank**. The first three bands are one boss wide — baby, toddler and tween sit at thresholds `0, 1, 2` — so the numerator is always zero. It rendered empty for every new player and only moved at squire:

```
defeats  rank        bar
   0     baby        ····················   0%
   1     toddler     ····················   0%     ← permanently empty
   2     tween       ····················   0%
   3     squire      ····················   0%
   4     squire      ██████████··········  50%     ← first movement
   8     knight      ····················   0%
  10     knight      ████████············  40%
```

Not a rendering bug — the ladder shape leaves it nothing to draw. The gap opened in `8629496`, which removed the `X defeats · Y to next` line on the reasoning that *"the monster, the rank, and the filling bar tell the story."* The bar inherited the whole job but can't fill early, so a brand-new player gets a monster, a rank, and a dead rectangle.

## The change

Nine pips, one per evolution, lit up to the current rank.

```
baby      ●········
toddler   ●●·······
squire    ●●●●·····
knight    ●●●●●●···
legend    ●●●●●●●●●
```

Always shows where you are from the very first boss, and draws the nine-evolution journey the landing page already sells. The pip count is asked of the ladder (`playerLevel(MAX_SAFE_INTEGER).level + 1`) rather than hardcoded, so adding a rank needs no edit here. The row carries an `aria-label` — "Evolution 6 of 9: knight" — since the pips themselves are decorative.

## Scope

**Display only.** Same Fibonacci thresholds, same defeats, same freeze awards, same lane demand, same nine art assets. No schema change, no migration, nothing to back-fill.

Two alternatives were considered and rejected, both of which would have made a boss worth half a step so the bar had a midpoint to draw:

- **Doubling the ladder** (2 bosses per rank) re-balances a season already in flight, pushes legend from 34 bosses to 68, halves the supply of freeze tokens we only just made spendable, and demotes every existing player — directly contradicting *"it never shrinks."*
- **Half-credit for a woken boss** avoids the demotion but couples a cosmetic concern to game state, and lets the bar move backwards when a boss lapses.

Neither is worth changing the economy to make a rectangle move.

## Verification

380 tests / 70 files passing (5 net new), `tsc` clean, eslint 0 errors, `next build` succeeds. New coverage pins the behaviour that was missing: a pip is lit at the very first rank, one more lights at each evolution across the whole ladder, the row always draws all nine, and the cap count is pinned to nine on purpose so adding a rank breaks the test rather than silently desyncing from the art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)