### PR TITLE
feat: the ladder goes Norse, and barbarian earns its place back

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,12 +11,12 @@ export const metadata = {
 const EVOLUTIONS = [
   { level: 0, name: "hatchling" },
   { level: 1, name: "whelp" },
-  { level: 2, name: "page" },
-  { level: 3, name: "squire" },
-  { level: 4, name: "knight" },
-  { level: 5, name: "captain" },
-  { level: 6, name: "champion" },
-  { level: 7, name: "king" },
+  { level: 2, name: "shieldbearer" },
+  { level: 3, name: "raider" },
+  { level: 4, name: "viking" },
+  { level: 5, name: "barbarian" },
+  { level: 6, name: "berserker" },
+  { level: 7, name: "warlord" },
   { level: 8, name: "legend" },
 ]
 

--- a/src/app/actions/rerollBossChallenge.test.ts
+++ b/src/app/actions/rerollBossChallenge.test.ts
@@ -34,8 +34,8 @@ describe('rerollBossChallenge', () => {
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
   })
 
-  it('a captain gets a second re-roll where a hatchling does not', async () => {
-    // Level 5+ gets 2 rerolls. We set defeats to 10, so the rank is captain.
+  it('a barbarian gets a second re-roll where a hatchling does not', async () => {
+    // Level 5+ gets 2 rerolls. We set defeats to 10, so the rank is barbarian.
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -71,7 +71,7 @@ describe('rerollBossChallenge', () => {
   })
 
   it('the reroll prompt addresses the rank', async () => {
-    // 10 defeats is level 5, whose rank name is 'captain'
+    // 10 defeats is level 5, whose rank name is 'barbarian'
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -83,10 +83,10 @@ describe('rerollBossChallenge', () => {
 
     await rerollBossChallenge('b1')
 
-    // buildChallengePrompt is real, so we check it was called with 'captain'
+    // buildChallengePrompt is real, so we check it was called with 'barbarian'
     // Since we can't spy on the pure function directly without mocking, 
     // we verify the result of the logic via the generate call's arguments.
-    expect(askCoach).toHaveBeenCalledWith(expect.any(String), expect.any(String), buildChallengePrompt('Running', '🏃', 'captain'))
+    expect(askCoach).toHaveBeenCalledWith(expect.any(String), expect.any(String), buildChallengePrompt('Running', '🏃', 'barbarian'))
   })
 }) 
 describe('rerollBossChallenge — the path that had no cap at all', () => {

--- a/src/app/actions/startSeason.test.ts
+++ b/src/app/actions/startSeason.test.ts
@@ -92,8 +92,8 @@ describe('startSeason', () => {
     expect(result.seasonStart.getUTCDate()).toBe(20)
   })
 
-  it('a captain-level player is blocked at 3 lanes with the demand named', async () => {
-    // 10 defeats is captain (threshold 8), which requires more than 3 lanes.
+  it('a barbarian-level player is blocked at 3 lanes with the demand named', async () => {
+    // 10 defeats is barbarian (threshold 8), which requires more than 3 lanes.
     // We simulate enough defeats to reach it, but not enough active lanes.
     // We'll mock count to return 3 active lanes, but 10 defeats.
     vi.mocked(prisma.lane.count).mockResolvedValue(3)

--- a/src/components/PlayerAvatarCard.test.tsx
+++ b/src/components/PlayerAvatarCard.test.tsx
@@ -18,11 +18,11 @@ describe('PlayerAvatarCard', () => {
     vi.clearAllMocks()
   })
 
-  it('the captain band renders name and level', async () => {
+  it('the barbarian band renders name and level', async () => {
     render(<PlayerAvatarCard defeats={8} />)
 
     const levelName = screen.getByTestId('avatar-level-name')
-    expect(levelName).toHaveTextContent(/Captain · Level 5/)
+    expect(levelName).toHaveTextContent(/Barbarian · Level 5/)
 
     expect(screen.queryByText(/defeats/)).not.toBeInTheDocument()
   })
@@ -47,7 +47,7 @@ describe('PlayerAvatarCard', () => {
 
   it('shows something from the very first rank', async () => {
     // The whole point of the change: a bar measuring distance-to-next-rank sat
-    // at zero for hatchling, whelp and page, because those bands are one boss
+    // at zero for hatchling, whelp and shieldbearer, because those bands are one boss
     // wide. A pip is lit at every rank, including the very first.
     render(<PlayerAvatarCard defeats={0} />)
 
@@ -63,7 +63,7 @@ describe('PlayerAvatarCard', () => {
   })
 
   it('does not light a pip part-way through a band', async () => {
-    // 4 defeats is still squire — the rank has not changed, so nor has the row.
+    // 4 defeats is still raider — the rank has not changed, so nor has the row.
     render(<PlayerAvatarCard defeats={4} />)
     expect(earned()).toBe(4)
   })
@@ -82,7 +82,7 @@ describe('PlayerAvatarCard', () => {
 
     expect(screen.getByTestId('avatar-pips')).toHaveAttribute(
       'aria-label',
-      expect.stringContaining('Evolution 6 of 9: captain')
+      expect.stringContaining('Evolution 6 of 9: barbarian')
     )
   })
 })

--- a/src/lib/playerLevel.test.ts
+++ b/src/lib/playerLevel.test.ts
@@ -6,12 +6,12 @@ describe('playerLevel', () => {
     const cases: Array<[number, string]> = [
       [0, 'hatchling'],
       [1, 'whelp'],
-      [2, 'page'],
-      [3, 'squire'],
-      [5, 'knight'],
-      [8, 'captain'],
-      [13, 'champion'],
-      [21, 'king'],
+      [2, 'shieldbearer'],
+      [3, 'raider'],
+      [5, 'viking'],
+      [8, 'barbarian'],
+      [13, 'berserker'],
+      [21, 'warlord'],
       [34, 'legend'],
     ]
 
@@ -29,11 +29,11 @@ describe('playerLevel', () => {
     expect(hatchling.nextAt).toBe(1)
     expect(hatchling.progress).toBe(0)
 
-    // 5 -> level 4 'knight', nextAt 8, progress 0
-    const knight = playerLevel(5)
-    expect(knight.level).toBe(4)
-    expect(knight.nextAt).toBe(8)
-    expect(knight.progress).toBe(0)
+    // 5 -> level 4 'viking', nextAt 8, progress 0
+    const viking = playerLevel(5)
+    expect(viking.level).toBe(4)
+    expect(viking.nextAt).toBe(8)
+    expect(viking.progress).toBe(0)
 
     // 6 -> level 4, progress 1/3 (6 is 1 step into the 5->8 band)
     const progressMid = playerLevel(6)

--- a/src/lib/playerLevel.ts
+++ b/src/lib/playerLevel.ts
@@ -7,7 +7,7 @@ export type PlayerLevel = {
    * Fraction through the CURRENT band. Nothing renders this, on purpose: the
    * first three bands are one boss wide, so it is pinned at 0 for every new
    * player. The avatar card draws a pip per evolution instead. Wiring this to
-   * a progress bar puts back a bar that cannot fill until squire.
+   * a progress bar puts back a bar that cannot fill until raider.
    */
   progress: number;
 };
@@ -15,12 +15,12 @@ export type PlayerLevel = {
 const LADDER: { threshold: number; name: string }[] = [
   { threshold: 0, name: "hatchling" },
   { threshold: 1, name: "whelp" },
-  { threshold: 2, name: "page" },
-  { threshold: 3, name: "squire" },
-  { threshold: 5, name: "knight" },
-  { threshold: 8, name: "captain" },
-  { threshold: 13, name: "champion" },
-  { threshold: 21, name: "king" },
+  { threshold: 2, name: "shieldbearer" },
+  { threshold: 3, name: "raider" },
+  { threshold: 5, name: "viking" },
+  { threshold: 8, name: "barbarian" },
+  { threshold: 13, name: "berserker" },
+  { threshold: 21, name: "warlord" },
   { threshold: 34, name: "legend" },
 ];
 


### PR DESCRIPTION
Supersedes the medieval ladder in #454, which merged to develop but never deployed.

`hatchling → whelp → shieldbearer → raider → viking → barbarian → berserker → warlord → legend`

## Why change it again

#454 fixed the real bug — three mythologies stitched together — but it kept reaching for **institutional titles**. A page, a squire, a knight, a captain: each is a rank somebody else agrees to confer. That's a grade wearing armour, and this app does not grade. Every rung had to be defended one at a time.

Norse doesn't have that problem. Viking rank was **taken, not granted**, so the ladder is earned by construction rather than by argument.

It also puts three words back where they belong. `barbarian` and `warlord` were in the original ladder as orphans, sitting after `knight` with nothing around them from their own world. Here they're native.

## Label against art

| # | sprite | name |
|---|---|---|
| 0 | infant, bib and bottle | hatchling |
| 1 | toddler, standing | whelp |
| 2 | clothed, belt and boots, first blade | shieldbearer |
| 3 | tunic, dagger — armed, not armoured | raider |
| 4 | full helm, sword, shield | viking |
| 5 | bulkier, horned helm, **round** shield | barbarian |
| 6 | leaping mid-charge, dust flying | berserker |
| 7 | heavy plate, polearm, planted | warlord |
| 8 | winged, radiant, glowing sword | legend |

Two observations drove this. **`berserkr` means "bear-shirt"** — a warrior who fought in a frenzy — and rung 6 is drawn mid-charge with dust flying. That's the closest label-to-art match on the ladder. And **rung 5 carries a Viking round shield**, which the medieval reading missed entirely.

## Not used

**thrall** — the historically correct bottom rung of Norse society, and it means slave. **drengr** and **huscarl** are both more authentic than shieldbearer and raider, and both fail the test banneret failed: a nine-year-old has never heard them.

## Scope

Labels only. Thresholds, level indices, artwork and pip counts untouched. Nothing branches on a rank name — `rank.name` is only interpolated into display copy and `buildChallengePrompt`.

## Verification

- `pnpm test` → **563 passed / 83 files**
- **Mutation checks** — `barbarian` → `captain` fails 4 tests including the coach-prompt assertion; `shieldbearer` → `page` fails the ladder table
- `pnpm run lint` 0 errors; `tsc --noEmit` clean
- `/about` served locally, all nine in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9YJ3SvhfYFnJ8yCHQofh7