### PR TITLE
release: bound what a check-in can be, and how many lanes an account owns

### DIFF
--- a/src/app/actions/createCheckIn.test.ts
+++ b/src/app/actions/createCheckIn.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 import { requireUserId } from '@/lib/tenancy'
@@ -10,11 +10,21 @@ vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
 
 const date = new Date(Date.UTC(2026, 0, 5))
 
+// The action now refuses a date outside today-or-yesterday, so the clock is
+// pinned to the day these fixtures use.
+const pinClock = () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-05T18:00:00.000Z'))
+}
+
 describe('createCheckIn', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    pinClock()
     vi.mocked(requireUserId).mockResolvedValue('u1')
   })
+
+  afterEach(() => vi.useRealTimers())
 
   it('a foreign lane returns not-found before writing', async () => {
     vi.mocked(prisma.lane.findFirst).mockResolvedValue(null)
@@ -66,5 +76,48 @@ describe('createCheckIn', () => {
 
     expect(result).toEqual({ ok: false, error: 'validation' })
     expect(prisma.checkIn.upsert).not.toHaveBeenCalled()
+  })
+})
+
+describe('createCheckIn — the date is not the caller\'s to choose freely', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-05T18:00:00.000Z'))
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue({ id: 'lane-1' } as never)
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  it('refuses a season fabricated by back-dating', async () => {
+    // The card only ever sends today, but the action is callable directly.
+    const result = await createCheckIn({
+      laneId: 'lane-1', date: new Date(Date.UTC(2025, 10, 1)), isRest: false,
+    })
+
+    expect(result).toEqual({ ok: false, error: 'outside-window' })
+    expect(prisma.checkIn.upsert).not.toHaveBeenCalled()
+  })
+
+  it('refuses a day that has not happened yet', async () => {
+    // History takes its weeks from the check-ins themselves, so a future date
+    // would put a phantom week on the page.
+    const result = await createCheckIn({
+      laneId: 'lane-1', date: new Date(Date.UTC(2099, 0, 1)), isRest: false,
+    })
+
+    expect(result).toEqual({ ok: false, error: 'outside-window' })
+    expect(prisma.checkIn.upsert).not.toHaveBeenCalled()
+  })
+
+  it('still accepts yesterday', async () => {
+    vi.mocked(prisma.checkIn.upsert).mockResolvedValue({ id: 'c1' } as never)
+
+    const result = await createCheckIn({
+      laneId: 'lane-1', date: new Date(Date.UTC(2026, 0, 4)), isRest: false,
+    })
+
+    expect(result).toEqual({ ok: true, id: 'c1' })
   })
 })

--- a/src/app/actions/createCheckIn.ts
+++ b/src/app/actions/createCheckIn.ts
@@ -2,6 +2,8 @@ import { prisma } from "@/lib/db";
 import { checkInSchema } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
 import { requireUserId } from "@/lib/tenancy";
+import { isWithinCheckInWindow } from "@/lib/checkInWindow";
+import { getTrainingDay } from "@/lib/trainingDay";
 
 export async function createCheckIn(
   input: unknown
@@ -14,6 +16,12 @@ export async function createCheckIn(
   }
 
   const { laneId, date, isRest, note } = parsed.data;
+
+  // checkInSchema accepts any Date, and this action is callable directly
+  // rather than only through the card that always sends today.
+  if (!isWithinCheckInWindow(date, getTrainingDay(new Date()))) {
+    return { ok: false, error: "outside-window" };
+  }
 
   const lane = await prisma.lane.findFirst({
     where: { id: laneId, userId },

--- a/src/app/actions/createLane.test.ts
+++ b/src/app/actions/createLane.test.ts
@@ -3,8 +3,9 @@ import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
 import { requireUserId } from '@/lib/tenancy'
 import { createLane } from './createLane'
+import { MAX_LANES_PER_USER } from '@/lib/season'
 
-vi.mock('@/lib/db', () => ({ prisma: { lane: { create: vi.fn() } } }))
+vi.mock('@/lib/db', () => ({ prisma: { lane: { create: vi.fn(), count: vi.fn() } } }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
 vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
 
@@ -12,6 +13,7 @@ describe('createLane', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(prisma.lane.count).mockResolvedValue(0)
   })
 
   it('the created lane belongs to the signed-in user', async () => {
@@ -97,5 +99,37 @@ describe('createLane', () => {
     expect(result).toEqual({ ok: false, error: 'validation' })
     expect(prisma.lane.create).not.toHaveBeenCalled()
     expect(revalidatePath).not.toHaveBeenCalled()
+  })
+})
+
+describe('createLane — a ceiling on how many lanes one account owns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+  })
+
+  it('refuses past the ceiling, and writes nothing', async () => {
+    // Nothing bounded this before: the demand ladder caps how many must be
+    // ACTIVE, not how many can exist.
+    vi.mocked(prisma.lane.count).mockResolvedValue(MAX_LANES_PER_USER)
+
+    const result = await createLane({ name: 'One more', emoji: '🥍', targetPerWeek: 3 })
+
+    expect(result).toEqual({ ok: false, error: 'too-many-lanes' })
+    expect(prisma.lane.create).not.toHaveBeenCalled()
+  })
+
+  it('counts only the caller\'s lanes', async () => {
+    vi.mocked(prisma.lane.count).mockResolvedValue(0)
+    vi.mocked(prisma.lane.create).mockResolvedValue({ id: 'l1' } as never)
+
+    await createLane({ name: 'Sprints', emoji: '🏃', targetPerWeek: 3 })
+
+    expect(prisma.lane.count).toHaveBeenCalledWith({ where: { userId: 'u1' } })
+  })
+
+  it('leaves room for a real season of swapping', async () => {
+    // A swap a week for thirteen weeks, never reusing a lane, is about twenty.
+    expect(MAX_LANES_PER_USER).toBeGreaterThan(20)
   })
 })

--- a/src/app/actions/createLane.ts
+++ b/src/app/actions/createLane.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { requireUserId } from "@/lib/tenancy";
 import { resolveSeasonStart } from "@/lib/seasonAnchor";
 import { getTrainingDay } from "@/lib/trainingDay";
+import { MAX_LANES_PER_USER } from "@/lib/season";
 
 export async function createLane(
   input: unknown
@@ -12,6 +13,11 @@ export async function createLane(
   const parsed = laneSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: "validation" };
+  }
+
+  const owned = await prisma.lane.count({ where: { userId } });
+  if (owned >= MAX_LANES_PER_USER) {
+    return { ok: false, error: "too-many-lanes" };
   }
 
   // A new lane begins on the Monday on or after today, so it always gets a

--- a/src/lib/checkInWindow.test.ts
+++ b/src/lib/checkInWindow.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isWithinCheckInWindow } from "@/lib/checkInWindow";
+
+const day = (iso: string) => new Date(iso + "T00:00:00.000Z");
+const TODAY = day("2026-08-24");
+
+describe("isWithinCheckInWindow", () => {
+  it("allows today", () => {
+    expect(isWithinCheckInWindow(TODAY, TODAY)).toBe(true);
+  });
+
+  it("allows yesterday, for the rollover and the forgotten tap", () => {
+    // The training day rolls at 3am, so a page opened last night and submitted
+    // after the rollover is recording a session that really happened.
+    expect(isWithinCheckInWindow(day("2026-08-23"), TODAY)).toBe(true);
+  });
+
+  it("refuses the day before that", () => {
+    expect(isWithinCheckInWindow(day("2026-08-22"), TODAY)).toBe(false);
+  });
+
+  it("refuses a day that has not happened", () => {
+    // History takes its weeks from the check-ins themselves, so a check-in
+    // dated in the future puts a phantom week on the page.
+    expect(isWithinCheckInWindow(day("2026-08-25"), TODAY)).toBe(false);
+    expect(isWithinCheckInWindow(day("2099-01-01"), TODAY)).toBe(false);
+  });
+
+  it("refuses a season fabricated by back-dating", () => {
+    // The whole point: without this, a season can be manufactured wholesale.
+    for (const d of ["2026-08-01", "2026-06-15", "1970-01-01"]) {
+      expect(isWithinCheckInWindow(day(d), TODAY), d).toBe(false);
+    }
+  });
+
+  it("judges by calendar day, not by the clock", () => {
+    // A check-in at 11pm and a "today" at 6am are the same day.
+    expect(
+      isWithinCheckInWindow(new Date("2026-08-24T23:15:00.000Z"), TODAY)
+    ).toBe(true);
+  });
+
+  it("holds across a month boundary", () => {
+    const firstOfSeptember = day("2026-09-01");
+
+    expect(isWithinCheckInWindow(day("2026-08-31"), firstOfSeptember)).toBe(true);
+    expect(isWithinCheckInWindow(day("2026-08-30"), firstOfSeptember)).toBe(false);
+  });
+});

--- a/src/lib/checkInWindow.ts
+++ b/src/lib/checkInWindow.ts
@@ -1,0 +1,38 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How far back a check-in may be dated. Today, or the day before it.
+ *
+ * Yesterday is allowed for one honest reason: the training day rolls over at
+ * 3am, so a page opened on Tuesday evening and submitted after the rollover
+ * would otherwise be refused for a session that really happened. It also
+ * forgives someone who forgot to tap last night, which is the kind of slack
+ * this app builds in everywhere else.
+ */
+export const CHECK_IN_GRACE_DAYS = 1;
+
+/**
+ * May a check-in be recorded for this day?
+ *
+ * `checkInSchema` accepts any `Date` at all, and the action is callable
+ * directly rather than only through the card that always sends today. Left
+ * open, that means two things: a season can be fabricated wholesale by
+ * back-dating, and the History page will happily build a week around a
+ * check-in dated 2099 — it takes its weeks from the check-ins themselves,
+ * with no window of its own.
+ *
+ * Both dates are compared at UTC midnight, so callers should pass the value
+ * from `getTrainingDay`.
+ */
+export function isWithinCheckInWindow(date: Date, today: Date): boolean {
+  const dayKey = (d: Date) =>
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+
+  const asked = dayKey(date);
+  const now = dayKey(today);
+
+  // Never the future: a day that has not happened cannot have been trained.
+  if (asked > now) return false;
+
+  return now - asked <= CHECK_IN_GRACE_DAYS * DAY_MS;
+}

--- a/src/lib/season.ts
+++ b/src/lib/season.ts
@@ -2,3 +2,16 @@ export const SEASON_WEEKS = 13;
 export const WEEKS_REQUIRED = 11;
 export const LANES_REQUIRED = 3;
 export const REST_CAP_PER_WEEK = 1;
+
+/**
+ * The most lanes one person may own, retired ones included.
+ *
+ * Nothing else bounds this: the demand ladder caps how many must be ACTIVE at
+ * six, while `createLane` had no ceiling of any kind. Paired with the check-in
+ * window, it is what actually bounds how many rows an account can create —
+ * lanes multiplied by the couple of days a check-in may be dated.
+ *
+ * Far above any real season: swapping a lane a week for thirteen weeks and
+ * never reusing one comes to about twenty.
+ */
+export const MAX_LANES_PER_USER = 50;


### PR DESCRIPTION
Release of [#443](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/443), reviewed and merged to `develop`. Completes Phase 1 of the spend/abuse work.

## What ships

`checkInSchema` accepted `date: z.date()` — any date at all — and the action is callable directly rather than only through the card, which always sends today. Two consequences, one of them a live correctness bug:

```
check-in dated 2099  →  streak       ignored (already filtered)
                     →  season grid  ignored (13-week window)
                     →  History      BUILDS A WEEK FOR IT
```

History takes its weeks from the check-ins themselves and has no window of its own, so a bad date puts a phantom week on the page. And a back-dated run could fabricate a whole season — defeating the thing the prize is awarded for.

A check-in must now be dated **today or yesterday**. Yesterday is deliberate: the training day rolls at 3am, so a page opened last night and submitted after the rollover is recording a session that really happened.

`createLane` also had no ceiling of any kind — the demand ladder caps how many lanes must be *active*, not how many can exist. **Fifty per account** now, far above a real season.

Together these bound the rows an account can create (lanes × the couple of days a check-in may be dated), which a request rate limit would not have done: the check-in write is an upsert keyed on `[laneId, date]`, so repeats simply update the same row.

## Deploy notes

- **No schema change**, nothing to back-fill.
- **No behaviour change through the UI** — the check-in card only ever sends today, which is inside the window.
- Eddie is unaffected in normal use. The only visible difference would be an attempt to log a day older than yesterday, which the UI does not offer.

## Verification on develop

532 tests / 79 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds. Mutation-tested: removing both guards fails 4 of the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)