### PR TITLE
release: history day colours

### DIFF
--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -139,6 +139,50 @@ describe('Page', () => {
     expect(screen.queryByText(/Empty Retired Lane/)).not.toBeInTheDocument()
   })
 
+  it('only the day the boss fell is purple, not the whole week', async () => {
+    // The case the old test could not see: with a single check-in day, "every
+    // day purple" and "the boss day purple" look identical. Five days apart
+    // they do not, and beating a boss used to repaint the whole week.
+    const { prisma } = await import('@/lib/db')
+    const monday = new Date('2026-08-17T00:00:00.000Z')
+    const friday = new Date('2026-08-21T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        bossBattles: [{ weekStarting: getWeekStart(monday), completedAt: friday }],
+        checkIns: [
+          { date: monday, isRest: false },
+          { date: new Date('2026-08-18T00:00:00.000Z'), isRest: false },
+          { date: new Date('2026-08-19T00:00:00.000Z'), isRest: false },
+          { date: new Date('2026-08-20T00:00:00.000Z'), isRest: false },
+          { date: friday, isRest: false },
+        ],
+      },
+    ] as any)
+
+    const { container } = render(await Page())
+
+    expect(container.querySelectorAll('.bg-purple-500')).toHaveLength(1)
+    expect(container.querySelectorAll('.bg-green-400')).toHaveLength(4)
+  })
+
+  it('a boss beaten at a time of day still matches its calendar day', async () => {
+    const { prisma } = await import('@/lib/db')
+    const day = new Date('2026-08-18T00:00:00.000Z')
+    vi.mocked(prisma.lane.findMany).mockResolvedValue([
+      {
+        id: 'l1', name: 'Jogs', emoji: '🏃', isActive: true, targetPerWeek: 5, sortOrder: 0,
+        // Beaten at 7pm, while the check-in is stored at UTC midnight.
+        bossBattles: [{ weekStarting: getWeekStart(day), completedAt: new Date('2026-08-18T19:32:00.000Z') }],
+        checkIns: [{ date: day, isRest: false }],
+      },
+    ] as any)
+
+    const { container } = render(await Page())
+
+    expect(container.querySelectorAll('.bg-purple-500')).toHaveLength(1)
+  })
+
   it('a session inside a battle week is purple', async () => {
     const { prisma } = await import('@/lib/db')
     const day = new Date('2026-08-18T00:00:00.000Z')

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -31,7 +31,7 @@ export default async function HistoryPage() {
   return (
     <main className="max-w-3xl mx-auto space-y-8 p-6">
       <h1 className="text-2xl font-bold">History</h1>
-      <p className="mt-1 text-sm text-zinc-500">Your season, week by week — green for a session, blue for a rest day, purple for a boss-battle week. Only days you showed up are here.</p>
+      <p className="mt-1 text-sm text-zinc-500">Your season, week by week — green for a session, blue for a rest day, purple for the day you beat a boss. Only days you showed up are here.</p>
       {recaps.map((recap) => (
         <section key={recap.weekStart.getTime()} className="space-y-3">
           <h2 className="text-lg font-semibold">
@@ -53,19 +53,34 @@ export default async function HistoryPage() {
                 )}
               </span>
               <div className="flex gap-1">
-                {lane.days.map((d) => (
-                  <div
-                    key={d.date.getTime()}
-                    className={`h-6 w-6 rounded ${
-                      d.isRest
-                        ? "bg-blue-300"
-                        : lane.battleFought
-                          ? "bg-purple-500"
-                          : "bg-green-400"
-                    }`}
-                    title={d.date.toISOString().slice(0, 10)}
-                  />
-                ))}
+                {lane.days.map((d) => {
+                  // Purple marks the day the boss fell, not the week it fell
+                  // in. Keying this off the week-level flag repainted every
+                  // session purple and lost the record of showing up.
+                  const beatTheBoss =
+                    lane.battleDay !== null &&
+                    d.date.getTime() === lane.battleDay.getTime()
+
+                  return (
+                    <div
+                      key={d.date.getTime()}
+                      // Rest still wins: a rest day reads blue even if the boss
+                      // happened to fall on it, which is the rule this page
+                      // already held to.
+                      className={`h-6 w-6 rounded ${
+                        d.isRest
+                          ? "bg-blue-300"
+                          : beatTheBoss
+                            ? "bg-purple-500"
+                            : "bg-green-400"
+                      }`}
+                      title={
+                        d.date.toISOString().slice(0, 10) +
+                        (d.isRest ? " — rest day" : beatTheBoss ? " — boss defeated" : "")
+                      }
+                    />
+                  )
+                })}
               </div>
               <span className="text-sm text-zinc-600">
                 {lane.hits} / {lane.target} days

--- a/src/lib/weekRecap.ts
+++ b/src/lib/weekRecap.ts
@@ -27,6 +27,14 @@ export interface RecapLaneWeek {
   hits: number;
   target: number;
   battleFought: boolean;
+  /**
+   * The day the boss fell, at UTC midnight, or null.
+   *
+   * Kept separate from `battleFought` because a boss can be beaten in its
+   * grace week — the week after the one it belongs to — so a week can be
+   * marked as fought without any of ITS days being the day it happened.
+   */
+  battleDay: Date | null;
   days: RecapDay[];
 }
 
@@ -64,6 +72,7 @@ export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
           hits: 0,
           days: [],
           battleFought: false,
+          battleDay: null,
           sortOrder: lane.sortOrder
         });
       }
@@ -86,6 +95,10 @@ export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
           if (weekEntry.laneData.has(lane.id)) {
             const laneWeek = weekEntry.laneData.get(lane.id)!;
             laneWeek.battleFought = true;
+            const fell = battle.completedAt;
+            laneWeek.battleDay = new Date(
+              Date.UTC(fell.getUTCFullYear(), fell.getUTCMonth(), fell.getUTCDate())
+            );
           }
         }
       }
@@ -112,6 +125,7 @@ export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
             );
           })(),
           battleFought: ld.battleFought,
+          battleDay: ld.battleDay,
           days: ld.days.sort((a: RecapDay, b: RecapDay) => a.date.getTime() - b.date.getTime())
         }))
         .sort((a, b) => {


### PR DESCRIPTION
Release of [#430](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/430), reviewed and merged to `develop`. Merging this updates `main`, the branch production is deployed from.

## What ships

**Purple marks the day the boss fell, not the whole week.** History coloured every square from a week-level flag, so beating a boss repainted every session that week purple — erasing the record of showing up that the page exists to show.

```
before   🟪🟪🟪🟪🟪  5/5  ⚔️ boss fought
after    🟩🟩🟩🟩🟪  5/5  ⚔️ boss fought
```

The week recap now carries the defeat day alongside the existing flag. Both are kept, because a boss can be beaten in its grace week — the week after the one it belongs to — so a week can be marked as fought without any of its own days being the day it happened.

Rest still wins over purple, matching the rule the page already held. The legend copy now says "purple for the day you beat a boss" rather than "boss-battle week".

## Deploy notes

- **No schema change.** Display and one added field on an in-memory recap type.
- **Nothing to back-fill.** `BossBattle.completedAt` has always been recorded; it was simply discarded by the recap.
- Eddie's History will look different immediately: sessions in his boss weeks go back to green, with a single purple square on the day he won.

## Verification on develop

420 tests / 72 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds. The new test was mutation-checked against the old rule — the previous test could not distinguish the two, because it had a single check-in day that was also the defeat day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)