### PR TITLE
release: a defeated boss earns its own square

### DIFF
--- a/src/lib/weekRecap.test.ts
+++ b/src/lib/weekRecap.test.ts
@@ -126,3 +126,69 @@ describe('weekRecap', () => {
     expect(laneWeek.days[1].isRest).toBe(false);
   });
 });
+describe('buildWeekRecaps — the boss gets its own square', () => {
+  const D = (s: string) => new Date(s + 'T00:00:00.000Z')
+  const lane = (checkIns: { date: Date; isRest: boolean }[], completedAt: Date | null) => [{
+    id: 'l1', name: 'Wall ball', emoji: '🥍', targetPerWeek: 5,
+    isActive: true, sortOrder: 0, checkIns,
+    bossBattles: completedAt ? [{ weekStarting: D('2026-08-10'), completedAt }] : [],
+  }]
+
+  const trainedMonToFri = [
+    { date: D('2026-08-10'), isRest: false },
+    { date: D('2026-08-11'), isRest: false },
+    { date: D('2026-08-12'), isRest: false },
+    { date: D('2026-08-13'), isRest: false },
+    { date: D('2026-08-14'), isRest: false },
+  ]
+
+  it('adds a square for a victory on a day with no check-in', () => {
+    // Beaten on the Saturday, a day he did not otherwise train.
+    const [week] = buildWeekRecaps(lane(trainedMonToFri, D('2026-08-15')))
+    const row = week.lanes[0]
+
+    expect(row.days).toHaveLength(6)
+    expect(row.days[5].date).toEqual(D('2026-08-15'))
+    expect(row.battleDay).toEqual(D('2026-08-15'))
+  })
+
+  it('does not count that square toward the weekly target', () => {
+    // Beating a boss is not a training day: the tally stays at what he trained.
+    const [week] = buildWeekRecaps(lane(trainedMonToFri, D('2026-08-15')))
+
+    expect(week.lanes[0].hits).toBe(5)
+    expect(week.lanes[0].days).toHaveLength(6)
+  })
+
+  it('does not double up when the victory lands on a training day', () => {
+    const [week] = buildWeekRecaps(lane(trainedMonToFri, D('2026-08-14')))
+    const row = week.lanes[0]
+
+    expect(row.days).toHaveLength(5)
+    expect(row.days.filter((d) => d.date.getTime() === D('2026-08-14').getTime())).toHaveLength(1)
+  })
+
+  it('keeps the square in date order', () => {
+    const [week] = buildWeekRecaps(lane(trainedMonToFri, D('2026-08-11')))
+    const dates = week.lanes[0].days.map((d) => d.date.getTime())
+
+    expect(dates).toEqual([...dates].sort((a, b) => a - b))
+  })
+
+  it('adds no square for a boss beaten in its grace week', () => {
+    // A square dated after the row it sits in would misstate when the week
+    // ended; the fought label still marks the week.
+    const [week] = buildWeekRecaps(lane(trainedMonToFri, D('2026-08-18')))
+    const row = week.lanes[0]
+
+    expect(row.days).toHaveLength(5)
+    expect(row.battleFought).toBe(true)
+  })
+
+  it('adds no square when the boss was never beaten', () => {
+    const [week] = buildWeekRecaps(lane(trainedMonToFri, null))
+
+    expect(week.lanes[0].days).toHaveLength(5)
+    expect(week.lanes[0].battleDay).toBeNull()
+  })
+})

--- a/src/lib/weekRecap.ts
+++ b/src/lib/weekRecap.ts
@@ -1,6 +1,8 @@
 import { getWeekStart } from "@/lib/weekUtils";
 import { effectiveTarget } from "@/lib/effectiveTarget";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 export interface RecapLaneInput {
   id: string;
   name: string;
@@ -96,9 +98,29 @@ export function buildWeekRecaps(lanes: RecapLaneInput[]): WeekRecap[] {
             const laneWeek = weekEntry.laneData.get(lane.id)!;
             laneWeek.battleFought = true;
             const fell = battle.completedAt;
-            laneWeek.battleDay = new Date(
+            const fellOn = new Date(
               Date.UTC(fell.getUTCFullYear(), fell.getUTCMonth(), fell.getUTCDate())
             );
+            laneWeek.battleDay = fellOn;
+
+            // The boss earns a square of its own. Beating a challenge in the
+            // backyard IS showing up, so a victory on a day with no check-in
+            // still belongs on the row rather than vanishing behind a label.
+            //
+            // Only when it falls inside this week: a boss can be beaten in its
+            // grace week, and a square dated after the row it sits in would be
+            // a lie about when the week ended.
+            const weekEnd = new Date(weekStart.getTime() + 7 * DAY_MS);
+            const withinWeek = fellOn >= weekStart && fellOn < weekEnd;
+            const alreadyADay = laneWeek.days.some(
+              (d) => d.date.getTime() === fellOn.getTime()
+            );
+
+            // Pushed to `days` but NOT counted in `hits`: the target measures
+            // training days, and the victory is not one of them.
+            if (withinWeek && !alreadyADay) {
+              laneWeek.days.push({ date: fellOn, isRest: false });
+            }
           }
         }
       }


### PR DESCRIPTION
Release of [#432](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/432), reviewed and merged to `develop`. Merging this updates `main`, the branch production deploys from.

## What ships

Follow-up to the History colour fix. Purple only appeared when the victory landed on a day that already had a check-in, so beating a boss on a day he didn't otherwise train showed the ⚔️ label with no purple anywhere — the thing the colour exists to mark was invisible.

```
before   🟩🟩🟩🟩🟩    5/5  ⚔️ boss fought
after    🟩🟩🟩🟩🟩🟪  5/5  ⚔️ boss fought
```

Beating a challenge in the backyard is showing up, so the victory now earns a square of its own, in date order. It counts as a day but **not** as a hit — the weekly target measures training days — so a week can read `5/5` with six squares, the sixth being the boss. Skipped for a grace-week victory, where a square dated past the end of its row would misstate when the week finished.

## Deploy notes

- **No schema change.** `BossBattle.completedAt` has always been recorded.
- Nothing to back-fill; the change is in how the week recap is assembled.
- Eddie's History gains a purple square on any past week where he beat a boss on a non-training day.

## Verification on develop

426 tests / 72 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds. Rendered against real data in a local Postgres with the victory deliberately on a day with no check-in — the case that previously showed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)