### PR TITLE
release: the sign-out button

### DIFF
--- a/src/components/SidebarNav.test.tsx
+++ b/src/components/SidebarNav.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import SidebarNav from './SidebarNav'
 import { usePathname } from 'next/navigation'
@@ -6,6 +7,10 @@ import { usePathname } from 'next/navigation'
 vi.mock('next/navigation', () => ({
   usePathname: vi.fn(),
 }))
+
+// The button posts to a server action; under vitest it is just the function
+// the form is wired to, which is what these tests check.
+vi.mock('@/app/actions/signOutAction', () => ({ signOutAction: vi.fn() }))
 
 describe('SidebarNav', () => {
   beforeEach(() => {
@@ -65,4 +70,45 @@ describe('SidebarNav', () => {
     expect(prizeLink).toBeInTheDocument()
     expect(prizeLink).toHaveAttribute('href', '/prize')
   })
-}) 
+})
+
+describe('SidebarNav — signing out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(usePathname).mockReturnValue('/')
+  })
+
+  it('offers a way out, which the app previously had none of', async () => {
+    render(<SidebarNav />)
+
+    expect(screen.getByTestId('sign-out')).toHaveTextContent('Sign out')
+  })
+
+  it('submits to the sign-out action rather than a dead click', async () => {
+    // The action existed and was tested all along; nothing ever called it.
+    render(<SidebarNav />)
+
+    const form = screen.getByTestId('sign-out').closest('form')
+    expect(form).not.toBeNull()
+    expect(form).toHaveAttribute('action')
+  })
+
+  it('keeps the label readable to screen readers when collapsed', async () => {
+    const user = userEvent.setup()
+    render(<SidebarNav />)
+
+    await user.click(screen.getByRole('button', { name: 'Collapse menu' }))
+
+    expect(screen.getByTestId('sign-out')).toHaveTextContent('Sign out')
+    expect(screen.getByTestId('sign-out')).toHaveAttribute('title', 'Sign out')
+  })
+
+  it('offers nothing to sign out of on the sign-in page', async () => {
+    // The shell wraps every route, so the sidebar renders there too.
+    vi.mocked(usePathname).mockReturnValue('/signin')
+
+    render(<SidebarNav />)
+
+    expect(screen.queryByTestId('sign-out')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -3,13 +3,15 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { signOutAction } from '@/app/actions/signOutAction'
 import {
   TodayIcon,
   LanesIcon,
   BattlesIcon,
   PrizeIcon,
   HistoryIcon,
-  MenuIcon
+  MenuIcon,
+  SignOutIcon
 } from '@/components/icons'
 
 interface NavItem {
@@ -32,7 +34,7 @@ export default function SidebarNav() {
 
   return (
     <aside
-      className={`transition-all border-r border-zinc-800 bg-zinc-900 ${collapsed ? 'w-16' : 'w-56'}`}
+      className={`flex h-full flex-col transition-all border-r border-zinc-800 bg-zinc-900 ${collapsed ? 'w-16' : 'w-56'}`}
     >
       <div className="p-4">
         <button
@@ -70,6 +72,22 @@ export default function SidebarNav() {
           )
         })}
       </nav>
+
+      {/* Not on the sign-in page: the shell wraps every route, so the sidebar
+          renders there too, and offering to sign out of nothing is nonsense. */}
+      {pathname !== '/signin' && (
+        <form action={signOutAction} className="mt-auto border-t border-zinc-800 p-2">
+          <button
+            type="submit"
+            title="Sign out"
+            data-testid="sign-out"
+            className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-100"
+          >
+            <SignOutIcon />
+            <span className={collapsed ? 'sr-only' : ''}>Sign out</span>
+          </button>
+        </form>
+      )}
     </aside>
   )
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -78,3 +78,13 @@ export function PrizeIcon() {
     </svg>
   )
 }
+
+export function SignOutIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-5 w-5">
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  )
+}


### PR DESCRIPTION
Release of [#434](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/434), reviewed and merged to `develop`. Merging this updates `main`, the branch production deploys from.

## What ships

`signOutAction` has existed — correct, and with a passing test — since the auth work landed, and **nothing ever called it**. A signed-in user had no way out of the app short of clearing cookies. The multi-user design doc listed "sign-out in SidebarNav" as Phase 3 work; the action got built and the button never did.

It is now a form at the bottom of the sidebar posting to the action, so it works without JavaScript. The label goes screen-reader-only when the sidebar is collapsed, matching the nav links.

Hidden on `/signin`: the shell wraps every route, so the sidebar renders on the sign-in page too, and offering to sign out of nothing would be nonsense.

## Deploy notes

- **No schema change**, no migration, nothing to back-fill.
- Purely additive UI — no existing behaviour changes.
- After deploy, Eddie can sign out from the sidebar on any page.

## Verification on develop

430 tests / 72 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds. Confirmed against the running dev server that `/signin` contains zero occurrences of the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)