### PR TITLE
release: the Viking ladder

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -9,14 +9,14 @@ export const metadata = {
 
 /** The nine evolutions, drawn from the same art the avatar uses. */
 const EVOLUTIONS = [
-  { level: 0, name: "baby" },
-  { level: 1, name: "toddler" },
-  { level: 2, name: "tween" },
-  { level: 3, name: "page" },
-  { level: 4, name: "squire" },
-  { level: 5, name: "knight" },
-  { level: 6, name: "barbarian" },
-  { level: 7, name: "warlord" },
+  { level: 0, name: "hatchling" },
+  { level: 1, name: "whelp" },
+  { level: 2, name: "page" },
+  { level: 3, name: "squire" },
+  { level: 4, name: "knight" },
+  { level: 5, name: "captain" },
+  { level: 6, name: "champion" },
+  { level: 7, name: "king" },
   { level: 8, name: "legend" },
 ]
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,12 +11,12 @@ export const metadata = {
 const EVOLUTIONS = [
   { level: 0, name: "hatchling" },
   { level: 1, name: "whelp" },
-  { level: 2, name: "page" },
-  { level: 3, name: "squire" },
-  { level: 4, name: "knight" },
-  { level: 5, name: "captain" },
-  { level: 6, name: "champion" },
-  { level: 7, name: "king" },
+  { level: 2, name: "shieldbearer" },
+  { level: 3, name: "raider" },
+  { level: 4, name: "viking" },
+  { level: 5, name: "barbarian" },
+  { level: 6, name: "berserker" },
+  { level: 7, name: "warlord" },
   { level: 8, name: "legend" },
 ]
 

--- a/src/app/actions/rerollBossChallenge.test.ts
+++ b/src/app/actions/rerollBossChallenge.test.ts
@@ -34,8 +34,8 @@ describe('rerollBossChallenge', () => {
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
   })
 
-  it('a knight gets a second re-roll where a page does not', async () => {
-    // Knight (level 5+) gets 2 rerolls. We set defeats to 10 so rank is Knight.
+  it('a captain gets a second re-roll where a hatchling does not', async () => {
+    // Level 5+ gets 2 rerolls. We set defeats to 10, so the rank is captain.
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -55,7 +55,7 @@ describe('rerollBossChallenge', () => {
   })
 
   it('the allowance exhausts to already-rerolled', async () => {
-    // Page (level < 5) gets 1 reroll. We set rerollCount to 1.
+    // Below level 5 gets 1 reroll (0 defeats is hatchling). rerollCount is 1.
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -71,7 +71,7 @@ describe('rerollBossChallenge', () => {
   })
 
   it('the reroll prompt addresses the rank', async () => {
-    // Knight (level 5+) rank name is 'Knight'
+    // 10 defeats is level 5, whose rank name is 'captain'
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -83,10 +83,10 @@ describe('rerollBossChallenge', () => {
 
     await rerollBossChallenge('b1')
 
-    // buildChallengePrompt is real, so we check if it was called with 'Knight'
+    // buildChallengePrompt is real, so we check it was called with 'captain'
     // Since we can't spy on the pure function directly without mocking, 
     // we verify the result of the logic via the generate call's arguments.
-    expect(askCoach).toHaveBeenCalledWith(expect.any(String), expect.any(String), buildChallengePrompt('Running', '🏃', 'knight'))
+    expect(askCoach).toHaveBeenCalledWith(expect.any(String), expect.any(String), buildChallengePrompt('Running', '🏃', 'captain'))
   })
 }) 
 describe('rerollBossChallenge — the path that had no cap at all', () => {

--- a/src/app/actions/rerollBossChallenge.test.ts
+++ b/src/app/actions/rerollBossChallenge.test.ts
@@ -34,8 +34,8 @@ describe('rerollBossChallenge', () => {
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
   })
 
-  it('a captain gets a second re-roll where a hatchling does not', async () => {
-    // Level 5+ gets 2 rerolls. We set defeats to 10, so the rank is captain.
+  it('a barbarian gets a second re-roll where a hatchling does not', async () => {
+    // Level 5+ gets 2 rerolls. We set defeats to 10, so the rank is barbarian.
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -71,7 +71,7 @@ describe('rerollBossChallenge', () => {
   })
 
   it('the reroll prompt addresses the rank', async () => {
-    // 10 defeats is level 5, whose rank name is 'captain'
+    // 10 defeats is level 5, whose rank name is 'barbarian'
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
     vi.mocked(prisma.bossBattle.findFirst).mockResolvedValue({
       id: 'b1',
@@ -83,10 +83,10 @@ describe('rerollBossChallenge', () => {
 
     await rerollBossChallenge('b1')
 
-    // buildChallengePrompt is real, so we check it was called with 'captain'
+    // buildChallengePrompt is real, so we check it was called with 'barbarian'
     // Since we can't spy on the pure function directly without mocking, 
     // we verify the result of the logic via the generate call's arguments.
-    expect(askCoach).toHaveBeenCalledWith(expect.any(String), expect.any(String), buildChallengePrompt('Running', '🏃', 'captain'))
+    expect(askCoach).toHaveBeenCalledWith(expect.any(String), expect.any(String), buildChallengePrompt('Running', '🏃', 'barbarian'))
   })
 }) 
 describe('rerollBossChallenge — the path that had no cap at all', () => {

--- a/src/app/actions/startSeason.test.ts
+++ b/src/app/actions/startSeason.test.ts
@@ -61,7 +61,7 @@ describe('startSeason', () => {
   it('fewer than three lanes throws before touching the prize', async () => {
     vi.mocked(prisma.lane.count).mockResolvedValue(2)
 
-    await expect(startSeason()).rejects.toThrow('Your baby demands 3 active lanes before the season starts')
+    await expect(startSeason()).rejects.toThrow('Your hatchling demands 3 active lanes before the season starts')
     expect(prisma.prize.findUnique).not.toHaveBeenCalled()
   })
 
@@ -92,10 +92,9 @@ describe('startSeason', () => {
     expect(result.seasonStart.getUTCDate()).toBe(20)
   })
 
-  it('a squire-level player is blocked at 3 lanes with the demand named', async () => {
-    // Squire level requires more than 3 lanes (e.g. 5)
-    // We simulate enough defeats to reach squire level, but not enough active lanes
-    // Let's assume squire level is reached at 10 defeats, and requires 5 lanes.
+  it('a captain-level player is blocked at 3 lanes with the demand named', async () => {
+    // 10 defeats is captain (threshold 8), which requires more than 3 lanes.
+    // We simulate enough defeats to reach it, but not enough active lanes.
     // We'll mock count to return 3 active lanes, but 10 defeats.
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(10)
@@ -138,8 +137,8 @@ describe('startSeason', () => {
     }
   })
 
-  it('a baby-level player starts at 3 lanes as before', async () => {
-    // Baby level (0 defeats) requires 3 lanes (as per AC 'as before')
+  it('a hatchling-level player starts at 3 lanes as before', async () => {
+    // Hatchling level (0 defeats) requires 3 lanes (as per AC 'as before')
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
     vi.mocked(prisma.prize.findUnique).mockResolvedValue({ id: 'p1', userId } as any)

--- a/src/app/actions/startSeason.test.ts
+++ b/src/app/actions/startSeason.test.ts
@@ -92,8 +92,8 @@ describe('startSeason', () => {
     expect(result.seasonStart.getUTCDate()).toBe(20)
   })
 
-  it('a captain-level player is blocked at 3 lanes with the demand named', async () => {
-    // 10 defeats is captain (threshold 8), which requires more than 3 lanes.
+  it('a barbarian-level player is blocked at 3 lanes with the demand named', async () => {
+    // 10 defeats is barbarian (threshold 8), which requires more than 3 lanes.
     // We simulate enough defeats to reach it, but not enough active lanes.
     // We'll mock count to return 3 active lanes, but 10 defeats.
     vi.mocked(prisma.lane.count).mockResolvedValue(3)

--- a/src/app/actions/swapLane.test.ts
+++ b/src/app/actions/swapLane.test.ts
@@ -55,7 +55,7 @@ describe('swapLane', () => {
 
   it('retires a lane outright when more than three are active', async () => {
     vi.mocked(prisma.lane.count).mockResolvedValue(4)
-    // zero defeats -> baby -> floor 3; four active lanes sit above it
+    // zero defeats -> hatchling -> floor 3; four active lanes sit above it
 
     const result = await swapLane({ outLaneId: 'lane-2' })
 
@@ -68,7 +68,7 @@ describe('swapLane', () => {
 
   it('demands a replacement at exactly three lanes', async () => {
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
-    // zero defeats -> baby -> floor 3; exactly at the floor demands a swap
+    // zero defeats -> hatchling -> floor 3; exactly at the floor demands a swap
 
     const result = await swapLane({ outLaneId: 'lane-2' })
 
@@ -157,8 +157,8 @@ describe('swapLane', () => {
     })
   })
 
-  it('a knight-level roster at 6 lanes must swap, not retire', async () => {
-    // Knight level requires a certain number of defeats.
+  it('a legend-level roster at 6 lanes must swap, not retire', async () => {
+    // 50 defeats is past the top threshold (34), so the rank is legend.
     // We'll set defeats to a high number so floor is low (e.g. 3).
     // If activeLaneCount is 6 and floor is 3, decision is NOT blocked and NOT mustPickReplacement.
     vi.mocked(prisma.lane.count).mockResolvedValue(6)
@@ -170,8 +170,8 @@ describe('swapLane', () => {
     expect(prisma.$transaction).toHaveBeenCalled()
   })
 
-  it("a baby-level roster keeps today's behavior", async () => {
-    // Baby level (0 defeats) -> floor 3, exactly today's rule: at three
+  it("a hatchling-level roster keeps today's behavior", async () => {
+    // Hatchling level (0 defeats) -> floor 3, exactly today's rule: at three
     // lanes a bare retire demands a replacement, same as before this story.
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)

--- a/src/components/PlayerAvatarCard.test.tsx
+++ b/src/components/PlayerAvatarCard.test.tsx
@@ -18,11 +18,11 @@ describe('PlayerAvatarCard', () => {
     vi.clearAllMocks()
   })
 
-  it('the captain band renders name and level', async () => {
+  it('the barbarian band renders name and level', async () => {
     render(<PlayerAvatarCard defeats={8} />)
 
     const levelName = screen.getByTestId('avatar-level-name')
-    expect(levelName).toHaveTextContent(/Captain · Level 5/)
+    expect(levelName).toHaveTextContent(/Barbarian · Level 5/)
 
     expect(screen.queryByText(/defeats/)).not.toBeInTheDocument()
   })
@@ -47,7 +47,7 @@ describe('PlayerAvatarCard', () => {
 
   it('shows something from the very first rank', async () => {
     // The whole point of the change: a bar measuring distance-to-next-rank sat
-    // at zero for hatchling, whelp and page, because those bands are one boss
+    // at zero for hatchling, whelp and shieldbearer, because those bands are one boss
     // wide. A pip is lit at every rank, including the very first.
     render(<PlayerAvatarCard defeats={0} />)
 
@@ -63,7 +63,7 @@ describe('PlayerAvatarCard', () => {
   })
 
   it('does not light a pip part-way through a band', async () => {
-    // 4 defeats is still squire — the rank has not changed, so nor has the row.
+    // 4 defeats is still raider — the rank has not changed, so nor has the row.
     render(<PlayerAvatarCard defeats={4} />)
     expect(earned()).toBe(4)
   })
@@ -82,7 +82,7 @@ describe('PlayerAvatarCard', () => {
 
     expect(screen.getByTestId('avatar-pips')).toHaveAttribute(
       'aria-label',
-      expect.stringContaining('Evolution 6 of 9: captain')
+      expect.stringContaining('Evolution 6 of 9: barbarian')
     )
   })
 })

--- a/src/components/PlayerAvatarCard.test.tsx
+++ b/src/components/PlayerAvatarCard.test.tsx
@@ -18,11 +18,11 @@ describe('PlayerAvatarCard', () => {
     vi.clearAllMocks()
   })
 
-  it('the knight band renders name and level', async () => {
+  it('the captain band renders name and level', async () => {
     render(<PlayerAvatarCard defeats={8} />)
 
     const levelName = screen.getByTestId('avatar-level-name')
-    expect(levelName).toHaveTextContent(/Knight · Level 5/)
+    expect(levelName).toHaveTextContent(/Captain · Level 5/)
 
     expect(screen.queryByText(/defeats/)).not.toBeInTheDocument()
   })
@@ -36,7 +36,7 @@ describe('PlayerAvatarCard', () => {
     expect(locked()).toBe(0)
   })
 
-  it('level zero renders the baby stage', async () => {
+  it('level zero renders the hatchling stage', async () => {
     render(<PlayerAvatarCard defeats={0} />)
 
     expect(screen.getByTestId('avatar-level-name')).toHaveTextContent(/Level 0/)
@@ -47,7 +47,7 @@ describe('PlayerAvatarCard', () => {
 
   it('shows something from the very first rank', async () => {
     // The whole point of the change: a bar measuring distance-to-next-rank sat
-    // at zero for baby, toddler and tween, because those bands are one boss
+    // at zero for hatchling, whelp and page, because those bands are one boss
     // wide. A pip is lit at every rank, including the very first.
     render(<PlayerAvatarCard defeats={0} />)
 
@@ -63,7 +63,7 @@ describe('PlayerAvatarCard', () => {
   })
 
   it('does not light a pip part-way through a band', async () => {
-    // 4 defeats is still page — the rank has not changed, so nor has the row.
+    // 4 defeats is still squire — the rank has not changed, so nor has the row.
     render(<PlayerAvatarCard defeats={4} />)
     expect(earned()).toBe(4)
   })
@@ -82,7 +82,7 @@ describe('PlayerAvatarCard', () => {
 
     expect(screen.getByTestId('avatar-pips')).toHaveAttribute(
       'aria-label',
-      expect.stringContaining('Evolution 6 of 9: knight')
+      expect.stringContaining('Evolution 6 of 9: captain')
     )
   })
 })

--- a/src/lib/playerLevel.test.ts
+++ b/src/lib/playerLevel.test.ts
@@ -4,14 +4,14 @@ import { playerLevel } from './playerLevel'
 describe('playerLevel', () => {
   it('the ladder maps defeats to levels (table-driven over 0,1,2,3,5,8,13,21,34)', () => {
     const cases: Array<[number, string]> = [
-      [0, 'baby'],
-      [1, 'toddler'],
-      [2, 'tween'],
-      [3, 'page'],
-      [5, 'squire'],
-      [8, 'knight'],
-      [13, 'barbarian'],
-      [21, 'warlord'],
+      [0, 'hatchling'],
+      [1, 'whelp'],
+      [2, 'page'],
+      [3, 'squire'],
+      [5, 'knight'],
+      [8, 'captain'],
+      [13, 'champion'],
+      [21, 'king'],
       [34, 'legend'],
     ]
 
@@ -23,17 +23,17 @@ describe('playerLevel', () => {
   })
 
   it('progress and nextAt inside a band and at the cap', () => {
-    // 0 -> level 0 'baby', nextAt 1, progress 0
-    const baby = playerLevel(0)
-    expect(baby.level).toBe(0)
-    expect(baby.nextAt).toBe(1)
-    expect(baby.progress).toBe(0)
+    // 0 -> level 0 'hatchling', nextAt 1, progress 0
+    const hatchling = playerLevel(0)
+    expect(hatchling.level).toBe(0)
+    expect(hatchling.nextAt).toBe(1)
+    expect(hatchling.progress).toBe(0)
 
-    // 5 -> level 4 'squire', nextAt 8, progress 0
-    const squire = playerLevel(5)
-    expect(squire.level).toBe(4)
-    expect(squire.nextAt).toBe(8)
-    expect(squire.progress).toBe(0)
+    // 5 -> level 4 'knight', nextAt 8, progress 0
+    const knight = playerLevel(5)
+    expect(knight.level).toBe(4)
+    expect(knight.nextAt).toBe(8)
+    expect(knight.progress).toBe(0)
 
     // 6 -> level 4, progress 1/3 (6 is 1 step into the 5->8 band)
     const progressMid = playerLevel(6)

--- a/src/lib/playerLevel.test.ts
+++ b/src/lib/playerLevel.test.ts
@@ -6,12 +6,12 @@ describe('playerLevel', () => {
     const cases: Array<[number, string]> = [
       [0, 'hatchling'],
       [1, 'whelp'],
-      [2, 'page'],
-      [3, 'squire'],
-      [5, 'knight'],
-      [8, 'captain'],
-      [13, 'champion'],
-      [21, 'king'],
+      [2, 'shieldbearer'],
+      [3, 'raider'],
+      [5, 'viking'],
+      [8, 'barbarian'],
+      [13, 'berserker'],
+      [21, 'warlord'],
       [34, 'legend'],
     ]
 
@@ -29,11 +29,11 @@ describe('playerLevel', () => {
     expect(hatchling.nextAt).toBe(1)
     expect(hatchling.progress).toBe(0)
 
-    // 5 -> level 4 'knight', nextAt 8, progress 0
-    const knight = playerLevel(5)
-    expect(knight.level).toBe(4)
-    expect(knight.nextAt).toBe(8)
-    expect(knight.progress).toBe(0)
+    // 5 -> level 4 'viking', nextAt 8, progress 0
+    const viking = playerLevel(5)
+    expect(viking.level).toBe(4)
+    expect(viking.nextAt).toBe(8)
+    expect(viking.progress).toBe(0)
 
     // 6 -> level 4, progress 1/3 (6 is 1 step into the 5->8 band)
     const progressMid = playerLevel(6)

--- a/src/lib/playerLevel.ts
+++ b/src/lib/playerLevel.ts
@@ -7,7 +7,7 @@ export type PlayerLevel = {
    * Fraction through the CURRENT band. Nothing renders this, on purpose: the
    * first three bands are one boss wide, so it is pinned at 0 for every new
    * player. The avatar card draws a pip per evolution instead. Wiring this to
-   * a progress bar puts back a bar that cannot fill until squire.
+   * a progress bar puts back a bar that cannot fill until raider.
    */
   progress: number;
 };
@@ -15,12 +15,12 @@ export type PlayerLevel = {
 const LADDER: { threshold: number; name: string }[] = [
   { threshold: 0, name: "hatchling" },
   { threshold: 1, name: "whelp" },
-  { threshold: 2, name: "page" },
-  { threshold: 3, name: "squire" },
-  { threshold: 5, name: "knight" },
-  { threshold: 8, name: "captain" },
-  { threshold: 13, name: "champion" },
-  { threshold: 21, name: "king" },
+  { threshold: 2, name: "shieldbearer" },
+  { threshold: 3, name: "raider" },
+  { threshold: 5, name: "viking" },
+  { threshold: 8, name: "barbarian" },
+  { threshold: 13, name: "berserker" },
+  { threshold: 21, name: "warlord" },
   { threshold: 34, name: "legend" },
 ];
 

--- a/src/lib/playerLevel.ts
+++ b/src/lib/playerLevel.ts
@@ -7,20 +7,20 @@ export type PlayerLevel = {
    * Fraction through the CURRENT band. Nothing renders this, on purpose: the
    * first three bands are one boss wide, so it is pinned at 0 for every new
    * player. The avatar card draws a pip per evolution instead. Wiring this to
-   * a progress bar puts back a bar that cannot fill until page.
+   * a progress bar puts back a bar that cannot fill until squire.
    */
   progress: number;
 };
 
 const LADDER: { threshold: number; name: string }[] = [
-  { threshold: 0, name: "baby" },
-  { threshold: 1, name: "toddler" },
-  { threshold: 2, name: "tween" },
-  { threshold: 3, name: "page" },
-  { threshold: 5, name: "squire" },
-  { threshold: 8, name: "knight" },
-  { threshold: 13, name: "barbarian" },
-  { threshold: 21, name: "warlord" },
+  { threshold: 0, name: "hatchling" },
+  { threshold: 1, name: "whelp" },
+  { threshold: 2, name: "page" },
+  { threshold: 3, name: "squire" },
+  { threshold: 5, name: "knight" },
+  { threshold: 8, name: "captain" },
+  { threshold: 13, name: "champion" },
+  { threshold: 21, name: "king" },
   { threshold: 34, name: "legend" },
 ];
 


### PR DESCRIPTION
## What ships

The nine evolutions become one world:

`hatchling → whelp → shieldbearer → raider → viking → barbarian → berserker → warlord → legend`

Production currently has `baby → toddler → tween → page → squire → knight → barbarian → warlord → legend` — three unrelated mythologies stitched together, with the two medieval rungs inverted (a page is junior to a squire; the ladder had it backwards, and the artwork agreed with history rather than the labels).

This release contains two commits toward that (#454 medieval, then #455 Norse), but **only the final state reaches production** — the intermediate medieval ladder never deployed. Eddie sees exactly one change, not two.

## Why Norse rather than medieval

#454 fixed the real bug but kept reaching for **institutional titles**. A page, a squire, a knight, a captain: each is a rank somebody else confers. That's a grade wearing armour, and this app does not grade.

Viking rank was **taken, not granted**, so the ladder is earned by construction. It also puts `barbarian` and `warlord` back among their own kind instead of leaving them orphaned after `knight`.

Two details settled it: `berserkr` means "bear-shirt" — a warrior who fought in a frenzy — and rung 6 is drawn mid-charge with dust flying. And rung 5 carries a Viking **round** shield, which the medieval reading missed.

## What Eddie sees

Nothing about his progress moves — same thresholds, same sprites, same pip counts. Only the words change. He **keeps** `barbarian` and `warlord`; the medieval version would have taken both.

## Scope

Labels only. Thresholds, level indices, artwork and pip counts untouched. Nothing branches on a rank name — `rank.name` is only interpolated into display copy (`src/app/page.tsx:140`, `src/app/actions/startSeason.ts:24`) and `buildChallengePrompt`.

Also corrected: two test titles that were wrong before any of this — `swapLane.test.ts` said "knight-level" while using 50 defeats (top rung), and `startSeason.test.ts` said "squire-level" at 10.

## Verification

- `pnpm test` → **563 passed / 83 files**
- **Mutation checks** — `barbarian` → `captain` fails 4 tests including the coach-prompt assertion; `shieldbearer` → `page` fails the ladder table
- `pnpm run lint` 0 errors; `tsc --noEmit` clean
- `/about` served locally, all nine in order

## Still deliberately off

The site remains `noindex` (`src/app/robots.ts` + layout metadata). That inverts after the domain — `legendseason.com` — is live and `AUTH_URL` plus the Google OAuth redirect URI are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9YJ3SvhfYFnJ8yCHQofh7