### PR TITLE
release: account deletion

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import { deleteAccount } from "@/app/actions/deleteAccount"
+import { DELETE_CONFIRMATION } from "@/lib/deleteConfirmation"
+import DeleteAccountPanel from "@/components/DeleteAccountPanel"
+
+export const dynamic = "force-dynamic"
+
+export default async function AccountPage() {
+  // Not getViewer: there is no account to manage without one, so a demo
+  // visitor belongs at the sign-in screen rather than looking at a page about
+  // deleting something they do not have.
+  const session = await auth()
+  if (!session?.user) redirect("/signin")
+
+  return (
+    <main className="max-w-2xl mx-auto space-y-6 p-6">
+      <h1 className="text-2xl font-bold">Account</h1>
+      <p className="mt-1 text-sm text-zinc-500">
+        Signed in as{" "}
+        <span className="text-zinc-300">{session.user.email}</span> with Google.
+      </p>
+
+      <DeleteAccountPanel
+        confirmation={DELETE_CONFIRMATION}
+        deleteAccount={async (confirmation) => {
+          "use server"
+          return deleteAccount(confirmation)
+        }}
+      />
+    </main>
+  )
+}

--- a/src/app/actions/deleteAccount.test.ts
+++ b/src/app/actions/deleteAccount.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
-import { del } from '@vercel/blob'
+import { del, list } from '@vercel/blob'
 import { requireUserId } from '@/lib/tenancy'
 import { signOut } from '@/auth'
 import { deleteAccount } from './deleteAccount'
@@ -11,13 +11,23 @@ vi.mock('@/lib/db', () => ({
     prize: { findUnique: vi.fn(), deleteMany: vi.fn() },
     lane: { deleteMany: vi.fn() },
     coachCall: { deleteMany: vi.fn() },
-    user: { delete: vi.fn() },
+    user: { deleteMany: vi.fn() },
     $transaction: vi.fn(),
   },
 }))
-vi.mock('@vercel/blob', () => ({ del: vi.fn() }))
+vi.mock('@vercel/blob', () => ({ del: vi.fn(), list: vi.fn() }))
 vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
 vi.mock('@/auth', () => ({ signOut: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => { throw Object.assign(new Error('redirect'), { digest: 'NEXT_REDIRECT' }) }),
+}))
+
+/** Success leaves by redirect, which Next signals by throwing. */
+const expectDeleted = async () => {
+  await expect(deleteAccount(DELETE_CONFIRMATION)).rejects.toMatchObject({
+    digest: 'NEXT_REDIRECT',
+  })
+}
 
 describe('deleteAccount', () => {
   beforeEach(() => {
@@ -25,6 +35,7 @@ describe('deleteAccount', () => {
     vi.mocked(requireUserId).mockResolvedValue('u1')
     vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
     vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+    vi.mocked(list).mockResolvedValue({ blobs: [] } as never)
   })
 
   it('refuses without the typed word, and destroys nothing', async () => {
@@ -40,40 +51,38 @@ describe('deleteAccount', () => {
     // Verified against a real database: deleting the User alone leaves the
     // lanes (orphaned), their check-ins, their battles, the prize and the
     // ledger all in place. Only Account and Session cascade.
-    await deleteAccount(DELETE_CONFIRMATION)
+    await expectDeleted()
 
     expect(prisma.lane.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } })
     expect(prisma.prize.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } })
     expect(prisma.coachCall.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } })
-    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: 'u1' } })
+    expect(prisma.user.deleteMany).toHaveBeenCalledWith({ where: { id: 'u1' } })
   })
 
   it('does it all at once, so a half-deleted account cannot survive', async () => {
-    await deleteAccount(DELETE_CONFIRMATION)
+    await expectDeleted()
 
     expect(prisma.$transaction).toHaveBeenCalledTimes(1)
     expect(vi.mocked(prisma.$transaction).mock.calls[0][0]).toHaveLength(4)
   })
 
   it('deletes the prize photo, which no database row would take with it', async () => {
-    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
-      photoUrl: 'https://blob.test/u1/prize.jpg',
+    vi.mocked(list).mockResolvedValue({
+      blobs: [{ url: 'https://blob.test/u1/prize.jpg' }],
     } as never)
 
-    await deleteAccount(DELETE_CONFIRMATION)
+    await expectDeleted()
 
-    expect(del).toHaveBeenCalledWith('https://blob.test/u1/prize.jpg')
+    expect(list).toHaveBeenCalledWith({ prefix: 'u1/' })
+    expect(del).toHaveBeenCalledWith(['https://blob.test/u1/prize.jpg'])
   })
 
   it('still deletes the account when the blob store will not answer', async () => {
     // Refusing because a photo could not be removed would strand someone who
     // asked to leave.
-    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
-      photoUrl: 'https://blob.test/u1/prize.jpg',
-    } as never)
-    vi.mocked(del).mockRejectedValue(new Error('blob store unreachable'))
+    vi.mocked(list).mockRejectedValue(new Error('blob store unreachable'))
 
-    await deleteAccount(DELETE_CONFIRMATION)
+    await expectDeleted()
 
     expect(prisma.$transaction).toHaveBeenCalled()
   })
@@ -82,21 +91,21 @@ describe('deleteAccount', () => {
     // The other order risks the worse failure: data gone, and a publicly
     // readable photo of a child left behind with nothing pointing at it.
     const order: string[] = []
-    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
-      photoUrl: 'https://blob.test/u1/prize.jpg',
+    vi.mocked(list).mockResolvedValue({
+      blobs: [{ url: 'https://blob.test/u1/prize.jpg' }],
     } as never)
     vi.mocked(del).mockImplementation(async () => { order.push('blob') })
     vi.mocked(prisma.$transaction).mockImplementation(async () => {
       order.push('rows'); return [] as never
     })
 
-    await deleteAccount(DELETE_CONFIRMATION)
+    await expectDeleted()
 
     expect(order).toEqual(['blob', 'rows'])
   })
 
   it('signs the person out once there is nothing left to be signed in to', async () => {
-    await deleteAccount(DELETE_CONFIRMATION)
+    await expectDeleted()
 
     expect(signOut).toHaveBeenCalledWith({ redirectTo: '/' })
   })

--- a/src/app/actions/deleteAccount.test.ts
+++ b/src/app/actions/deleteAccount.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { prisma } from '@/lib/db'
+import { del } from '@vercel/blob'
+import { requireUserId } from '@/lib/tenancy'
+import { signOut } from '@/auth'
+import { deleteAccount } from './deleteAccount'
+import { DELETE_CONFIRMATION } from '@/lib/deleteConfirmation'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    prize: { findUnique: vi.fn(), deleteMany: vi.fn() },
+    lane: { deleteMany: vi.fn() },
+    coachCall: { deleteMany: vi.fn() },
+    user: { delete: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+vi.mock('@vercel/blob', () => ({ del: vi.fn() }))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
+vi.mock('@/auth', () => ({ signOut: vi.fn() }))
+
+describe('deleteAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.$transaction).mockResolvedValue([] as never)
+  })
+
+  it('refuses without the typed word, and destroys nothing', async () => {
+    const result = await deleteAccount('delete please')
+
+    expect(result).toEqual({ ok: false, error: 'not-confirmed' })
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(del).not.toHaveBeenCalled()
+    expect(signOut).not.toHaveBeenCalled()
+  })
+
+  it('names every table that does not cascade on its own', async () => {
+    // Verified against a real database: deleting the User alone leaves the
+    // lanes (orphaned), their check-ins, their battles, the prize and the
+    // ledger all in place. Only Account and Session cascade.
+    await deleteAccount(DELETE_CONFIRMATION)
+
+    expect(prisma.lane.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } })
+    expect(prisma.prize.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } })
+    expect(prisma.coachCall.deleteMany).toHaveBeenCalledWith({ where: { userId: 'u1' } })
+    expect(prisma.user.delete).toHaveBeenCalledWith({ where: { id: 'u1' } })
+  })
+
+  it('does it all at once, so a half-deleted account cannot survive', async () => {
+    await deleteAccount(DELETE_CONFIRMATION)
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(prisma.$transaction).mock.calls[0][0]).toHaveLength(4)
+  })
+
+  it('deletes the prize photo, which no database row would take with it', async () => {
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      photoUrl: 'https://blob.test/u1/prize.jpg',
+    } as never)
+
+    await deleteAccount(DELETE_CONFIRMATION)
+
+    expect(del).toHaveBeenCalledWith('https://blob.test/u1/prize.jpg')
+  })
+
+  it('still deletes the account when the blob store will not answer', async () => {
+    // Refusing because a photo could not be removed would strand someone who
+    // asked to leave.
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      photoUrl: 'https://blob.test/u1/prize.jpg',
+    } as never)
+    vi.mocked(del).mockRejectedValue(new Error('blob store unreachable'))
+
+    await deleteAccount(DELETE_CONFIRMATION)
+
+    expect(prisma.$transaction).toHaveBeenCalled()
+  })
+
+  it('removes the photo before the rows, not after', async () => {
+    // The other order risks the worse failure: data gone, and a publicly
+    // readable photo of a child left behind with nothing pointing at it.
+    const order: string[] = []
+    vi.mocked(prisma.prize.findUnique).mockResolvedValue({
+      photoUrl: 'https://blob.test/u1/prize.jpg',
+    } as never)
+    vi.mocked(del).mockImplementation(async () => { order.push('blob') })
+    vi.mocked(prisma.$transaction).mockImplementation(async () => {
+      order.push('rows'); return [] as never
+    })
+
+    await deleteAccount(DELETE_CONFIRMATION)
+
+    expect(order).toEqual(['blob', 'rows'])
+  })
+
+  it('signs the person out once there is nothing left to be signed in to', async () => {
+    await deleteAccount(DELETE_CONFIRMATION)
+
+    expect(signOut).toHaveBeenCalledWith({ redirectTo: '/' })
+  })
+
+  it('needs a session, so nobody can delete an account by asking nicely', async () => {
+    vi.mocked(requireUserId).mockRejectedValue(new Error('NEXT_REDIRECT'))
+
+    await expect(deleteAccount(DELETE_CONFIRMATION)).rejects.toThrow()
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/actions/deleteAccount.ts
+++ b/src/app/actions/deleteAccount.ts
@@ -1,9 +1,10 @@
 'use server'
 
-import { del } from '@vercel/blob'
+import { del, list } from '@vercel/blob'
 import { prisma } from '@/lib/db'
 import { requireUserId } from '@/lib/tenancy'
 import { signOut } from '@/auth'
+import { redirect } from 'next/navigation'
 import { DELETE_CONFIRMATION } from '@/lib/deleteConfirmation'
 
 /**
@@ -28,24 +29,30 @@ import { DELETE_CONFIRMATION } from '@/lib/deleteConfirmation'
 export async function deleteAccount(
   confirmation: string
 ): Promise<{ ok: false; error: string }> {
+  // Only ever RETURNS on a refusal; success leaves by redirect.
   const userId = await requireUserId()
 
   if (confirmation !== DELETE_CONFIRMATION) {
     return { ok: false, error: 'not-confirmed' }
   }
 
-  const prize = await prisma.prize.findUnique({ where: { userId } })
-  if (prize?.photoUrl) {
-    try {
-      await del(prize.photoUrl)
-    } catch (err) {
-      // Best effort. Refusing to delete the account because a blob store was
-      // briefly unreachable would strand someone who asked to leave.
-      console.error(
-        'Failed to delete prize photo during account deletion:',
-        err instanceof Error ? err.message : err
-      )
+  // The WHOLE prefix, not just the photo the prize currently points at.
+  // `uploadPrizePhoto` deliberately swallows a failed delete when replacing a
+  // picture, so a hiccup there leaves an older image orphaned under the same
+  // prefix — publicly readable, with nothing referring to it. Those are
+  // exactly what this is meant to remove.
+  try {
+    const { blobs } = await list({ prefix: `${userId}/` })
+    if (blobs.length > 0) {
+      await del(blobs.map((b) => b.url))
     }
+  } catch (err) {
+    // Best effort. Refusing to delete the account because a blob store was
+    // briefly unreachable would strand someone who asked to leave.
+    console.error(
+      'Failed to delete stored photos during account deletion:',
+      err instanceof Error ? err.message : err
+    )
   }
 
   await prisma.$transaction([
@@ -54,11 +61,36 @@ export async function deleteAccount(
     prisma.lane.deleteMany({ where: { userId } }),
     prisma.prize.deleteMany({ where: { userId } }),
     prisma.coachCall.deleteMany({ where: { userId } }),
-    // Takes Account and Session with it.
-    prisma.user.delete({ where: { id: userId } }),
+    // deleteMany, not delete: sessions are JWTs, so a cookie on a second
+    // device still resolves to this id after the row is gone. `delete` throws
+    // P2025 on a missing row and would reject the whole transaction, turning
+    // a second attempt into a crash instead of a no-op. Takes Account and
+    // Session with it either way.
+    prisma.user.deleteMany({ where: { id: userId } }),
   ])
 
-  // Throws a redirect, so nothing may follow it.
-  await signOut({ redirectTo: '/' })
-  return { ok: false, error: 'unreachable' }
+  // The account is gone by this point. Whatever happens now, the person must
+  // not be told it failed — that would invite a retry of something already
+  // done. signOut throws its redirect on success, which is the intended exit.
+  try {
+    await signOut({ redirectTo: '/' })
+  } catch (err) {
+    if (isRedirect(err)) throw err
+    console.error(
+      'Sign-out after account deletion failed:',
+      err instanceof Error ? err.message : err
+    )
+  }
+
+  redirect('/')
+}
+
+/** Next signals a redirect by throwing, so it must never be swallowed. */
+function isRedirect(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    typeof (err as { digest?: unknown }).digest === 'string' &&
+    (err as { digest: string }).digest.startsWith('NEXT_REDIRECT')
+  )
 }

--- a/src/app/actions/deleteAccount.ts
+++ b/src/app/actions/deleteAccount.ts
@@ -1,0 +1,64 @@
+'use server'
+
+import { del } from '@vercel/blob'
+import { prisma } from '@/lib/db'
+import { requireUserId } from '@/lib/tenancy'
+import { signOut } from '@/auth'
+import { DELETE_CONFIRMATION } from '@/lib/deleteConfirmation'
+
+/**
+ * Remove an account and everything belonging to it.
+ *
+ * Deleting the User row is NOT enough, and quietly so. `Lane.user` and
+ * `Prize.user` are optional relations with no `onDelete`, which Prisma
+ * defaults to SetNull — so deleting the user orphans the lanes rather than
+ * removing them, and every check-in and boss battle hanging off them survives
+ * with a null owner. `CoachCall` has no relation at all. Verified against a
+ * real database: a plain `user.delete` left the lane, its check-ins, its
+ * battles, the prize and the ledger all in place.
+ *
+ * So everything is named explicitly. Only `Account` and `Session` cascade on
+ * their own, and only because those relations say so.
+ *
+ * The photo goes first. If the database call fails afterwards the person keeps
+ * their account and loses a picture, which is a worse day than they wanted but
+ * a recoverable one. The other order risks the opposite: data deleted, and a
+ * publicly readable photo of a child left behind with nothing pointing at it.
+ */
+export async function deleteAccount(
+  confirmation: string
+): Promise<{ ok: false; error: string }> {
+  const userId = await requireUserId()
+
+  if (confirmation !== DELETE_CONFIRMATION) {
+    return { ok: false, error: 'not-confirmed' }
+  }
+
+  const prize = await prisma.prize.findUnique({ where: { userId } })
+  if (prize?.photoUrl) {
+    try {
+      await del(prize.photoUrl)
+    } catch (err) {
+      // Best effort. Refusing to delete the account because a blob store was
+      // briefly unreachable would strand someone who asked to leave.
+      console.error(
+        'Failed to delete prize photo during account deletion:',
+        err instanceof Error ? err.message : err
+      )
+    }
+  }
+
+  await prisma.$transaction([
+    // Lanes first, and by hand: their check-ins, boss battles, freezes and
+    // target changes cascade from the lane, not from the user.
+    prisma.lane.deleteMany({ where: { userId } }),
+    prisma.prize.deleteMany({ where: { userId } }),
+    prisma.coachCall.deleteMany({ where: { userId } }),
+    // Takes Account and Session with it.
+    prisma.user.delete({ where: { id: userId } }),
+  ])
+
+  // Throws a redirect, so nothing may follow it.
+  await signOut({ redirectTo: '/' })
+  return { ok: false, error: 'unreachable' }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,10 @@ export default async function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full bg-zinc-950 text-zinc-100">
-        <AppShell account={<AccountControl signedIn={Boolean(session?.user)} />}>
+        <AppShell
+          signedIn={Boolean(session?.user)}
+          account={<AccountControl signedIn={Boolean(session?.user)} />}
+        >
           {children}
         </AppShell>
       </body>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -8,9 +8,11 @@ interface AppShellProps {
   children: React.ReactNode
   /** Sign in / sign out, resolved on the server and rendered top right. */
   account?: React.ReactNode
+  /** Whether there is an account to manage — the nav hides what there is not. */
+  signedIn?: boolean
 }
 
-export default function AppShell({ children, account }: AppShellProps) {
+export default function AppShell({ children, account, signedIn = false }: AppShellProps) {
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
   
@@ -50,7 +52,7 @@ export default function AppShell({ children, account }: AppShellProps) {
           isOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
-        <SidebarNav />
+        <SidebarNav signedIn={signedIn} />
       </aside>
 
       {/* min-w-0 keeps a wide child (the history heatmap, a long coach note)

--- a/src/components/DeleteAccountPanel.test.tsx
+++ b/src/components/DeleteAccountPanel.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import DeleteAccountPanel from './DeleteAccountPanel'
+
+const props = () => ({
+  confirmation: 'DELETE',
+  deleteAccount: vi.fn().mockResolvedValue(undefined),
+})
+
+describe('DeleteAccountPanel', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('will not fire until the word is typed', async () => {
+    render(<DeleteAccountPanel {...props()} />)
+
+    expect(screen.getByTestId('delete-account-submit')).toBeDisabled()
+  })
+
+  it('stays disabled for something close but wrong', async () => {
+    const user = userEvent.setup()
+    render(<DeleteAccountPanel {...props()} />)
+
+    await user.type(screen.getByTestId('delete-confirm-input'), 'delete')
+
+    expect(screen.getByTestId('delete-account-submit')).toBeDisabled()
+  })
+
+  it('arms once the word matches, and passes it on', async () => {
+    const user = userEvent.setup()
+    const p = props()
+    render(<DeleteAccountPanel {...p} />)
+
+    await user.type(screen.getByTestId('delete-confirm-input'), 'DELETE')
+    await user.click(screen.getByTestId('delete-account-submit'))
+
+    expect(p.deleteAccount).toHaveBeenCalledWith('DELETE')
+  })
+
+  it('says what is about to go, in plain terms', async () => {
+    render(<DeleteAccountPanel {...props()} />)
+
+    expect(screen.getByTestId('delete-account')).toHaveTextContent(/cannot be undone/)
+  })
+
+  it('surfaces a refusal rather than looking like it worked', async () => {
+    const user = userEvent.setup()
+    const p = props()
+    p.deleteAccount.mockResolvedValue({ ok: false, error: 'not-confirmed' })
+    render(<DeleteAccountPanel {...p} />)
+
+    await user.type(screen.getByTestId('delete-confirm-input'), 'DELETE')
+    await user.click(screen.getByTestId('delete-account-submit'))
+
+    expect(await screen.findByTestId('delete-account-error')).toBeInTheDocument()
+  })
+})

--- a/src/components/DeleteAccountPanel.tsx
+++ b/src/components/DeleteAccountPanel.tsx
@@ -63,10 +63,18 @@ export default function DeleteAccountPanel({
         onClick={() =>
           startTransition(async () => {
             setError(null)
-            const result = await deleteAccount(typed.trim())
-            // Success redirects, so anything returned here is a refusal.
-            if (result && !result.ok) {
-              setError("That didn't go through — give it another go.")
+            try {
+              const result = await deleteAccount(typed.trim())
+              // Success leaves by redirect, so anything returned is a refusal.
+              if (result && !result.ok) {
+                setError("That didn't go through — give it another go.")
+              }
+            } catch {
+              // React escalates a rejected transition to the nearest error
+              // boundary, so without this the page crashes rather than saying
+              // what went wrong. The redirect on success is thrown too, but
+              // Next handles that before it reaches here.
+              setError("Something went wrong — give it another go.")
             }
           })
         }

--- a/src/components/DeleteAccountPanel.tsx
+++ b/src/components/DeleteAccountPanel.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+interface DeleteAccountPanelProps {
+  /** The word that has to be typed before the button will do anything. */
+  confirmation: string
+  deleteAccount: (confirmation: string) => Promise<{ ok: boolean; error?: string } | void>
+}
+
+/**
+ * The only way out, and deliberately a slow one.
+ *
+ * Typing the word rather than clicking through a dialog: this removes a
+ * season of someone's training and cannot be undone, so it should be
+ * impossible to do by accident or by muscle memory.
+ */
+export default function DeleteAccountPanel({
+  confirmation,
+  deleteAccount,
+}: DeleteAccountPanelProps) {
+  const [typed, setTyped] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const armed = typed.trim() === confirmation
+
+  return (
+    <div
+      data-testid="delete-account"
+      className="space-y-3 rounded-lg border border-red-500/40 bg-red-500/5 p-4"
+    >
+      <h2 className="text-lg font-semibold text-red-200">Delete this account</h2>
+      <p className="text-sm text-zinc-400">
+        This removes the whole season — every lane, every day you showed up,
+        every boss you beat, the prize and its photo. It cannot be undone, and
+        there is no copy kept.
+      </p>
+
+      <label htmlFor="delete-confirm" className="block text-sm text-zinc-400">
+        Type <span className="font-semibold text-zinc-100">{confirmation}</span>{" "}
+        to confirm
+      </label>
+      <input
+        id="delete-confirm"
+        data-testid="delete-confirm-input"
+        value={typed}
+        onChange={(e) => setTyped(e.target.value)}
+        autoComplete="off"
+        className="w-full max-w-xs rounded-lg border border-zinc-700 bg-zinc-900 p-2 font-mono"
+      />
+
+      {error && (
+        <p data-testid="delete-account-error" className="text-sm text-amber-300">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="button"
+        data-testid="delete-account-submit"
+        disabled={!armed || isPending}
+        onClick={() =>
+          startTransition(async () => {
+            setError(null)
+            const result = await deleteAccount(typed.trim())
+            // Success redirects, so anything returned here is a refusal.
+            if (result && !result.ok) {
+              setError("That didn't go through — give it another go.")
+            }
+          })
+        }
+        className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {isPending ? "Deleting..." : "Delete my account"}
+      </button>
+    </div>
+  )
+}

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -9,7 +9,8 @@ import {
   BattlesIcon,
   PrizeIcon,
   HistoryIcon,
-  MenuIcon
+  MenuIcon,
+  AccountIcon
 } from '@/components/icons'
 
 interface NavItem {
@@ -26,7 +27,11 @@ const NAV: NavItem[] = [
   { href: '/history', label: 'History', icon: HistoryIcon },
 ]
 
-export default function SidebarNav() {
+interface SidebarNavProps {
+  signedIn?: boolean
+}
+
+export default function SidebarNav({ signedIn = false }: SidebarNavProps) {
   const [collapsed, setCollapsed] = useState<boolean>(false)
   const pathname = usePathname()
 
@@ -46,7 +51,10 @@ export default function SidebarNav() {
       </div>
 
       <nav className="mt-2">
-        {NAV.map((item) => {
+        {/* Account only when there is one. Showing it to a demo visitor would
+            bounce them to the sign-in screen, which is the dead end the demo
+            exists to remove. */}
+        {(signedIn ? [...NAV, { href: '/account', label: 'Account', icon: AccountIcon }] : NAV).map((item) => {
           const isActive = pathname === item.href
           const Icon = item.icon
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -98,3 +98,12 @@ export function SignInIcon() {
     </svg>
   )
 }
+
+export function AccountIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className={className ?? "h-5 w-5"}>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 21a8 8 0 0 1 16 0" />
+    </svg>
+  )
+}

--- a/src/lib/deleteConfirmation.ts
+++ b/src/lib/deleteConfirmation.ts
@@ -1,0 +1,8 @@
+/**
+ * The word that has to be typed before an account is destroyed.
+ *
+ * Lives here rather than beside the action because a `'use server'` module may
+ * only export async functions — Next strips anything else, and the import
+ * fails at build time with the module appearing to have no exports at all.
+ */
+export const DELETE_CONFIRMATION = "DELETE";

--- a/src/lib/tenancy.test.ts
+++ b/src/lib/tenancy.test.ts
@@ -3,10 +3,13 @@ import { requireUserId } from './tenancy'
 
 import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
+import { prisma } from '@/lib/db'
 
 vi.mock('@/auth', () => ({
   auth: vi.fn(),
 }))
+
+vi.mock('@/lib/db', () => ({ prisma: { user: { count: vi.fn() } } }))
 
 vi.mock('next/navigation', () => ({
   redirect: vi.fn(() => { throw new Error('REDIRECT') }),
@@ -22,6 +25,7 @@ const mockRedirect = vi.mocked(redirect)
 describe('tenancy', () => {
   it('a session returns its user id', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'u1' } } as never)
+    vi.mocked(prisma.user.count).mockResolvedValue(1)
 
     const userId = await requireUserId()
 
@@ -42,5 +46,19 @@ describe('tenancy', () => {
 
     await expect(requireUserId()).rejects.toThrow('REDIRECT')
     expect(mockRedirect).toHaveBeenCalledWith('/signin')
+  })
+})
+
+describe('requireUserId — a cookie is not proof the account exists', () => {
+  it('sends a deleted account back to sign-in rather than trusting the JWT', async () => {
+    // Sessions are JWTs, so a signed cookie keeps naming a user for its full
+    // thirty-day window after the account is deleted. Without the row check a
+    // write on a second device fails on a foreign key instead of asking them
+    // to sign in.
+    mockAuth.mockResolvedValue({ user: { id: 'gone' } } as never)
+    vi.mocked(prisma.user.count).mockResolvedValue(0)
+
+    await expect(requireUserId()).rejects.toThrow()
+    expect(redirect).toHaveBeenCalledWith('/signin')
   })
 })

--- a/src/lib/tenancy.ts
+++ b/src/lib/tenancy.ts
@@ -1,11 +1,24 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { prisma } from "@/lib/db";
 
+/**
+ * The signed-in user, or a redirect to the sign-in screen.
+ *
+ * Every write goes through here. The row is checked rather than trusting the
+ * cookie alone: sessions are JWTs, so a signed cookie keeps naming a user for
+ * its full thirty-day window after the account is deleted, and a write on a
+ * second device would otherwise fail on a foreign key instead of asking them
+ * to sign in.
+ */
 export async function requireUserId(): Promise<string> {
   const session = await auth();
-  if (session?.user?.id) {
-    return session.user.id;
+  const userId = session?.user?.id;
+
+  if (userId && (await prisma.user.count({ where: { id: userId } })) === 1) {
+    return userId;
   }
+
   redirect("/signin");
   // The redirect function throws, so this line is unreachable.
   throw new Error("Redirected");

--- a/src/lib/viewer.test.ts
+++ b/src/lib/viewer.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
+import { prisma } from "@/lib/db";
 import { getViewer } from "@/lib/viewer";
 
 vi.mock("@/auth", () => ({ auth: vi.fn() }));
 vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+vi.mock("@/lib/db", () => ({ prisma: { user: { count: vi.fn() } } }));
 
 describe("getViewer", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: the account named by the cookie still exists.
+    vi.mocked(prisma.user.count).mockResolvedValue(1);
+  });
 
   it("reports the signed-in user", async () => {
     vi.mocked(auth).mockResolvedValue({ user: { id: "u1" } } as never);
@@ -37,5 +43,26 @@ describe("getViewer", () => {
     vi.mocked(auth).mockResolvedValue({ user: {} } as never);
 
     expect(await getViewer()).toEqual({ kind: "demo" });
+  });
+});
+
+describe("getViewer — a cookie is not proof the account exists", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("falls back to the demo for a deleted account", async () => {
+    // Otherwise a second device sits in a signed-in-but-empty app for the
+    // full thirty-day JWT window rather than seeing what any visitor sees.
+    vi.mocked(auth).mockResolvedValue({ user: { id: "gone" } } as never);
+    vi.mocked(prisma.user.count).mockResolvedValue(0);
+
+    expect(await getViewer()).toEqual({ kind: "demo" });
+  });
+
+  it("does not ask the database when there is no session at all", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    await getViewer();
+
+    expect(prisma.user.count).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import { prisma } from "@/lib/db";
 
 export type Viewer = { kind: "user"; userId: string } | { kind: "demo" };
 
@@ -13,10 +14,18 @@ export type Viewer = { kind: "user"; userId: string } | { kind: "demo" };
  * Keeping the two apart is the whole safety argument for the public demo: an
  * action cannot accidentally become reachable by a stranger, because no action
  * imports this.
+ *
+ * The row is checked, not just the cookie. Sessions are JWTs, so a signed
+ * cookie keeps naming a user for its full thirty-day window after the account
+ * is deleted — and a second device would otherwise sit in a signed-in-but-empty
+ * app rather than falling back to the demo like any other visitor.
  */
 export async function getViewer(): Promise<Viewer> {
   const session = await auth();
   const userId = session?.user?.id;
+  if (!userId) return { kind: "demo" };
 
-  return userId ? { kind: "user", userId } : { kind: "demo" };
+  const stillExists = await prisma.user.count({ where: { id: userId } });
+
+  return stillExists === 1 ? { kind: "user", userId } : { kind: "demo" };
 }


### PR DESCRIPTION
Release of [#445](https://github.com/myhumblecoder-dev/lacrosse-grind/pull/445), reviewed and merged to `develop`. First piece of Phase 2 — the prerequisite for a privacy policy that tells the truth.

## What ships

There was no way for anyone to remove their account or their data. There is now, at `/account`, armed by typing the word rather than clicking a dialog.

**Deleting the User row is not enough, and fails quietly.** `Lane.user` and `Prize.user` are optional relations with no `onDelete`, which Prisma defaults to `SetNull` — so deleting the user *orphans* the lanes rather than removing them, and every check-in and boss battle survives with a null owner. Measured against a real database before writing anything:

```
              before  after   ← after user.delete alone
lanes            1      1     (userId now null)
checkIns         1      1
battles          1      1
prizes           1      1
coach            1      1
```

Every table is now named explicitly in one transaction, verified the same way: eleven counts, all zero, no orphans.

**Stale sessions are handled.** Sessions are JWTs, so a cookie on a second device keeps resolving to a user id for its full thirty-day window after deletion. `getViewer` and `requireUserId` now check the row still exists — the reader falls back to the demo, the writer asks for sign-in — and the delete itself is idempotent, so a second attempt is a no-op rather than a crash.

**Stored photos go too**, the whole `${userId}/` prefix rather than only the currently-referenced one, because a failed replace can leave publicly readable orphans behind.

## Deploy notes

- **No schema change**, nothing to back-fill.
- **One extra query per `auth()` call** — the row-existence check. Deliberate: the JWT strategy exists to avoid a database read, but "deleted everywhere except the other device, for a month" is not deletion.
- `/account` appears in the sidebar **only when signed in**, so demo visitors are unaffected.
- Eddie sees a new Account item in the nav. Nothing else changes for him.

## Verification on develop

550 tests / 81 files passing, `tsc` clean, eslint 0 errors, `next build` succeeds with `/account` listed. Deletion was verified end to end against a real Postgres, and all five findings from code review are fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)