### PR TITLE
fix: move the Dependabot overrides where pnpm still reads them

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,5 @@
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.10"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid": "^3.3.17",
-      "postcss": "^8.5.23",
-      "js-yaml": "^4.3.1",
-      "deepmerge-ts": "^8.0.0"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver
+
+# Security pins from Dependabot. These live HERE, not under a "pnpm" key in
+# package.json: pnpm 11 stopped reading that key and silently drops the
+# overrides when it regenerates the lockfile, downgrading deepmerge-ts back to
+# the version with the stack-exhaustion advisory. pnpm 10 (what CI runs) reads
+# both locations, so this file is the one that works everywhere.
+overrides:
+  nanoid: ^3.3.17
+  postcss: ^8.5.23
+  js-yaml: ^4.3.1
+  deepmerge-ts: ^8.0.0


### PR DESCRIPTION
## The bug

pnpm 11 stopped reading the `pnpm` key from `package.json`:

> `[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides".`

So every local `pnpm install` / `pnpm test` / `pnpm dev` regenerated `pnpm-lock.yaml` **with the overrides block stripped**:

- `deepmerge-ts` 8.0.2 → **7.1.5** (undoing 33bf23e, the stack-exhaustion high)
- `postcss@8.4.31` reintroduced
- `nanoid` and `js-yaml` pins dropped

Committing such a lockfile would have shipped the vulnerable versions. I hit this twice while working on an unrelated change and had to `git checkout pnpm-lock.yaml` both times.

**CI is currently insulated only by accident** — `.github/workflows/ci.yml:23` pins `pnpm/action-setup` to `version: 10`, which still reads the old location. That protection disappears the moment anyone bumps it.

## The fix

Move the four pins to `pnpm-workspace.yaml`, which is read by **both** majors, so they apply regardless of which pnpm runs.

`pnpm-lock.yaml` is deliberately **not** in this diff — it comes out byte-identical, which is the proof this changes *where the overrides are declared*, not *what resolves*.

## Verification

| check | result |
|---|---|
| `pnpm 11.22 install` | overrides block retained; `deepmerge-ts@8.0.2`, `postcss@8.5.24`; ignored-field warning gone |
| `pnpm 10.34` in a clean dir, CI's exact flag `install --frozen-lockfile` | no `ERR_PNPM_OUTDATED_LOCKFILE`; physically installed `deepmerge-ts@8.0.2` and `postcss@8.5.24` |
| lockfile diff vs develop | none |
| `pnpm test` | 563 passed / 83 files |
| `pnpm run lint` | 0 errors |

The pnpm 10 run was done in a fresh directory with only `package.json`, `pnpm-lock.yaml` and `pnpm-workspace.yaml` copied in, to reproduce a clean CI checkout rather than a `node_modules` built by pnpm 11.

## Related, not done here

There is no `packageManager` field, which is why local (11) and CI (10) diverged in the first place. Pinning it would prevent the next version-skew surprise, but it changes resolution behaviour for Vercel too, so it belongs on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9YJ3SvhfYFnJ8yCHQofh7