### PR TITLE
release: SSRF fix, working streak freezes, evolution pips

### DIFF
--- a/docs/design/multi-user-oauth.md
+++ b/docs/design/multi-user-oauth.md
@@ -84,9 +84,16 @@ The inline closures in pages are thin wrappers delegating to these module
 files — the check inside the module covers both exposure paths; no closure
 refactoring needed.
 
-**uploadPrizePhoto (hand-eyes):** drop or harden `fetchRemoteImage`
+**uploadPrizePhoto (hand-eyes):** ~~drop or harden `fetchRemoteImage`
 (https-only, reject private/link-local IPs — simplest is dropping remote
-fetch), and prefix Blob pathnames with `userId`.
+fetch), and prefix Blob pathnames with `userId`.~~ **DONE** — hardened
+rather than dropped, so pasting a shop link still works:
+`src/lib/fetchableUrl.ts` (https-only, no credentials, literal addresses
+judged directly, every resolved address checked) over
+`src/lib/publicAddress.ts`. Redirects are followed by hand and re-checked
+per hop, since the automatic ones were the actual hole. Blob pathnames
+are prefixed with `userId` and the filename is sanitised, or `..` would
+climb straight out of that prefix.
 
 **LLM abuse mitigation (open sign-ups):** pure `src/lib/llmCap.ts` + a
 check in the 3 LLM actions (createBossBattle, createReflection,

--- a/docs/design/multi-user-oauth.md
+++ b/docs/design/multi-user-oauth.md
@@ -89,11 +89,13 @@ refactoring needed.
 fetch), and prefix Blob pathnames with `userId`.~~ **DONE** — hardened
 rather than dropped, so pasting a shop link still works:
 `src/lib/fetchableUrl.ts` (https-only, no credentials, literal addresses
-judged directly, every resolved address checked) over
+judged directly, every DNS answer checked) over
 `src/lib/publicAddress.ts`. Redirects are followed by hand and re-checked
 per hop, since the automatic ones were the actual hole. Blob pathnames
 are prefixed with `userId` and the filename is sanitised, or `..` would
-climb straight out of that prefix.
+climb straight out of that prefix. Rebinding is narrowed, not closed:
+`fetch` re-resolves the name, so pinning the connection to a checked
+address (custom dispatcher) is still open.
 
 **LLM abuse mitigation (open sign-ups):** pure `src/lib/llmCap.ts` + a
 check in the 3 LLM actions (createBossBattle, createReflection,

--- a/src/app/actions/uploadPrizePhoto.test.ts
+++ b/src/app/actions/uploadPrizePhoto.test.ts
@@ -5,6 +5,7 @@ import type { Prize } from '@prisma/client'
 import { uploadPrizePhoto } from './uploadPrizePhoto'
 import { put, del } from '@vercel/blob'
 import { revalidatePath } from 'next/cache'
+import { resolveHost } from '@/lib/resolveHost'
 
 vi.mock('@/lib/db', () => ({
   prisma: {
@@ -35,6 +36,10 @@ vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
+// The guard resolves the hostname before fetching. DNS is the one bit of I/O
+// here, so it is steered rather than left to answer for real.
+vi.mock('@/lib/resolveHost', () => ({ resolveHost: vi.fn() }))
+
 const makePrize = (overrides: Partial<Prize> = {}): Prize =>
   ({
     id: '',
@@ -52,6 +57,8 @@ describe('uploadPrizePhoto', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(requireUserId).mockResolvedValue(USER_ID)
+    // Default: hostnames resolve to an ordinary public address.
+    vi.mocked(resolveHost).mockResolvedValue(['93.184.216.34'])
   })
 
   it('the stored prize row is the signed-in user\'s', async () => {
@@ -155,6 +162,7 @@ describe('uploadPrizePhoto', () => {
     const okResponse = (type = 'image/png', size = 1024) =>
       ({
         ok: true,
+        status: 200,
         headers: { get: (h: string) => (h === 'content-type' ? type : null) },
         blob: async () => ({ size }) as Blob,
       }) as unknown as Response
@@ -196,7 +204,9 @@ describe('uploadPrizePhoto', () => {
     })
 
     it('failed fetch returns fetch-failed', async () => {
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as Response))
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false, status: 500, headers: { get: () => null },
+      } as unknown as Response))
 
       const fd = new FormData()
       fd.append('photoUrl', remoteUrl)
@@ -218,6 +228,97 @@ describe('uploadPrizePhoto', () => {
 
       expect(result).toEqual({ ok: true, url: 'https://blob.test/prize/from-file.png' })
       expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('a redirect into the metadata endpoint is not followed', async () => {
+      // The hole automatic redirects leave: the pasted URL is perfectly
+      // ordinary, and the 302 is where the attack lives.
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: { get: (h: string) => (h === 'location' ? 'https://169.254.169.254/latest/meta-data/' : null) },
+      } as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: false, error: 'url-not-allowed' })
+      // The first hop happened; the second never did.
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(put).not.toHaveBeenCalled()
+    })
+
+    it('a redirect to another public image is followed', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false, status: 302,
+          headers: { get: (h: string) => (h === 'location' ? 'https://cdn.example/real.png' : null) },
+        } as unknown as Response)
+        .mockResolvedValueOnce(okResponse())
+      vi.stubGlobal('fetch', fetchMock)
+      vi.mocked(put).mockResolvedValue({ url: 'https://blob.test/prize/real.png' } as never)
+      vi.mocked(db.prize.findUnique).mockResolvedValue(makePrize({ photoUrl: null }))
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: true, url: 'https://blob.test/prize/real.png' })
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('a redirect loop gives up rather than spinning', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false, status: 302,
+        headers: { get: (h: string) => (h === 'location' ? 'https://images.test/again.png' : null) },
+      } as unknown as Response)
+      vi.stubGlobal('fetch', fetchMock)
+
+      const fd = new FormData()
+      fd.append('photoUrl', remoteUrl)
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: false, error: 'fetch-failed' })
+      expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(5)
+    })
+
+    it('a link into the private network never reaches fetch', async () => {
+      vi.mocked(resolveHost).mockResolvedValue(['10.0.0.5'])
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const fd = new FormData()
+      fd.append('photoUrl', 'https://inside.test/x.png')
+
+      expect(await uploadPrizePhoto(fd)).toEqual({ ok: false, error: 'url-not-allowed' })
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('a traversing filename cannot climb out of the user folder', async () => {
+      // The blob path is `${userId}/${name}`, so the user id is the only thing
+      // keeping one family's photos out of another's.
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse()))
+      vi.mocked(put).mockResolvedValue({ url: 'https://blob.test/x.png' } as never)
+      vi.mocked(db.prize.findUnique).mockResolvedValue(makePrize({ photoUrl: null }))
+
+      const fd = new FormData()
+      fd.append('photoUrl', 'https://images.test/a/..')
+      await uploadPrizePhoto(fd)
+
+      const pathname = vi.mocked(put).mock.calls[0][0] as string
+      expect(pathname.startsWith(`${USER_ID}/`)).toBe(true)
+      expect(pathname).not.toContain('..')
+    })
+
+    it('a traversing upload filename is sanitised too', async () => {
+      vi.mocked(put).mockResolvedValue({ url: 'https://blob.test/x.png' } as never)
+      vi.mocked(db.prize.findUnique).mockResolvedValue(makePrize({ photoUrl: null }))
+
+      const fd = new FormData()
+      fd.append('photo', new File(['bytes'], '../../escape.png', { type: 'image/png' }))
+      await uploadPrizePhoto(fd)
+
+      const pathname = vi.mocked(put).mock.calls[0][0] as string
+      expect(pathname).toBe(`${USER_ID}/escape.png`)
     })
   })
 })

--- a/src/app/actions/uploadPrizePhoto.ts
+++ b/src/app/actions/uploadPrizePhoto.ts
@@ -2,11 +2,32 @@ import { put, del } from "@vercel/blob";
 import { revalidatePath } from "next/cache";
 import { prisma as db } from "@/lib/db";
 import { requireUserId } from "@/lib/tenancy";
+import { assertFetchableUrl } from "@/lib/fetchableUrl";
+import { resolveHost } from "@/lib/resolveHost";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const FETCH_TIMEOUT_MS = 8000;
+const MAX_REDIRECTS = 3;
 
 /** What we're about to upload, once a File or a remote URL has been resolved. */
 type Payload = { body: File | Blob; name: string };
+
+/**
+ * Reduce an untrusted filename to something safe to append to a blob path.
+ *
+ * Uploads are stored at `${userId}/${name}`, so the user id is the only thing
+ * separating one family's photos from another's. Both sources of that name are
+ * attacker-controlled — the last path segment of a pasted URL, and the
+ * filename in a multipart upload — and a name of `..` would climb straight out
+ * of that namespace.
+ */
+function safeBlobName(raw: string): string {
+  const base = raw.split(/[\\/]/).pop() ?? "";
+  const cleaned = base
+    .replace(/[^A-Za-z0-9._-]/g, "-") // allowlist; everything else is a dash
+    .replace(/^\.+/, ""); // no leading dots: kills ".." and dotfiles
+  return cleaned.slice(0, 100) || "photo";
+}
 
 /**
  * Download a pasted image link so it can be re-uploaded to our own store.
@@ -14,15 +35,42 @@ type Payload = { body: File | Blob; name: string };
  * We deliberately do NOT keep the remote URL: `next/image` only renders hosts
  * listed in `remotePatterns`, widening that to `**` would turn the app into an
  * open image proxy, and a hotlinked image vanishes when its host deletes it.
+ *
+ * Redirects are followed by hand rather than by `fetch`, because the automatic
+ * ones are the hole: a perfectly ordinary https link is allowed to answer with
+ * a 302 to the metadata endpoint, and checking only the URL that was pasted
+ * would wave it straight through.
  */
 async function fetchRemoteImage(
   url: string
 ): Promise<{ ok: true; payload: Payload } | { ok: false; error: string }> {
+  let target = url;
   let response: Response;
-  try {
-    response = await fetch(url);
-  } catch {
-    return { ok: false, error: "fetch-failed" };
+
+  for (let hop = 0; ; hop++) {
+    const allowed = await assertFetchableUrl(target, resolveHost);
+    if (!allowed.ok) return { ok: false, error: allowed.error };
+
+    try {
+      response = await fetch(allowed.url, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        headers: { accept: "image/*" },
+      });
+    } catch {
+      return { ok: false, error: "fetch-failed" };
+    }
+
+    // Positive test, so anything that is not clearly a redirect — including a
+    // response with no status at all — falls through to the content checks
+    // rather than being chased as one.
+    if (!(response.status >= 300 && response.status < 400)) break;
+
+    if (hop >= MAX_REDIRECTS) return { ok: false, error: "fetch-failed" };
+    const location = response.headers.get("location");
+    if (!location) return { ok: false, error: "fetch-failed" };
+    // Resolved against the current URL so a relative Location still works.
+    target = new URL(location, allowed.url).toString();
   }
 
   if (!response.ok) {
@@ -42,7 +90,7 @@ async function fetchRemoteImage(
   }
 
   const lastSegment = new URL(url).pathname.split("/").filter(Boolean).pop();
-  return { ok: true, payload: { body, name: lastSegment || "photo" } };
+  return { ok: true, payload: { body, name: safeBlobName(lastSegment ?? "") } };
 }
 
 export async function uploadPrizePhoto(formData: FormData): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
@@ -59,7 +107,7 @@ export async function uploadPrizePhoto(formData: FormData): Promise<{ ok: true; 
     if (file.size > MAX_FILE_SIZE) {
       return { ok: false, error: "too-large" };
     }
-    payload = { body: file, name: file.name };
+    payload = { body: file, name: safeBlobName(file.name) };
   } else if (typeof remoteUrl === "string" && remoteUrl.trim().length > 0) {
     const fetched = await fetchRemoteImage(remoteUrl.trim());
     if (!fetched.ok) {

--- a/src/app/actions/uploadPrizePhoto.ts
+++ b/src/app/actions/uploadPrizePhoto.ts
@@ -30,6 +30,43 @@ function safeBlobName(raw: string): string {
 }
 
 /**
+ * Read a response body, giving up as soon as it exceeds `max`.
+ *
+ * Size is checked while reading rather than after, because `.blob()` buffers
+ * the whole body first: a link to a multi-gigabyte endpoint would drive the
+ * server's memory up before anyone got to measure it. `content-length` is
+ * consulted as a shortcut but never trusted — it is optional, and a hostile
+ * host will simply lie.
+ */
+async function readCapped(response: Response, max: number): Promise<Blob | null> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > max) return null;
+
+  const stream = response.body;
+  if (!stream) {
+    const blob = await response.blob();
+    return blob.size > max ? null : blob;
+  }
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > max) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  return new Blob(chunks as BlobPart[]);
+}
+
+/**
  * Download a pasted image link so it can be re-uploaded to our own store.
  *
  * We deliberately do NOT keep the remote URL: `next/image` only renders hosts
@@ -82,10 +119,8 @@ async function fetchRemoteImage(
     return { ok: false, error: "not-an-image" };
   }
 
-  // Size is measured from the downloaded bytes, not content-length: that
-  // header is optional and a remote host can lie about it.
-  const body = await response.blob();
-  if (body.size > MAX_FILE_SIZE) {
+  const body = await readCapped(response, MAX_FILE_SIZE);
+  if (body === null) {
     return { ok: false, error: "too-large" };
   }
 

--- a/src/components/PlayerAvatarCard.test.tsx
+++ b/src/components/PlayerAvatarCard.test.tsx
@@ -10,33 +10,79 @@ vi.mock('@/components/PlayerAvatar', () => ({
 // Render them for real; mocking a collaborator makes the test assert against
 // its own mock and pass whatever the component does.
 
+const earned = () => screen.queryAllByTestId('pip-earned').length
+const locked = () => screen.queryAllByTestId('pip-locked').length
+
 describe('PlayerAvatarCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('the knight band renders name, level, and distance to next', async () => {
+  it('the knight band renders name and level', async () => {
     render(<PlayerAvatarCard defeats={8} />)
-    
+
     const levelName = screen.getByTestId('avatar-level-name')
     expect(levelName).toHaveTextContent(/Knight · Level 5/)
-    
+
     expect(screen.queryByText(/defeats/)).not.toBeInTheDocument()
   })
 
-  it('the cap renders a full bar', async () => {
+  it('the cap lights every evolution', async () => {
     render(<PlayerAvatarCard defeats={99999} />)
-    
-    const bar = screen.getByTestId('avatar-progress-bar')
-    expect(bar).toHaveStyle({ width: '100%' })
+
+    // Pinned to nine on purpose: it is a product fact the art assets and the
+    // landing page both commit to, so adding a rank should break this test.
+    expect(earned()).toBe(9)
+    expect(locked()).toBe(0)
   })
 
   it('level zero renders the baby stage', async () => {
     render(<PlayerAvatarCard defeats={0} />)
-    
+
     expect(screen.getByTestId('avatar-level-name')).toHaveTextContent(/Level 0/)
     // The zero state stays quiet — no defeat arithmetic until the first win.
     expect(screen.queryByText(/0 defeats/)).not.toBeInTheDocument()
     expect(screen.queryByText(/to next/)).not.toBeInTheDocument()
+  })
+
+  it('shows something from the very first rank', async () => {
+    // The whole point of the change: a bar measuring distance-to-next-rank sat
+    // at zero for baby, toddler and tween, because those bands are one boss
+    // wide. A pip is lit at every rank, including the very first.
+    render(<PlayerAvatarCard defeats={0} />)
+
+    expect(earned()).toBe(1)
+  })
+
+  it('lights one more pip at each evolution', async () => {
+    for (const [defeats, expected] of [[0, 1], [1, 2], [2, 3], [3, 4], [5, 5], [8, 6], [13, 7], [21, 8], [34, 9]] as const) {
+      const { unmount } = render(<PlayerAvatarCard defeats={defeats} />)
+      expect(earned(), `defeats=${defeats}`).toBe(expected)
+      unmount()
+    }
+  })
+
+  it('does not light a pip part-way through a band', async () => {
+    // 4 defeats is still squire — the rank has not changed, so nor has the row.
+    render(<PlayerAvatarCard defeats={4} />)
+    expect(earned()).toBe(4)
+  })
+
+  it('always draws the full ladder, lit or not', async () => {
+    const { unmount } = render(<PlayerAvatarCard defeats={0} />)
+    const total = earned() + locked()
+    unmount()
+
+    render(<PlayerAvatarCard defeats={13} />)
+    expect(earned() + locked()).toBe(total)
+  })
+
+  it('names the evolution reached for screen readers', async () => {
+    render(<PlayerAvatarCard defeats={8} />)
+
+    expect(screen.getByTestId('avatar-pips')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Evolution 6 of 9: knight')
+    )
   })
 })

--- a/src/components/PlayerAvatarCard.tsx
+++ b/src/components/PlayerAvatarCard.tsx
@@ -5,25 +5,46 @@ interface PlayerAvatarCardProps {
   defeats: number;
 }
 
+// How many evolutions the ladder holds, asked of the ladder itself so adding a
+// rank never needs a matching edit here.
+const EVOLUTIONS = playerLevel(Number.MAX_SAFE_INTEGER).level + 1;
+
+/**
+ * The monster, its rank, and one pip per evolution.
+ *
+ * Pips rather than a progress bar: the first three ranks are a single boss
+ * wide, so a bar measuring distance-to-next-rank was pinned at zero for every
+ * new player — empty at exactly the moment someone is deciding whether this
+ * app is worth anything. A pip row always shows where you are, and draws the
+ * nine-evolution journey the game is actually about.
+ */
 export default function PlayerAvatarCard({ defeats }: PlayerAvatarCardProps) {
-  const { level, name, progress } = playerLevel(defeats);
+  const { level, name } = playerLevel(defeats);
+  const earned = level + 1;
 
   return (
     <div className="flex flex-row items-center gap-4 rounded-lg border p-4">
       <PlayerAvatar level={level} name={name} />
       <div className="flex flex-col gap-1">
-        <div 
-          data-testid="avatar-level-name" 
-          className="text-sm font-medium"
-        >
+        <div data-testid="avatar-level-name" className="text-sm font-medium">
           {name.charAt(0).toUpperCase() + name.slice(1)} · Level {level}
         </div>
-        <div className="h-2 w-full rounded-full bg-zinc-700">
-          <div
-            data-testid="avatar-progress-bar"
-            className="h-full rounded-full bg-emerald-500"
-            style={{ width: `${Math.round(progress * 100)}%` }}
-          />
+        <div
+          data-testid="avatar-pips"
+          className="flex items-center gap-1.5"
+          role="img"
+          aria-label={`Evolution ${earned} of ${EVOLUTIONS}: ${name}`}
+        >
+          {Array.from({ length: EVOLUTIONS }, (_, i) => (
+            <span
+              key={i}
+              data-testid={i < earned ? "pip-earned" : "pip-locked"}
+              aria-hidden="true"
+              className={`h-2.5 w-2.5 rounded-full ${
+                i < earned ? "bg-emerald-500" : "bg-zinc-700"
+              }`}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/PlayerAvatarCard.tsx
+++ b/src/components/PlayerAvatarCard.tsx
@@ -5,8 +5,10 @@ interface PlayerAvatarCardProps {
   defeats: number;
 }
 
-// How many evolutions the ladder holds, asked of the ladder itself so adding a
-// rank never needs a matching edit here.
+// How many evolutions the ladder holds, asked of the ladder itself so a tenth
+// rank renders here without an edit. The test still pins nine deliberately: a
+// new rank needs new art, so it should fail until someone has decided about
+// that rather than quietly drawing an unlit pip with no monster behind it.
 const EVOLUTIONS = playerLevel(Number.MAX_SAFE_INTEGER).level + 1;
 
 /**

--- a/src/lib/fetchableUrl.test.ts
+++ b/src/lib/fetchableUrl.test.ts
@@ -86,3 +86,45 @@ describe("assertFetchableUrl", () => {
     expect(resolver).not.toHaveBeenCalled();
   });
 });
+
+describe("assertFetchableUrl — addresses disguised as IPv6 literals", () => {
+  const publicHost = async () => ["93.184.216.34"];
+
+  it("refuses the metadata endpoint however it is spelled", async () => {
+    for (const url of [
+      "https://[::ffff:169.254.169.254]/latest/meta-data/",
+      "https://[::169.254.169.254]/",
+      "https://[2002:a9fe:a9fe::]/",
+      "https://[64:ff9b::a9fe:a9fe]/",
+      "https://2852039166/", // decimal shorthand, normalised by URL
+      "https://0251.0376.0251.0376/", // octal shorthand
+    ]) {
+      const result = await assertFetchableUrl(url, publicHost);
+      expect(result, url).toEqual({ ok: false, error: "url-not-allowed" });
+    }
+  });
+
+  it("refuses loopback and private space in bracketed form", async () => {
+    for (const url of [
+      "https://[::1]/", "https://[::ffff:127.0.0.1]/",
+      "https://[::ffff:10.0.0.1]/", "https://[2002:c0a8:1::]/",
+    ]) {
+      const result = await assertFetchableUrl(url, publicHost);
+      expect(result, url).toEqual({ ok: false, error: "url-not-allowed" });
+    }
+  });
+
+  it("does not mistake hostnames of hex letters and digits for addresses", async () => {
+    // b2b.ec and f5.ca are names. Treating them as malformed addresses
+    // refused real shop links with no explanation.
+    for (const host of ["b2b.ec", "a1.cc", "f5.ca", "cdn3.ac", "1and1.com"]) {
+      const result = await assertFetchableUrl(`https://${host}/x.png`, publicHost);
+      expect(result.ok, host).toBe(true);
+    }
+  });
+
+  it("still allows a public IPv6 host", async () => {
+    const result = await assertFetchableUrl("https://[2606:4700:4700::1111]/x.png", publicHost);
+    expect(result.ok).toBe(true);
+  });
+})

--- a/src/lib/fetchableUrl.test.ts
+++ b/src/lib/fetchableUrl.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { assertFetchableUrl } from "@/lib/fetchableUrl";
+
+const publicHost = async () => ["93.184.216.34"];
+const blocked = { ok: false, error: "url-not-allowed" };
+
+describe("assertFetchableUrl", () => {
+  it("allows an ordinary https image on a public host", async () => {
+    const result = await assertFetchableUrl("https://images.example/ps5.png", publicHost);
+
+    expect(result.ok).toBe(true);
+  });
+
+  // The design doc's own verification checklist, which did not pass before.
+  it("refuses the cloud metadata endpoint", async () => {
+    const direct = await assertFetchableUrl("https://169.254.169.254/latest/meta-data/", publicHost);
+    const byName = await assertFetchableUrl("https://metadata.attacker.test/", async () => [
+      "169.254.169.254",
+    ]);
+
+    expect(direct).toEqual(blocked);
+    expect(byName).toEqual(blocked);
+  });
+
+  it("refuses file: URLs", async () => {
+    expect(await assertFetchableUrl("file:///etc/passwd", publicHost)).toEqual(blocked);
+  });
+
+  it("refuses plain http", async () => {
+    expect(await assertFetchableUrl("http://images.example/ps5.png", publicHost)).toEqual(blocked);
+  });
+
+  it("refuses schemes that are not http at all", async () => {
+    for (const url of ["ftp://h/x.png", "gopher://h/x", "data:image/png;base64,AAAA"]) {
+      expect(await assertFetchableUrl(url, publicHost), url).toEqual(blocked);
+    }
+  });
+
+  it("refuses a host that resolves into the private network", async () => {
+    for (const ip of ["127.0.0.1", "10.1.2.3", "192.168.1.1", "172.16.0.9", "::1"]) {
+      const result = await assertFetchableUrl("https://inside.test/x.png", async () => [ip]);
+      expect(result, ip).toEqual(blocked);
+    }
+  });
+
+  it("refuses a name answering with one public and one private address", async () => {
+    // Split-horizon rebinding: passing on the strength of the good answer
+    // would let the connection land on the bad one.
+    const result = await assertFetchableUrl("https://rebind.test/x.png", async () => [
+      "93.184.216.34",
+      "169.254.169.254",
+    ]);
+
+    expect(result).toEqual(blocked);
+  });
+
+  it("refuses credentials embedded in the URL", async () => {
+    const result = await assertFetchableUrl("https://user:pass@images.example/x.png", publicHost);
+
+    expect(result).toEqual(blocked);
+  });
+
+  it("refuses a name that resolves to nothing", async () => {
+    expect(await assertFetchableUrl("https://void.test/x.png", async () => [])).toEqual(blocked);
+  });
+
+  it("refuses when the resolver itself fails", async () => {
+    const result = await assertFetchableUrl("https://nope.test/x.png", async () => {
+      throw new Error("ENOTFOUND");
+    });
+
+    expect(result).toEqual(blocked);
+  });
+
+  it("refuses input that is not a URL", async () => {
+    for (const raw of ["", "not a url", "//images.example/x.png"]) {
+      expect(await assertFetchableUrl(raw, publicHost), JSON.stringify(raw)).toEqual(blocked);
+    }
+  });
+
+  it("never resolves a host it has already rejected on scheme", async () => {
+    const resolver = vi.fn(publicHost);
+
+    await assertFetchableUrl("http://169.254.169.254/", resolver);
+
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/fetchableUrl.ts
+++ b/src/lib/fetchableUrl.ts
@@ -54,9 +54,14 @@ export async function assertFetchableUrl(
     return { ok: false, error: "url-not-allowed" };
   }
 
-  // A name that resolves to nothing tells us nothing, and EVERY address has to
-  // pass: one public and one private answer is a rebinding attempt, not a
+  // A name that resolves to nothing tells us nothing, and EVERY answer has to
+  // pass: one public and one private address is a rebinding attempt, not a
   // coincidence.
+  //
+  // This narrows rebinding rather than closing it. `fetch` resolves the name
+  // again for itself, so an authoritative server answering differently the
+  // second time still wins. Closing that needs the connection pinned to an
+  // address we checked, which means a custom dispatcher.
   if (addresses.length === 0) {
     return { ok: false, error: "url-not-allowed" };
   }
@@ -70,15 +75,18 @@ export async function assertFetchableUrl(
 /**
  * The hostname as a bare IP address, or null if it is a name.
  *
- * URL keeps IPv6 hosts in brackets, so those come off first. Anything made
- * only of digits and dots counts, including the octal and hex spellings that
- * `isPublicAddress` refuses — the point is to route them to that judgement
- * rather than to DNS.
+ * Deliberately strict. `URL` has already canonicalised every IPv4 shorthand by
+ * the time we see it — `https://2852039166/`, `https://0177.0.0.1/` and
+ * `https://127.1/` all arrive as plain dotted quads — so nothing is gained by
+ * guessing at looser spellings, and guessing costs real hostnames: a test of
+ * "digits, dots and hex letters" swallows `b2b.ec` and `f5.ca`, which are
+ * names, and refuses them as malformed addresses.
+ *
+ * IPv6 hosts keep their brackets in a URL, which is what identifies them.
  */
 function asIpLiteral(hostname: string): string | null {
-  const bare = hostname.replace(/^\[/, "").replace(/\]$/, "");
-  if (bare === "") return null;
-  if (bare.includes(":")) return bare; // any IPv6 form
-  if (/^[0-9a-fx.]+$/i.test(bare) && /\d/.test(bare)) return bare;
-  return null;
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) ? hostname : null;
 }

--- a/src/lib/fetchableUrl.ts
+++ b/src/lib/fetchableUrl.ts
@@ -1,0 +1,84 @@
+import { isPublicAddress } from "@/lib/publicAddress";
+
+/**
+ * Is this URL safe for the SERVER to request on a stranger's behalf?
+ *
+ * A pasted link is fetched from inside our own network, where none of the
+ * browser's protections apply: `http://169.254.169.254/` hands back instance
+ * credentials, and `https://10.0.0.5:5432` probes a database nobody outside
+ * can reach. So the scheme is restricted and the hostname is resolved, letting
+ * the decision be made about the address we will actually talk to rather than
+ * the name written in front of it.
+ *
+ * Takes its resolver rather than calling DNS, so the rule can be tested by
+ * handing it answers instead of depending on the network.
+ */
+export async function assertFetchableUrl(
+  raw: string,
+  resolveHost: (hostname: string) => Promise<string[]>
+): Promise<{ ok: true; url: URL } | { ok: false; error: string }> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, error: "url-not-allowed" };
+  }
+
+  // https only: `file:` would read the server's own disk, and plain http lets
+  // anyone on the path swap the image for something else anyway.
+  if (url.protocol !== "https:") {
+    return { ok: false, error: "url-not-allowed" };
+  }
+
+  // Credentials in a URL are only ever an attempt to have us authenticate to
+  // something internal.
+  if (url.username || url.password) {
+    return { ok: false, error: "url-not-allowed" };
+  }
+
+  // A hostname that is already an address is judged on the spot. Sending it
+  // through DNS would make the verdict depend on a resolver echoing literals
+  // back unchanged, and `https://169.254.169.254/` must be refused whatever a
+  // resolver has to say about it.
+  const literal = asIpLiteral(url.hostname);
+  if (literal !== null) {
+    return isPublicAddress(literal)
+      ? { ok: true, url }
+      : { ok: false, error: "url-not-allowed" };
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await resolveHost(url.hostname);
+  } catch {
+    return { ok: false, error: "url-not-allowed" };
+  }
+
+  // A name that resolves to nothing tells us nothing, and EVERY address has to
+  // pass: one public and one private answer is a rebinding attempt, not a
+  // coincidence.
+  if (addresses.length === 0) {
+    return { ok: false, error: "url-not-allowed" };
+  }
+  if (!addresses.every(isPublicAddress)) {
+    return { ok: false, error: "url-not-allowed" };
+  }
+
+  return { ok: true, url };
+}
+
+/**
+ * The hostname as a bare IP address, or null if it is a name.
+ *
+ * URL keeps IPv6 hosts in brackets, so those come off first. Anything made
+ * only of digits and dots counts, including the octal and hex spellings that
+ * `isPublicAddress` refuses — the point is to route them to that judgement
+ * rather than to DNS.
+ */
+function asIpLiteral(hostname: string): string | null {
+  const bare = hostname.replace(/^\[/, "").replace(/\]$/, "");
+  if (bare === "") return null;
+  if (bare.includes(":")) return bare; // any IPv6 form
+  if (/^[0-9a-fx.]+$/i.test(bare) && /\d/.test(bare)) return bare;
+  return null;
+}

--- a/src/lib/playerLevel.ts
+++ b/src/lib/playerLevel.ts
@@ -3,6 +3,12 @@ export type PlayerLevel = {
   name: string;
   defeats: number;
   nextAt: number | null;
+  /**
+   * Fraction through the CURRENT band. Nothing renders this, on purpose: the
+   * first three bands are one boss wide, so it is pinned at 0 for every new
+   * player. The avatar card draws a pip per evolution instead. Wiring this to
+   * a progress bar puts back a bar that cannot fill until squire.
+   */
   progress: number;
 };
 

--- a/src/lib/publicAddress.test.ts
+++ b/src/lib/publicAddress.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isPublicAddress } from "@/lib/publicAddress";
+
+describe("isPublicAddress", () => {
+  it("allows ordinary public addresses", () => {
+    for (const ip of ["93.184.216.34", "8.8.8.8", "1.1.1.1", "142.250.187.206"]) {
+      expect(isPublicAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it("refuses the cloud metadata endpoint", () => {
+    // The one that matters: it hands instance credentials to any caller.
+    expect(isPublicAddress("169.254.169.254")).toBe(false);
+    expect(isPublicAddress("::ffff:169.254.169.254")).toBe(false);
+    expect(isPublicAddress("169.254.0.1")).toBe(false);
+  });
+
+  it("refuses loopback and the private ranges", () => {
+    for (const ip of [
+      "127.0.0.1", "127.1.2.3", "0.0.0.0",
+      "10.0.0.1", "10.255.255.255",
+      "172.16.0.1", "172.31.255.255",
+      "192.168.0.1", "192.168.1.1",
+      "100.64.0.1", // CGNAT
+    ]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("allows the public neighbours of private ranges", () => {
+    // Off-by-one guards: these sit just outside the blocked blocks.
+    for (const ip of ["172.15.0.1", "172.32.0.1", "11.0.0.1", "100.63.255.255", "100.128.0.1"]) {
+      expect(isPublicAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it("refuses multicast, reserved and broadcast", () => {
+    for (const ip of ["224.0.0.1", "239.255.255.250", "240.0.0.1", "255.255.255.255"]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("refuses octal and hex octets that resolvers disagree about", () => {
+    // 0177.0.0.1 is 127.0.0.1 to anything reading it as octal.
+    for (const ip of ["0177.0.0.1", "010.0.0.1", "0x7f.0.0.1", "127.0.0.01"]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("refuses IPv6 loopback, unique-local and link-local", () => {
+    for (const ip of ["::1", "::", "fc00::1", "fd12:3456::1", "fe80::1", "fe80::1%eth0", "ff02::1"]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("allows public IPv6", () => {
+    for (const ip of ["2606:4700:4700::1111", "2a00:1450:4009:81f::200e"]) {
+      expect(isPublicAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it("refuses anything it cannot parse rather than failing open", () => {
+    for (const ip of ["", "   ", "not-an-ip", "1.2.3", "1.2.3.4.5", "999.1.1.1", "<script>"]) {
+      expect(isPublicAddress(ip), JSON.stringify(ip)).toBe(false);
+    }
+  });
+});

--- a/src/lib/publicAddress.test.ts
+++ b/src/lib/publicAddress.test.ts
@@ -65,3 +65,54 @@ describe("isPublicAddress", () => {
     }
   });
 });
+
+describe("isPublicAddress — IPv4 hidden inside IPv6", () => {
+  // These all reach the metadata endpoint or the private network while looking
+  // nothing like it as text. `new URL()` rewrites the readable spellings into
+  // hex, so a guard that matched prefixes as strings waved them through.
+  it("refuses IPv4-mapped addresses in hex form", () => {
+    expect(isPublicAddress("::ffff:a9fe:a9fe")).toBe(false); // 169.254.169.254
+    expect(isPublicAddress("::ffff:7f00:1")).toBe(false); // 127.0.0.1
+    expect(isPublicAddress("::ffff:a00:1")).toBe(false); // 10.0.0.1
+    expect(isPublicAddress("::ffff:c0a8:1")).toBe(false); // 192.168.0.1
+  });
+
+  it("refuses deprecated IPv4-compatible addresses", () => {
+    expect(isPublicAddress("::7f00:1")).toBe(false); // 127.0.0.1
+    expect(isPublicAddress("::a9fe:a9fe")).toBe(false); // 169.254.169.254
+  });
+
+  it("refuses 6to4-wrapped private addresses", () => {
+    expect(isPublicAddress("2002:a00:1::1")).toBe(false); // wraps 10.0.0.1
+    expect(isPublicAddress("2002:a9fe:a9fe::")).toBe(false); // wraps metadata
+    expect(isPublicAddress("2002:7f00:1::")).toBe(false); // wraps 127.0.0.1
+  });
+
+  it("refuses NAT64-translated private addresses", () => {
+    expect(isPublicAddress("64:ff9b::a9fe:a9fe")).toBe(false);
+    expect(isPublicAddress("64:ff9b::7f00:1")).toBe(false);
+  });
+
+  it("still allows 6to4 wrapping a public address", () => {
+    // 2002:5db8:d822:: wraps 93.184.216.34 — a real public host.
+    expect(isPublicAddress("2002:5db8:d822::")).toBe(true);
+  });
+
+  it("refuses malformed IPv6 rather than failing open", () => {
+    for (const ip of ["::ffff::1", "1:2:3", "gggg::1", "1::2::3", "12345::1"]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+})
+
+describe("isPublicAddress — reserved ranges are the documented width", () => {
+  it("blocks only the reserved /24s, not the whole /16", () => {
+    // These are routable public space and must not be refused.
+    for (const ip of ["192.0.1.5", "198.51.50.5", "203.0.50.5"]) {
+      expect(isPublicAddress(ip), ip).toBe(true);
+    }
+    for (const ip of ["192.0.0.8", "192.0.2.5", "198.51.100.5", "203.0.113.5"]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+})

--- a/src/lib/publicAddress.ts
+++ b/src/lib/publicAddress.ts
@@ -1,0 +1,71 @@
+/**
+ * Is this IP address one we are willing to make a request to?
+ *
+ * Only addresses on the public internet qualify. Everything reachable *from*
+ * the server but not *by* the person pasting the link is refused: loopback,
+ * the RFC1918 ranges, and above all 169.254.169.254, the cloud metadata
+ * endpoint that hands out instance credentials to anything that asks.
+ *
+ * Rejects anything it cannot parse. A blocklist that fails open is not a
+ * blocklist, and an address we do not recognise is not one we can vouch for.
+ */
+export function isPublicAddress(ip: string): boolean {
+  const addr = ip.trim().toLowerCase();
+  if (addr === "") return false;
+
+  // ::ffff:169.254.169.254 reaches the same metadata service as the bare v4
+  // address, so unwrap IPv4-mapped form before judging it.
+  const mapped = addr.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPublicAddress(mapped[1]);
+
+  if (addr.includes(":")) return isPublicV6(addr);
+  return isPublicV4(addr);
+}
+
+function isPublicV4(addr: string): boolean {
+  const parts = addr.split(".");
+  if (parts.length !== 4) return false;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    // Reject "010" and "0x7f": a leading zero or 0x prefix is read as octal or
+    // hex by some resolvers and as decimal by others, which is exactly the
+    // disagreement an attacker wants.
+    if (!/^\d{1,3}$/.test(part)) return false;
+    if (part.length > 1 && part[0] === "0") return false;
+    const n = Number(part);
+    if (n > 255) return false;
+    octets.push(n);
+  }
+
+  const [a, b] = octets;
+  if (a === 0) return false; // 0.0.0.0/8 "this network"
+  if (a === 10) return false; // private
+  if (a === 127) return false; // loopback
+  if (a === 169 && b === 254) return false; // link-local INCLUDING metadata
+  if (a === 172 && b >= 16 && b <= 31) return false; // private
+  if (a === 192 && b === 168) return false; // private
+  if (a === 100 && b >= 64 && b <= 127) return false; // CGNAT
+  if (a === 192 && b === 0) return false; // 192.0.0/24 + 192.0.2/24 test nets
+  if (a === 198 && (b === 18 || b === 19)) return false; // benchmarking
+  if (a === 198 && b === 51) return false; // TEST-NET-2
+  if (a === 203 && b === 0) return false; // TEST-NET-3
+  if (a >= 224) return false; // multicast, reserved, broadcast
+
+  return true;
+}
+
+function isPublicV6(addr: string): boolean {
+  // Strip a zone index (fe80::1%eth0) before matching.
+  const bare = addr.split("%")[0];
+  if (!/^[0-9a-f:.]+$/.test(bare)) return false;
+
+  if (bare === "::" || bare === "::1") return false; // unspecified, loopback
+  if (/^f[cd]/.test(bare)) return false; // fc00::/7 unique local
+  if (/^fe[89ab]/.test(bare)) return false; // fe80::/10 link-local
+  if (/^ff/.test(bare)) return false; // ff00::/8 multicast
+  if (/^2001:0?db8:/.test(bare)) return false; // documentation
+  if (/^64:ff9b:/.test(bare)) return false; // NAT64, can wrap a private v4
+
+  return true;
+}

--- a/src/lib/publicAddress.ts
+++ b/src/lib/publicAddress.ts
@@ -6,6 +6,12 @@
  * the RFC1918 ranges, and above all 169.254.169.254, the cloud metadata
  * endpoint that hands out instance credentials to anything that asks.
  *
+ * IPv6 is decoded rather than prefix-matched, because half a dozen forms carry
+ * an IPv4 address inside them and `new URL()` rewrites them into hex on the
+ * way past: `[::ffff:169.254.169.254]` arrives as `::ffff:a9fe:a9fe`, which
+ * matches no textual pattern for the metadata endpoint while reaching exactly
+ * the same host.
+ *
  * Rejects anything it cannot parse. A blocklist that fails open is not a
  * blocklist, and an address we do not recognise is not one we can vouch for.
  */
@@ -13,12 +19,7 @@ export function isPublicAddress(ip: string): boolean {
   const addr = ip.trim().toLowerCase();
   if (addr === "") return false;
 
-  // ::ffff:169.254.169.254 reaches the same metadata service as the bare v4
-  // address, so unwrap IPv4-mapped form before judging it.
-  const mapped = addr.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mapped) return isPublicAddress(mapped[1]);
-
-  if (addr.includes(":")) return isPublicV6(addr);
+  if (addr.includes(":")) return isPublicV6(addr.split("%")[0]);
   return isPublicV4(addr);
 }
 
@@ -38,7 +39,10 @@ function isPublicV4(addr: string): boolean {
     octets.push(n);
   }
 
-  const [a, b] = octets;
+  return isPublicOctets(octets);
+}
+
+function isPublicOctets([a, b, c]: number[]): boolean {
   if (a === 0) return false; // 0.0.0.0/8 "this network"
   if (a === 10) return false; // private
   if (a === 127) return false; // loopback
@@ -46,26 +50,91 @@ function isPublicV4(addr: string): boolean {
   if (a === 172 && b >= 16 && b <= 31) return false; // private
   if (a === 192 && b === 168) return false; // private
   if (a === 100 && b >= 64 && b <= 127) return false; // CGNAT
-  if (a === 192 && b === 0) return false; // 192.0.0/24 + 192.0.2/24 test nets
+  if (a === 192 && b === 0 && (c === 0 || c === 2)) return false; // IETF + TEST-NET-1
   if (a === 198 && (b === 18 || b === 19)) return false; // benchmarking
-  if (a === 198 && b === 51) return false; // TEST-NET-2
-  if (a === 203 && b === 0) return false; // TEST-NET-3
+  if (a === 198 && b === 51 && c === 100) return false; // TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return false; // TEST-NET-3
   if (a >= 224) return false; // multicast, reserved, broadcast
 
   return true;
 }
 
 function isPublicV6(addr: string): boolean {
-  // Strip a zone index (fe80::1%eth0) before matching.
-  const bare = addr.split("%")[0];
-  if (!/^[0-9a-f:.]+$/.test(bare)) return false;
+  const groups = expandV6(addr);
+  if (groups === null) return false;
 
-  if (bare === "::" || bare === "::1") return false; // unspecified, loopback
-  if (/^f[cd]/.test(bare)) return false; // fc00::/7 unique local
-  if (/^fe[89ab]/.test(bare)) return false; // fe80::/10 link-local
-  if (/^ff/.test(bare)) return false; // ff00::/8 multicast
-  if (/^2001:0?db8:/.test(bare)) return false; // documentation
-  if (/^64:ff9b:/.test(bare)) return false; // NAT64, can wrap a private v4
+  // Any form carrying an IPv4 address is judged as that address. This is the
+  // one that matters: ::ffff:a9fe:a9fe and 2002:a9fe:a9fe:: both reach
+  // 169.254.169.254.
+  const embedded = embeddedV4(groups);
+  if (embedded !== null) return isPublicOctets(embedded);
+
+  const [g0, g1] = groups;
+  if ((g0 & 0xfe00) === 0xfc00) return false; // fc00::/7 unique local
+  if ((g0 & 0xffc0) === 0xfe80) return false; // fe80::/10 link-local
+  if ((g0 & 0xff00) === 0xff00) return false; // ff00::/8 multicast
+  if (g0 === 0x2001 && g1 === 0x0db8) return false; // documentation
+  if (g0 === 0x0100 && g1 === 0 && groups[2] === 0 && groups[3] === 0) {
+    return false; // 100::/64 discard-only
+  }
 
   return true;
+}
+
+/** The IPv4 address embedded in an IPv6 one, as octets, or null. */
+function embeddedV4(g: number[]): number[] | null {
+  const leadingZero = g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0;
+
+  // ::ffff:a.b.c.d — IPv4-mapped, and ::a.b.c.d — IPv4-compatible. The second
+  // is deprecated, which is precisely why a guard is unlikely to expect it.
+  // :: and ::1 fall in here too and decode to 0.0.0.0 and 0.0.0.1, which the
+  // octet rules already refuse — no need to special-case them back out.
+  if (leadingZero && (g[5] === 0xffff || g[5] === 0)) {
+    return groupsToOctets(g[6], g[7]);
+  }
+  // 2002:a.b.c.d::/48 — 6to4 wraps an IPv4 address in its second and third
+  // groups.
+  if (g[0] === 0x2002) return groupsToOctets(g[1], g[2]);
+  // 64:ff9b::/96 — NAT64 translates to the IPv4 address in its tail.
+  if (g[0] === 0x0064 && g[1] === 0xff9b) return groupsToOctets(g[6], g[7]);
+
+  return null;
+}
+
+function groupsToOctets(high: number, low: number): number[] {
+  return [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff];
+}
+
+/** An IPv6 address as its eight 16-bit groups, or null if it will not parse. */
+function expandV6(input: string): number[] | null {
+  let text = input;
+
+  // A trailing dotted quad becomes the last two groups before anything else.
+  const dotted = text.match(/^(.*:)(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (dotted) {
+    const octets = dotted.slice(2).map(Number);
+    if (octets.some((n) => n > 255)) return null;
+    const high = ((octets[0] << 8) | octets[1]).toString(16);
+    const low = ((octets[2] << 8) | octets[3]).toString(16);
+    text = `${dotted[1]}${high}:${low}`;
+  }
+
+  const halves = text.split("::");
+  if (halves.length > 2) return null;
+
+  const head = halves[0] === "" ? [] : halves[0].split(":");
+  const tail = halves.length === 2 ? (halves[1] === "" ? [] : halves[1].split(":")) : [];
+
+  let parts: string[];
+  if (halves.length === 1) {
+    parts = head;
+  } else {
+    const missing = 8 - head.length - tail.length;
+    if (missing < 1) return null;
+    parts = [...head, ...Array<string>(missing).fill("0"), ...tail];
+  }
+  if (parts.length !== 8) return null;
+
+  const groups = parts.map((p) => (/^[0-9a-f]{1,4}$/.test(p) ? parseInt(p, 16) : NaN));
+  return groups.some(Number.isNaN) ? null : groups;
 }

--- a/src/lib/resolveHost.ts
+++ b/src/lib/resolveHost.ts
@@ -1,0 +1,13 @@
+import { lookup } from "node:dns/promises";
+
+/**
+ * Every address a hostname resolves to.
+ *
+ * The one place DNS is touched, kept to a single thin function so the guard
+ * that judges those addresses stays free of I/O and can be tested by handing
+ * it answers directly.
+ */
+export async function resolveHost(hostname: string): Promise<string[]> {
+  const addresses = await lookup(hostname, { all: true });
+  return addresses.map((a) => a.address);
+}


### PR DESCRIPTION
Release of three changes already reviewed and merged to `develop`. Merging this updates `main`, which is the branch production is deployed from.

| | |
|---|---|
| [#428](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/428) | **Security** — close the SSRF in the prize photo URL fetch |
| [#427](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/427) | Evolution pips replace the avatar progress bar |
| [#425](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/425) | Streak freezes actually absorb a missed day |

## The one that matters

`uploadPrizePhoto` called `fetch()` on whatever URL was pasted into the prize photo field. Sign-ups are open, so any signed-in user could make the server request `http://169.254.169.254/latest/meta-data/` and read instance credentials, probe internal services, or hand it `file://`.

Now guarded: https only, no embedded credentials, every DNS answer checked, and IPv6 **decoded** rather than pattern-matched — `[::ffff:169.254.169.254]` arrives as `::ffff:a9fe:a9fe` and would otherwise match no textual rule while reaching exactly that host. Redirects are followed by hand and re-checked per hop, since the automatic ones were the real hole. Also closes a path-traversal in the blob filename, which is the only thing keeping one family's photos out of another's.

## Also shipping

**Streak freezes work.** Both freeze actions previously had zero call sites and `computeStreak` didn't know freezes existed, so the badge showed a count nothing could spend. After checking in, Today now offers to bridge the missed day. Also lifts a cap that limited every streak to 7 days and reset it each Monday.

**Evolution pips.** The avatar bar measured distance to the next rank, and the first three bands are one boss wide — it rendered empty for every new player. Nine pips, lit to the current rank. Display only: same thresholds, same defeats, same freeze awards, same art.

## Deploy notes

- **No schema change** in this release. The `Lane.startsOn` / `LaneTarget` migration went out with the previous one and is already applied.
- **Eddie's streaks will read higher** than before — they were capped at 7 and reset weekly; his real runs now surface.
- **His banked freeze becomes spendable** the first time he checks in on a day following a repairable gap.
- Worth confirming after deploy that the qualified-week count on `/prize` is unchanged.

## Verification on develop

418 tests / 72 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds. The SSRF guard was mutation-tested — disabling it fails 12 tests — and every bypass found in review is pinned by a regression test naming the address it decodes to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)