### PR TITLE
release: count a week the same way everywhere

### DIFF
--- a/src/app/boss-battles/page.test.tsx
+++ b/src/app/boss-battles/page.test.tsx
@@ -335,3 +335,49 @@ describe('Page', () => {
     expect(screen.queryByTestId('beat-boss')).not.toBeInTheDocument()
   })
 })
+
+describe('Page — the boss wakes on the season\'s count', () => {
+  const day = (iso: string) => new Date(iso + 'T00:00:00.000Z')
+
+  it('does not wake a boss on a week the prize grid will score as missed', async () => {
+    // Three rest days against a target of three. Raw that is 3/3 and the boss
+    // used to wake; the season counts it as 1, so the week is not earned.
+    const trainingDay = getTrainingDay(new Date())
+    const thisWeekStart = getWeekStart(trainingDay)
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([{
+      id: 'l1', name: 'Wall ball', emoji: '🥍', targetPerWeek: 3,
+      isActive: true, sortOrder: 0, startsOn: null, targetChanges: [],
+      checkIns: [
+        { date: thisWeekStart, isRest: true },
+        { date: new Date(thisWeekStart.getTime() + 86400000), isRest: true },
+        { date: new Date(thisWeekStart.getTime() + 172800000), isRest: true },
+      ],
+      bossBattles: [],
+    }] as any)
+
+    render(await Page())
+
+    expect(screen.getByTestId('battle-locked')).toBeInTheDocument()
+  })
+
+  it('keeps a beaten boss on screen even if the tally now reads lower', async () => {
+    // The safety net for tightening the count: a victory already won must not
+    // disappear behind "hit your target to unlock".
+    const trainingDay = getTrainingDay(new Date())
+    const thisWeekStart = getWeekStart(trainingDay)
+    vi.mocked(db.lane.findMany).mockResolvedValueOnce([{
+      id: 'l1', name: 'Wall ball', emoji: '🥍', targetPerWeek: 5,
+      isActive: true, sortOrder: 0, startsOn: null, targetChanges: [],
+      checkIns: [{ date: thisWeekStart, isRest: true }],
+      bossBattles: [{
+        weekStarting: thisWeekStart, challenge: 'burpees', rerollCount: 0,
+        completedAt: new Date(), coachNote: 'Well won.',
+      }],
+    }] as any)
+
+    render(await Page())
+
+    expect(screen.queryByTestId('battle-locked')).not.toBeInTheDocument()
+    expect(screen.getByTestId('boss-defeated')).toBeInTheDocument()
+  })
+})

--- a/src/app/boss-battles/page.tsx
+++ b/src/app/boss-battles/page.tsx
@@ -12,6 +12,7 @@ import { validateSwap } from "@/lib/validateSwap"
 import { playerLevel } from "@/lib/playerLevel"
 import { requiredLanes } from "@/lib/laneRequirement"
 import { isLanePending } from "@/lib/lanePending"
+import { countQualifyingHits } from "@/lib/qualifyingWeek"
 import { effectiveTarget } from "@/lib/effectiveTarget"
 
 export const dynamic = "force-dynamic"
@@ -96,9 +97,7 @@ export default async function BossBattlesPage() {
     // swapped-in lane can still carry check-ins from an earlier stint that
     // would otherwise wake a boss for a week it sat retired.
     if (isLanePending(lane.startsOn, lastWeekStart)) return false
-    const lastWeekHits = lane.checkIns.filter(
-      (c) => c.date >= lastWeekStart && c.date < thisWeekStart
-    ).length
+    const lastWeekHits = countQualifyingHits(lane.checkIns, lastWeekStart)
     const lastWeekBattle = lane.bossBattles.find(
       (b) => b.weekStarting.getTime() === lastWeekStart.getTime()
     )
@@ -128,7 +127,9 @@ export default async function BossBattlesPage() {
 
       {lanes.map((lane) => {
         const pending = isLanePending(lane.startsOn, thisWeekStart)
-        const currentHits = lane.checkIns.filter((c) => c.date >= thisWeekStart).length
+        // The season's own counter, so a boss cannot wake on a week the Prize
+        // grid will score as missed.
+        const currentHits = countQualifyingHits(lane.checkIns, thisWeekStart)
         const target = effectiveTarget(
           lane.targetChanges,
           thisWeekStart,
@@ -160,11 +161,17 @@ export default async function BossBattlesPage() {
                 ⏳ New lane — its first boss wakes{" "}
                 {formatWeekLabel(lane.startsOn!)}.
               </p>
-            ) : hitTarget ? (
+            ) : hitTarget || battle ? (
+              /* `|| battle` keeps a boss already woken or already beaten on
+                 screen. A battle row only exists because the target was hit at
+                 the time, and hiding a victory behind "hit your target" if the
+                 tally later reads lower would take back something earned. */
               <div className="space-y-3">
-                <div className="text-sm font-medium text-green-600">
-                  ✅ Target hit
-                </div>
+                {hitTarget && (
+                  <div className="text-sm font-medium text-green-600">
+                    ✅ Target hit
+                  </div>
+                )}
                 {challengeCard(lane.id, thisWeekStart, battle, rerollAllowance)}
                 {battle?.completedAt && (
                   <BossBattleSwapTrigger

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -293,3 +293,72 @@ describe('Page — the freeze offer', () => {
     expect(include.checkIns.where.date.gte.getTime()).toBeLessThan(weekStart.getTime())
   })
 })
+
+describe('Page — the bar counts what the season counts', () => {
+  const day = (iso: string) => new Date(iso + 'T00:00:00.000Z')
+  const TODAY = '2026-08-23' // Sunday, so the whole week is in range
+
+  const laneWith = (checkIns: { date: Date; isRest: boolean }[]) => [{
+    id: 'l1', name: 'Wall ball', emoji: '🥍', targetPerWeek: 3,
+    isActive: true, sortOrder: 0, startsOn: null, targetChanges: [],
+    checkIns, streakFreezes: [],
+  }]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(TODAY + 'T18:00:00.000Z'))
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(prisma.lane.count).mockResolvedValue(3)
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  it('caps rest days the way the prize grid does', async () => {
+    // Three rest days and nothing else. The season counts that as one hit,
+    // so a target of three is NOT met — the bar used to read 3 / 3 and call
+    // it done while the Prize grid scored the same week as missed.
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(
+      laneWith([
+        { date: day('2026-08-17'), isRest: true },
+        { date: day('2026-08-18'), isRest: true },
+        { date: day('2026-08-19'), isRest: true },
+      ]) as never
+    )
+
+    render(await Page())
+
+    expect(screen.getByText('1 / 3 days this week')).toBeInTheDocument()
+  })
+
+  it('still gives a single rest day full credit', async () => {
+    // Rest counts — it is only the second one in a week that does not.
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(
+      laneWith([
+        { date: day('2026-08-17'), isRest: false },
+        { date: day('2026-08-18'), isRest: true },
+        { date: day('2026-08-19'), isRest: false },
+      ]) as never
+    )
+
+    render(await Page())
+
+    expect(screen.getByText('3 / 3 days this week')).toBeInTheDocument()
+  })
+
+  it('counts only this week, not the streak window behind it', async () => {
+    vi.mocked(prisma.lane.findMany).mockResolvedValue(
+      laneWith([
+        { date: day('2026-08-10'), isRest: false }, // last week
+        { date: day('2026-08-11'), isRest: false }, // last week
+        { date: day('2026-08-18'), isRest: false },
+      ]) as never
+    )
+
+    render(await Page())
+
+    expect(screen.getByText('1 / 3 days this week')).toBeInTheDocument()
+  })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db"
 import { requireUserId } from "@/lib/tenancy"
 import { computeStreak } from "@/lib/streak"
+import { countQualifyingHits } from "@/lib/qualifyingWeek"
 import { findRepairableGap } from "@/lib/repairableGap"
 import { getWeekStart } from "@/lib/weekUtils"
 import { getTrainingDay } from "@/lib/trainingDay"
@@ -113,9 +114,10 @@ export default async function DashboardPage() {
         const todayCheckIn = lane.checkIns.find(
           (c) => c.date.getTime() === today.getTime()
         )
-        // The query now reaches back past Monday for the streak, so this
-        // week's tally has to be narrowed again here.
-        const weeklyHits = lane.checkIns.filter((c) => c.date >= weekStart).length
+        // Counted the same way the season counts it. Rest days are capped at
+        // REST_CAP_PER_WEEK toward a target, so tallying them raw here showed
+        // a week as hit that the Prize grid then scored as missed.
+        const weeklyHits = countQualifyingHits(lane.checkIns, weekStart)
 
         const history = lane.checkIns.map((c) => ({
           date: c.date,


### PR DESCRIPTION
Release of [#436](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/436), reviewed and merged to `develop`. Merging this updates `main`, the branch production deploys from.

## What ships

Three places tallied a week's hits raw while only season qualification applied the rest cap, so the app disagreed with itself about whether a week was earned:

| site | counted |
|---|---|
| Today's progress bar | raw |
| **whether the boss wakes** | raw |
| whether last week's boss is still fightable | raw |
| `isQualifyingWeek` — what the prize depends on | rest-capped |

With `REST_CAP_PER_WEEK = 1`, three rest days against a target of three read as `3 / 3` with the boss unlocked, while the Prize grid scored that same week as **missed**. A challenge could be woken, fought and won for a week that never counted toward the season.

All three now use `countQualifyingHits`, the season's own counter. Rest still counts — only the second rest day in a week does not, which was already the rule.

## Deploy notes

- **No schema change**, nothing to back-fill.
- **Only weeks with two or more rest days change**, by `restDays − 1`. A week with one rest day or none reads identically.
- **Season scoring itself is unchanged.** `isQualifyingWeek` already applied the cap; this brings the other three into line with it, so the Prize grid's qualified-week count should not move.
- A tightened tally can fall below a target previously met, so the boss card is now shown when `hitTarget || battle` — an already-beaten boss stays on screen rather than hiding behind "hit your target to unlock".

## Worth checking after deploy

Eddie's Today numbers may read lower on any week where he logged two or more rest days, and that is the corrected figure. The Prize grid's qualified-week count should be unchanged — it is the one number to confirm.

## Verification on develop

435 tests / 72 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds. Mutation-tested: restoring the raw counting fails 3 of the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)