### PR TITLE
chore: keep the app out of search results for now

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,10 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Lacrosse Grind",
   description: "Daily training companion — effort over outcome.",
+  // Belt and braces with robots.txt. A URL linked from elsewhere — the
+  // marketing page links straight here — can be listed without ever being
+  // crawled, so the disallow alone would not keep it out of results.
+  robots: { index: false, follow: false },
 };
 
 export default async function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next"
+
+/**
+ * Keep the app out of search results.
+ *
+ * The demo made every page publicly readable, which also made them
+ * crawlable. This is a private training log for one family, not a site
+ * looking for traffic — the marketing page on GitHub Pages is what should
+ * be found, not a stranger's sample season or a signed-in child's data.
+ *
+ * Paired with the `noindex` directive in the root layout: robots.txt asks a
+ * crawler not to fetch, while `noindex` tells one that fetched anyway not to
+ * list it. Neither alone covers both cases.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      disallow: "/",
+    },
+  }
+}


### PR DESCRIPTION
Interim, and deliberately so.

Demo mode made every page publicly readable — which also made them crawlable, before there is a privacy policy, terms, an answer on children's data, or any way to delete an account.

```
GET /robots.txt   →  User-Agent: *
                     Disallow: /

<meta name="robots" content="noindex, nofollow">
```

**Both, because they cover different cases.** `robots.txt` asks a crawler not to fetch. But the GitHub Pages marketing button links straight to the app, and a URL linked from elsewhere can be listed in results without ever being crawled — a bare link with no description. `noindex` is what keeps it out of the listing.

Uses the Metadata Route (`src/app/robots.ts`) per this Next version's own docs, rather than a static `public/robots.txt`.

## This comes off again

The app is headed for open sign-ups and *wants* to be found. This is the safe ordering while the legal footing gets built: bound the money, stand up terms/privacy/deletion, then become discoverable. Being findable before it is defensible is the one sequence that could actually hurt.

One caveat for whoever removes it: a crawler that fully obeys `Disallow` never fetches the page, so it never sees the `noindex`. If the URL is still surfacing later, the counter-intuitive fix is to *allow* crawling so the directive gets read.

## Verification

`tsc` clean, 504 tests passing, `next build` succeeds. Confirmed against a local server: `/robots.txt` serves the disallow and every page carries the meta tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)