### PR TITLE
Epic 6: multi-player — hand-written batch (11 stories)

### DIFF
--- a/docs/epics/epic-6-multi-player.md
+++ b/docs/epics/epic-6-multi-player.md
@@ -1,0 +1,429 @@
+# Epic 6 — Multi-Player Support
+
+One account tracks multiple kids. A `Player` entity owns lanes and prize/season
+state. Existing data migrates to a first auto-created Player. The UI gets an
+active-player switcher. Players are private to the owning account.
+
+---
+
+## Story 11 — Player model: add Player to schema.prisma
+
+Add the `Player` model to `prisma/schema.prisma`. Wire nullable `playerId` FKs
+onto `Lane` and `Prize` (nullable = additive, no data loss on `db push`). Wire
+`User.players` relation. Cascade-delete lanes and prizes when a player is
+deleted.
+
+**Files to modify:**
+- `prisma/schema.prisma`
+
+**Acceptance Criteria:**
+- `Player` model added with fields: `id String @id @default(cuid())`, `userId String`, `name String`, `isDefault Boolean @default(false)`, `createdAt DateTime @default(now())`, `updatedAt DateTime @updatedAt`.
+- `Player` has relation `user User @relation(fields: [userId], references: [id], onDelete: Cascade)` and reverse `lanes Lane[]` and `prizes Prize[]`.
+- `Player` has `@@index([userId])` and `@@unique([userId, name])`.
+- `User` model gains `players Player[]` reverse relation.
+- `Lane` model gains `playerId String?` column and `player Player? @relation(fields: [playerId], references: [id], onDelete: Cascade)`.
+- `Prize` model gains `playerId String?` column and `player Player? @relation(fields: [playerId], references: [id], onDelete: Cascade)`.
+- `Lane` gains `@@index([playerId, isActive])`.
+- All existing models and fields are preserved unchanged.
+- `export const dynamic = 'force-dynamic'` is not applicable here (schema file).
+
+**Testing:** not applicable — Prisma schema file; there is no unit under test.
+
+---
+
+## Story 12 — Architecture doc: update data model section for Player
+
+Update `docs/architecture.md` §2 data-model section to document the `Player`
+model and the new nullable `playerId` columns on `Lane` and `Prize`. Also update
+§3 file inventory to add the new action and component paths introduced by this
+epic.
+
+**Files to modify:**
+- `docs/architecture.md`
+
+**Acceptance Criteria:**
+- §2 data model includes the full `Player` model Prisma block with all fields from Story 1.
+- §2 notes that `Lane` and `Prize` each gain a nullable `playerId String?` column.
+- §3 file inventory adds rows for: `src/app/actions/ensureDefaultPlayer.ts`, `src/app/actions/createPlayer.ts`, `src/app/actions/switchPlayer.ts`, `src/components/PlayerSwitcher.tsx`.
+- No other sections of `docs/architecture.md` are altered.
+
+**Testing:** not applicable — documentation file; there is no unit under test.
+
+---
+
+## Story 13 — ensureDefaultPlayer action
+
+**Depends on:** Story 11
+
+A `'use server'` action `ensureDefaultPlayer(): Promise<{ playerId: string }>`.
+When the signed-in user has no `Player` rows, it creates one (`name: 'Player 1'`,
+`isDefault: true`) and binds all existing orphan `Lane` and `Prize` rows to it.
+When at least one player already exists, returns the first player's id without
+writing anything.
+
+**Files to create:**
+- `src/app/actions/ensureDefaultPlayer.ts`
+- `src/app/actions/ensureDefaultPlayer.test.ts`
+
+**Acceptance Criteria:**
+- `ensureDefaultPlayer(): Promise<{ playerId: string }>` is the SOLE export of `src/app/actions/ensureDefaultPlayer.ts`.
+- Imports `{ prisma } from '@/lib/db'` and `{ requireUserId } from '@/lib/tenancy'`. Imports nothing from `next/cache`.
+- When `prisma.player.findFirst({ where: { userId }, orderBy: { createdAt: 'asc' } })` returns null: calls `prisma.player.create({ data: { userId, name: 'Player 1', isDefault: true } })`; then `prisma.lane.updateMany({ where: { userId, playerId: null }, data: { playerId: newPlayer.id } })`; then `prisma.prize.updateMany({ where: { userId, playerId: null }, data: { playerId: newPlayer.id } })`; returns `{ playerId: newPlayer.id }`.
+- When `prisma.player.findFirst` returns an existing player: returns `{ playerId: existing.id }` without calling `prisma.player.create`, `prisma.lane.updateMany`, or `prisma.prize.updateMany`.
+- Test file mocks `@/lib/db` and `@/lib/tenancy`. Does NOT mock `next/cache`.
+- Each mock assertion checks the `where` and `data` args on SHORT separate lines: `expect(mock.X).toHaveBeenCalledOnce(); const arg = mock.X.mock.calls[0][0]; expect(arg.where).toEqual({...}); expect(arg.data).toEqual({...})`.
+
+**Testing:**
+- Test returns existing playerId without creating when player row exists
+- Test creates player and binds orphan lanes when no players exist
+- Test does not call player.create when player already exists
+
+---
+
+## Story 14 — Layout: call ensureDefaultPlayer for signed-in users
+
+**Depends on:** Story 13
+
+Modify `src/app/layout.tsx` to call `ensureDefaultPlayer()` for signed-in
+users. This ensures every page load sees migrated state before rendering.
+The call is fire-and-await; it does not change any prop passed to `AppShell`.
+
+**Files to modify:**
+- `src/app/layout.tsx`
+
+**Acceptance Criteria:**
+- After the existing `const session = await auth()` call, when `session?.user` is truthy, the layout adds `await ensureDefaultPlayer()` before the JSX `return`.
+- Imports `{ ensureDefaultPlayer } from '@/app/actions/ensureDefaultPlayer'` at the top of the file.
+- When `session?.user` is falsy (demo visitor), `ensureDefaultPlayer` is NOT called.
+- `export const dynamic = 'force-dynamic'` is declared in this file.
+- All existing props passed to `AppShell` remain unchanged.
+- `src/app/layout.tsx` default-exports a React Server Component (async function `RootLayout`).
+
+**Testing:**
+- Test layout renders AppShell with signedIn false when no session
+- Test layout renders AppShell with signedIn true when session exists
+
+---
+
+## Story 15 — Tenancy: add requirePlayerId helper
+
+**Depends on:** Story 11
+
+Add `requirePlayerId(userId: string): Promise<string>` to `src/lib/tenancy.ts`.
+It reads the `x-active-player-id` cookie, validates ownership, and falls back
+to the oldest player if the cookie is absent or names a foreign player. Redirects
+to `'/'` only if no player rows exist at all.
+
+**Files to modify:**
+- `src/lib/tenancy.ts`
+- `src/lib/tenancy.test.ts`
+
+**Acceptance Criteria:**
+- Exports `requirePlayerId(userId: string): Promise<string>` as a new named export from `src/lib/tenancy.ts`. `requireUserId` is unchanged. Implement `requirePlayerId` exactly once; do NOT emit an alternate variant or re-export.
+- `requirePlayerId` imports `{ cookies } from 'next/headers'` and `{ redirect } from 'next/navigation'`. It imports `{ prisma } from '@/lib/db'`. It does NOT import `{ auth }`.
+- If `(await cookies()).get('x-active-player-id')?.value` is a non-empty string, calls `prisma.player.findFirst({ where: { id: cookieValue, userId } })`; if the row exists, returns `row.id`.
+- If the cookie is absent or the row is null, calls `prisma.player.findFirst({ where: { userId }, orderBy: { createdAt: 'asc' } })`; if found, returns `row.id`.
+- If that second query also returns null (no players at all), calls `redirect('/')`.
+- `tenancy.test.ts` new test cases import ONLY `{ requirePlayerId }` from `./tenancy`. They mock `@/lib/db`, `next/headers` (`cookies`), and `next/navigation` (`redirect`). They do NOT mock `@/auth`.
+
+**Testing:**
+- Test returns cookie player id when cookie names an owned player
+- Test falls back to oldest player when cookie is absent
+- Test redirects when no player rows exist for userId
+
+---
+
+## Story 16 — createPlayer action
+
+**Depends on:** Story 11
+
+A `'use server'` action `createPlayer` that validates a player name and
+persists a new `Player` row for the signed-in user.
+
+**Files to create:**
+- `src/app/actions/createPlayer.ts`
+- `src/app/actions/createPlayer.test.ts`
+
+**Acceptance Criteria:**
+- `createPlayer(name: string): Promise<{ ok: true; id: string } | { ok: false; error: string }>` is the SOLE export of `src/app/actions/createPlayer.ts`.
+- Imports `{ prisma } from '@/lib/db'` and `{ requireUserId } from '@/lib/tenancy'`. Imports `{ z } from 'zod'` for inline validation: `const nameSchema = z.string().trim().min(1).max(40)`.
+- Calls `requireUserId()` first; then `nameSchema.safeParse(name)` — if `!parsed.success` returns `{ ok: false, error: 'validation' }`.
+- On success: calls `prisma.player.create({ data: { userId, name: parsed.data, isDefault: false } })`; returns `{ ok: true, id: row.id }`. Implement `createPlayer` exactly once; do NOT emit an alternate variant or re-export.
+- Test file mocks `@/lib/db` and `@/lib/tenancy`. Does NOT mock `next/cache`.
+
+**Testing:**
+- Test returns ok:false for empty name
+- Test returns ok:false for whitespace-only name
+- Test returns ok:true with row id for valid input
+
+---
+
+## Story 17 — Viewer: add getActivePlayerId and update getViewer
+
+**Depends on:** Story 11
+
+Update `src/lib/viewer.ts` so that `getViewer` returns a `playerId` alongside
+the `userId`, and add a `getActivePlayerId` helper that reads the cookie and
+validates ownership.
+
+**Files to modify:**
+- `src/lib/viewer.ts`
+- `src/lib/viewer.test.ts`
+
+**Acceptance Criteria:**
+- Exports `getActivePlayerId(userId: string): Promise<string | null>` as a new named export from `src/lib/viewer.ts`. It imports `{ cookies } from 'next/headers'` and `{ prisma } from '@/lib/db'`. Reads `(await cookies()).get('x-active-player-id')?.value`; if present calls `prisma.player.findFirst({ where: { id: cookieValue, userId } })`; returns `row.id` if found, `null` otherwise. If cookie absent, returns `null`. Implement `getActivePlayerId` exactly once; do NOT emit an alternate variant or re-export.
+- `Viewer` type updated: `{ kind: 'user'; userId: string; playerId: string } | { kind: 'demo' }`. Export the updated `Viewer` type.
+- `getViewer` updated: after confirming the user row exists, calls `getActivePlayerId(userId)` to get `playerId`; if null, falls back to `prisma.player.findFirst({ where: { userId }, orderBy: { createdAt: 'asc' } })?.id ?? ''`; returns `{ kind: 'user', userId, playerId }`.
+- `getViewer` and `getActivePlayerId` are named exports of `src/lib/viewer.ts`; `Viewer` is an exported type.
+- `viewer.test.ts` new test cases import `{ getViewer, getActivePlayerId }` from `./viewer`. They mock `@/lib/db`, `next/headers` (`cookies`). They do NOT re-mock `@/auth` (existing suite already mocks it). Tests use fully-typed mock fixtures (no `as any`).
+
+**Testing:**
+- Test getActivePlayerId returns null when cookie is absent
+- Test getActivePlayerId returns playerId when cookie matches owned player
+- Test getViewer returns demo when session has no user
+
+---
+
+## Story 18 — Scope createLane to active player
+
+**Depends on:** Story 15
+
+Update `src/app/actions/createLane.ts` to resolve the active player and include
+`playerId` in the new lane's data.
+
+**Files to modify:**
+- `src/app/actions/createLane.ts`
+- `src/app/actions/createLane.test.ts`
+
+**Acceptance Criteria:**
+- `createLane(input: unknown): Promise<{ ok: true; id: string } | { ok: false; error: string }>` remains the SOLE export of the file.
+- Imports `{ requireUserId, requirePlayerId } from '@/lib/tenancy'`, `{ prisma } from '@/lib/db'`.
+- After `requireUserId()`, `createLane` calls `requirePlayerId(userId)` and stores the result as `playerId`.
+- `prisma.lane.create` is called with `data: { ...parsed.data, sortOrder: 0, userId, playerId, startsOn }`.
+- The lane ownership check `prisma.lane.count({ where: { userId } })` remains unchanged (total count across all players).
+- `createLane.test.ts` new test cases mock `@/lib/tenancy` to return `{ requireUserId: vi.fn().mockResolvedValue('u1'), requirePlayerId: vi.fn().mockResolvedValue('p1') }`. Assert `prisma.lane.create` received `playerId: 'p1'` using short-line assertions: `expect(mock.lane.create).toHaveBeenCalledOnce(); const arg = mock.lane.create.mock.calls[0][0]; expect(arg.data.playerId).toBe('p1')`.
+
+**Testing:**
+- Test lane create call includes playerId from requirePlayerId
+- Test lane create is not called when validation fails
+
+---
+
+## Story 19 — Scope createCheckIn to active player
+
+**Depends on:** Story 15
+
+Update `src/app/actions/createCheckIn.ts` so the lane ownership lookup is
+scoped to the active player, not just the userId.
+
+**Files to modify:**
+- `src/app/actions/createCheckIn.ts`
+- `src/app/actions/createCheckIn.test.ts`
+
+**Acceptance Criteria:**
+- `createCheckIn(input: unknown): Promise<{ ok: true; id: string } | { ok: false; error: string }>` remains the SOLE export of the file.
+- Imports `{ requireUserId, requirePlayerId } from '@/lib/tenancy'`, `{ prisma } from '@/lib/db'`.
+- After `requireUserId()`, `createCheckIn` calls `requirePlayerId(userId)` and stores the result as `playerId`.
+- The lane lookup changes from `prisma.lane.findFirst({ where: { id: laneId, userId } })` to `prisma.lane.findFirst({ where: { id: laneId, playerId } })`.
+- All other logic (window check, upsert, revalidatePath) is unchanged.
+- `createCheckIn.test.ts` new test cases mock `@/lib/tenancy` to return `{ requireUserId: vi.fn().mockResolvedValue('u1'), requirePlayerId: vi.fn().mockResolvedValue('p1') }`. Assert `prisma.lane.findFirst` was called with player scope using short-line assertions: `expect(mock.lane.findFirst).toHaveBeenCalledOnce(); const arg = mock.lane.findFirst.mock.calls[0][0]; expect(arg.where.playerId).toBe('p1')`.
+
+**Testing:**
+- Test lane lookup uses playerId from requirePlayerId
+- Test returns not-found when lane belongs to different player
+
+---
+
+## Story 20 — Scope dashboard page to active player
+
+**Depends on:** Story 17
+
+Update `src/app/page.tsx` `loadDashboard` so all DB reads are scoped to
+`viewer.playerId` instead of `viewer.userId`.
+
+**Files to modify:**
+- `src/app/page.tsx`
+
+**Acceptance Criteria:**
+- `export const dynamic = 'force-dynamic'` is already declared and must remain.
+- `loadDashboard` receives `viewer: Viewer` (updated type with `playerId`). For the `user` path: `prisma.prize.findUnique({ where: { playerId: viewer.playerId } })`; `prisma.lane.count({ where: { isActive: true, playerId: viewer.playerId } })`; `prisma.bossBattle.count({ where: { completedAt: { not: null }, lane: { playerId: viewer.playerId } } })`; `prisma.lane.findMany({ where: { isActive: true, playerId: viewer.playerId }, ... })`.
+- All queries that previously used `{ userId }` now use `{ playerId: viewer.playerId }` for lane-scoped filters. The `viewer.userId` value is no longer passed to lane or prize queries.
+- Demo path is unchanged.
+- No new files are created.
+- The existing `src/app/page.test.tsx` suite mocks `getViewer` — new test cases call `vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })`. Assert that `prisma.lane.findMany` is called with `where` containing `{ playerId: 'p1' }` using short-line assertions: `const arg = vi.mocked(prisma.lane.findMany).mock.calls[0][0]; expect(arg.where?.playerId).toBe('p1')`.
+
+**Testing:**
+- Test loadDashboard queries lanes by playerId not userId
+- Test loadDashboard queries prize by playerId
+
+---
+
+## Story 21 — Scope lanes page to active player
+
+**Depends on:** Story 17
+
+Update `src/app/lanes/page.tsx` `loadLanes` so all DB reads are scoped to
+`viewer.playerId`.
+
+**Files to modify:**
+- `src/app/lanes/page.tsx`
+
+**Acceptance Criteria:**
+- `export const dynamic = 'force-dynamic'` is already declared and must remain.
+- `loadLanes` receives `viewer: Viewer`. For the `user` path: `prisma.lane.findMany({ where: { playerId: viewer.playerId }, ... })`; `prisma.prize.findUnique({ where: { playerId: viewer.playerId } })`; `prisma.bossBattle.count({ where: { completedAt: { not: null }, lane: { playerId: viewer.playerId } } })`.
+- All queries that previously used `{ userId }` now use `{ playerId: viewer.playerId }`.
+- Demo path is unchanged.
+- No new files are created.
+- The existing `src/app/lanes/page.test.tsx` suite mocks `getViewer` — new test cases call `vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })`. Assert that `prisma.lane.findMany` is called with `where` containing `{ playerId: 'p1' }` using short-line assertions: `const arg = vi.mocked(prisma.lane.findMany).mock.calls[0][0]; expect(arg.where?.playerId).toBe('p1')`.
+
+**Testing:**
+- Test loadLanes queries lanes by playerId not userId
+- Test loadLanes queries prize by playerId
+
+---
+
+## Story 22 — Scope prize page to active player
+
+**Depends on:** Story 17
+
+Update `src/app/prize/page.tsx` `loadPrize` so the prize and lane reads are
+scoped to `viewer.playerId`.
+
+**Files to modify:**
+- `src/app/prize/page.tsx`
+
+**Acceptance Criteria:**
+- `export const dynamic = 'force-dynamic'` is already declared and must remain.
+- `loadPrize` receives `viewer: Viewer`. For the `user` path: `prisma.prize.findUnique({ where: { playerId: viewer.playerId } })`; `prisma.lane.findMany({ where: { playerId: viewer.playerId }, ... })`.
+- The `prisma.prize.findUnique` previously used `{ where: { userId } }`; it now uses `{ where: { playerId: viewer.playerId } }`.
+- All lane queries that previously used `{ userId }` now use `{ playerId: viewer.playerId }`.
+- Demo path is unchanged.
+- No new files are created.
+- The existing `src/app/prize/page.test.tsx` suite mocks `getViewer` — new test cases call `vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })`. Assert that `prisma.prize.findUnique` is called with `where` containing `{ playerId: 'p1' }` using short-line assertions: `const arg = vi.mocked(prisma.prize.findUnique).mock.calls[0][0]; expect(arg.where?.playerId).toBe('p1')`.
+
+**Testing:**
+- Test loadPrize queries prize by playerId not userId
+- Test loadPrize queries lanes by playerId
+
+---
+
+## Story 23 — switchPlayer action
+
+**Depends on:** Story 11
+
+A `'use server'` action that validates the requested player belongs to the signed-in
+user, then sets the `x-active-player-id` cookie and revalidates the root path.
+
+**Files to create:**
+- `src/app/actions/switchPlayer.ts`
+- `src/app/actions/switchPlayer.test.ts`
+
+**Acceptance Criteria:**
+- `switchPlayer(playerId: string): Promise<void>` is the SOLE export of `src/app/actions/switchPlayer.ts`.
+- Imports `{ cookies } from 'next/headers'`, `{ revalidatePath } from 'next/cache'`, `{ prisma } from '@/lib/db'`, `{ requireUserId } from '@/lib/tenancy'`.
+- Calls `requireUserId()` then `prisma.player.findFirst({ where: { id: playerId, userId } })`. If the row is null, returns without setting the cookie or calling `revalidatePath`.
+- If the player row exists: calls `(await cookies()).set('x-active-player-id', playerId, { path: '/', httpOnly: true, sameSite: 'lax', maxAge: 31536000 })` then `revalidatePath('/')`.
+- Test file mocks `@/lib/db`, `@/lib/tenancy`, `next/headers` (`cookies`), and `next/cache` (`revalidatePath`). Assertions use short lines: `expect(mockCookies.set).toHaveBeenCalledOnce(); const [name, val, opts] = mockCookies.set.mock.calls[0]; expect(name).toBe('x-active-player-id'); expect(val).toBe('p1'); expect(opts.httpOnly).toBe(true)`.
+
+**Testing:**
+- Test does not set cookie when player not found
+- Test sets cookie with name and playerId when player is valid
+- Test calls revalidatePath with slash when player is valid
+
+---
+
+## Story 24 — PlayerSwitcher component
+
+**Depends on:** Story 23
+
+A client component that renders a `<select>` for switching between players.
+Renders null when there is only one player (no choice to make).
+
+**Files to create:**
+- `src/components/PlayerSwitcher.tsx`
+- `src/components/PlayerSwitcher.test.tsx`
+
+**Acceptance Criteria:**
+- Default-exports a component named `PlayerSwitcher`. It is a `'use client'` component.
+- Props interface: `players: { id: string; name: string }[]`, `activePlayerId: string`, `switchPlayer: (playerId: string) => Promise<void>`.
+- When `players.length <= 1`, returns `null` — the component renders nothing.
+- When `players.length >= 2`: renders a `<select data-testid="player-switcher">` whose `value` equals `activePlayerId`. Each player renders as `<option value={player.id}>{player.name}</option>`.
+- `onChange` on the select calls `switchPlayer(e.target.value)`.
+- Imports nothing from `@/lib/db` or `@/lib/tenancy`.
+- Test file uses RTL. Does NOT use `vi.mock` for anything in `@/lib`.
+
+**Testing:**
+- Test renders null when players array has one entry
+- Test renders select with all player names when two entries
+- Test onChange calls switchPlayer with selected player id
+
+---
+
+## Story 25 — AppShell: add playerSwitcher prop slot
+
+**Depends on:** Story 24
+
+Add an optional `playerSwitcher?: React.ReactNode` prop to `AppShell`. Render it
+in the header alongside the account control.
+
+**Files to modify:**
+- `src/components/AppShell.tsx`
+- `src/components/AppShell.test.tsx`
+
+**Acceptance Criteria:**
+- `AppShell` accepts an optional `playerSwitcher?: React.ReactNode` prop. Default-exports a component named `AppShell`.
+- The header renders `<div className="flex items-center gap-2">{playerSwitcher}{account}</div>` in place of the bare `{account}` node, so the switcher sits left of the account control.
+- When `playerSwitcher` is undefined or null, the layout is visually unchanged (the flex wrapper renders an empty slot).
+- `AppShell.test.tsx` new test: when `playerSwitcher={<span data-testid="switcher-slot">SW</span>}` is passed, `screen.getByTestId('switcher-slot')` is in the document.
+
+**Testing:**
+- Test playerSwitcher node is rendered in the header when provided
+- Test header renders without error when playerSwitcher is undefined
+
+---
+
+## Story 26 — SidebarNav: add playerSwitcher prop slot
+
+**Depends on:** Story 24
+
+Add an optional `playerSwitcher?: React.ReactNode` prop to `SidebarNav`. Render
+it in a padded block at the bottom of the nav column.
+
+**Files to modify:**
+- `src/components/SidebarNav.tsx`
+- `src/components/SidebarNav.test.tsx`
+
+**Acceptance Criteria:**
+- `SidebarNav` accepts an optional `playerSwitcher?: React.ReactNode` prop. Default-exports a component named `SidebarNav`.
+- Renders `<div className="px-4 py-2">{playerSwitcher}</div>` at the bottom of the `<aside>`, below the nav links.
+- When `playerSwitcher` is undefined or null, the block renders but is visually empty (no layout shift).
+- `SidebarNav.test.tsx` new test: when `playerSwitcher={<span data-testid="nav-switcher">NS</span>}` is passed, `screen.getByTestId('nav-switcher')` is in the document.
+
+**Testing:**
+- Test playerSwitcher node appears in nav when provided
+- Test nav renders without error when playerSwitcher is undefined
+
+---
+
+## Story 27 — Layout: wire PlayerSwitcher into AppShell and SidebarNav
+
+**Depends on:** Story 14, Story 25, Story 26
+
+Update `src/app/layout.tsx` to fetch the player list and active player, then
+pass a `<PlayerSwitcher>` through `AppShell`.
+
+**Files to modify:**
+- `src/app/layout.tsx`
+
+**Acceptance Criteria:**
+- `export const dynamic = 'force-dynamic'` is declared in this file.
+- After the `auth()` call, when `session?.user` is truthy: fetches `const players = await prisma.player.findMany({ where: { userId: session.user.id }, orderBy: { createdAt: 'asc' }, select: { id: true, name: true } })`; resolves `activePlayerId` as `(await cookies()).get('x-active-player-id')?.value ?? players[0]?.id ?? ''`.
+- Imports `{ cookies } from 'next/headers'`, `{ prisma } from '@/lib/db'`, `PlayerSwitcher from '@/components/PlayerSwitcher'`, `{ switchPlayer } from '@/app/actions/switchPlayer'`.
+- Passes `playerSwitcher={<PlayerSwitcher players={players} activePlayerId={activePlayerId} switchPlayer={switchPlayer} />}` to `AppShell`.
+- When `session?.user` is falsy, `playerSwitcher` is not passed (undefined).
+- `AppShell` also receives `playerSwitcher` forwarded to `SidebarNav` (the wiring between AppShell and SidebarNav is already specified in Stories 15–16; this story only concerns the layout-level fetch and prop assembly).
+- `src/app/layout.tsx` default-exports an async React Server Component (`RootLayout`).
+
+**Testing:**
+- Test layout renders AppShell when session exists with player switcher
+- Test layout renders AppShell when no session without player switcher

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,9 @@ model Prize {
   id          String    @id @default(cuid())
   userId      String?   @unique
   user        User?     @relation(fields: [userId], references: [id])
-  playerId    String?
+  // One prize per player (the domain rule) — and findUnique-by-playerId in
+  // the pages requires the unique index. Nullable stays additive-safe.
+  playerId    String?   @unique
   player      Player?   @relation(fields: [playerId], references: [id], onDelete: Cascade)
   title       String
   description String?

--- a/src/app/actions/createCheckIn.test.ts
+++ b/src/app/actions/createCheckIn.test.ts
@@ -125,8 +125,8 @@ describe('createCheckIn — the date is not the caller\'s to choose freely', () 
   it('lane lookup uses playerId from requirePlayerId', async () => {
     await createCheckIn({ laneId: 'l1', date, isRest: false })
     expect(prisma.lane.findFirst).toHaveBeenCalledOnce()
-    const arg = vi.mocked(prisma.lane.findFirst).mock.calls[0][0]
-    expect(arg.where.playerId).toBe('p1')
+    expect(prisma.lane.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ playerId: 'p1' }) }))
   })
 
   it('returns not-found when lane belongs to different player', async () => {

--- a/src/app/actions/createCheckIn.test.ts
+++ b/src/app/actions/createCheckIn.test.ts
@@ -123,7 +123,7 @@ describe('createCheckIn — the date is not the caller\'s to choose freely', () 
   })
 
   it('lane lookup uses playerId from requirePlayerId', async () => {
-    await createCheckIn({ laneId: 'l1', date: '2026-08-27' })
+    await createCheckIn({ laneId: 'l1', date, isRest: false })
     expect(prisma.lane.findFirst).toHaveBeenCalledOnce()
     const arg = vi.mocked(prisma.lane.findFirst).mock.calls[0][0]
     expect(arg.where.playerId).toBe('p1')

--- a/src/app/actions/createCheckIn.test.ts
+++ b/src/app/actions/createCheckIn.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
-import { requireUserId } from '@/lib/tenancy'
+import { requireUserId, requirePlayerId } from '@/lib/tenancy'
 import { createCheckIn } from './createCheckIn'
 
 vi.mock('@/lib/db', () => ({ prisma: { checkIn: { upsert: vi.fn() }, lane: { findFirst: vi.fn() } } }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
-vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn(), requirePlayerId: vi.fn() }))
 
 const date = new Date(Date.UTC(2026, 0, 5))
 
@@ -22,6 +22,7 @@ describe('createCheckIn', () => {
     vi.clearAllMocks()
     pinClock()
     vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(requirePlayerId).mockResolvedValue('p1')
   })
 
   afterEach(() => vi.useRealTimers())
@@ -119,5 +120,18 @@ describe('createCheckIn — the date is not the caller\'s to choose freely', () 
     })
 
     expect(result).toEqual({ ok: true, id: 'c1' })
+  })
+
+  it('lane lookup uses playerId from requirePlayerId', async () => {
+    await createCheckIn({ laneId: 'l1', date: '2026-08-27' })
+    expect(prisma.lane.findFirst).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.lane.findFirst).mock.calls[0][0]
+    expect(arg.where.playerId).toBe('p1')
+  })
+
+  it('returns not-found when lane belongs to different player', async () => {
+    vi.mocked(prisma.lane.findFirst).mockResolvedValue(null as never)
+    const out = await createCheckIn({ laneId: 'l-foreign', date: '2026-08-27' })
+    expect(out.ok).toBe(false)
   })
 })

--- a/src/app/actions/createCheckIn.ts
+++ b/src/app/actions/createCheckIn.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/db";
 import { checkInSchema } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
-import { requireUserId } from "@/lib/tenancy";
+import { requireUserId, requirePlayerId } from "@/lib/tenancy";
 import { isWithinCheckInWindow } from "@/lib/checkInWindow";
 import { getTrainingDay } from "@/lib/trainingDay";
 
@@ -9,6 +9,7 @@ export async function createCheckIn(
   input: unknown
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
   const userId = await requireUserId();
+  const playerId = await requirePlayerId(userId);
 
   const parsed = checkInSchema.safeParse(input);
   if (!parsed.success) {
@@ -24,7 +25,7 @@ export async function createCheckIn(
   }
 
   const lane = await prisma.lane.findFirst({
-    where: { id: laneId, userId },
+    where: { id: laneId, playerId },
   });
 
   if (!lane) {

--- a/src/app/actions/createLane.test.ts
+++ b/src/app/actions/createLane.test.ts
@@ -138,8 +138,8 @@ describe('createLane — a ceiling on how many lanes one account owns', () => {
   it('lane create call includes playerId from requirePlayerId', async () => {
     await createLane({ name: 'Wall Ball', emoji: '🥍', targetPerWeek: 5 })
     expect(prisma.lane.create).toHaveBeenCalledOnce()
-    const arg = vi.mocked(prisma.lane.create).mock.calls[0][0]
-    expect(arg.data.playerId).toBe('p1')
+    expect(prisma.lane.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ playerId: 'p1' }) }))
   })
 
   it('lane create is not called when validation fails', async () => {

--- a/src/app/actions/createLane.test.ts
+++ b/src/app/actions/createLane.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { prisma } from '@/lib/db'
 import { revalidatePath } from 'next/cache'
-import { requireUserId } from '@/lib/tenancy'
+import { requireUserId, requirePlayerId } from '@/lib/tenancy'
 import { createLane } from './createLane'
 import { MAX_LANES_PER_USER } from '@/lib/season'
 
 vi.mock('@/lib/db', () => ({ prisma: { lane: { create: vi.fn(), count: vi.fn() } } }))
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
-vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn(), requirePlayerId: vi.fn() }))
 
 describe('createLane', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(requirePlayerId).mockResolvedValue('p1')
     vi.mocked(prisma.lane.count).mockResolvedValue(0)
   })
 
@@ -131,5 +132,18 @@ describe('createLane — a ceiling on how many lanes one account owns', () => {
   it('leaves room for a real season of swapping', async () => {
     // A swap a week for thirteen weeks, never reusing a lane, is about twenty.
     expect(MAX_LANES_PER_USER).toBeGreaterThan(20)
+  })
+
+  it('lane create call includes playerId from requirePlayerId', async () => {
+    await createLane({ name: 'Wall Ball', emoji: '🥍', targetPerWeek: 5 })
+    expect(prisma.lane.create).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.lane.create).mock.calls[0][0]
+    expect(arg.data.playerId).toBe('p1')
+  })
+
+  it('lane create is not called when validation fails', async () => {
+    vi.mocked(prisma.lane.create).mockClear()
+    await createLane({ name: '' })
+    expect(prisma.lane.create).not.toHaveBeenCalled()
   })
 })

--- a/src/app/actions/createLane.test.ts
+++ b/src/app/actions/createLane.test.ts
@@ -39,6 +39,7 @@ describe('createLane', () => {
         ...input,
         sortOrder: 0,
         userId: 'u1',
+        playerId: 'p1',
         startsOn: expect.any(Date)
       }
     })

--- a/src/app/actions/createLane.ts
+++ b/src/app/actions/createLane.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/db";
 import { laneSchema } from "@/lib/validation";
 import { revalidatePath } from "next/cache";
-import { requireUserId } from "@/lib/tenancy";
+import { requireUserId, requirePlayerId } from "@/lib/tenancy";
 import { resolveSeasonStart } from "@/lib/seasonAnchor";
 import { getTrainingDay } from "@/lib/trainingDay";
 import { MAX_LANES_PER_USER } from "@/lib/season";
@@ -10,6 +10,7 @@ export async function createLane(
   input: unknown
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
   const userId = await requireUserId();
+  const playerId = await requirePlayerId(userId);
   const parsed = laneSchema.safeParse(input);
   if (!parsed.success) {
     return { ok: false, error: "validation" };
@@ -26,7 +27,7 @@ export async function createLane(
   const startsOn = resolveSeasonStart(getTrainingDay(new Date()));
 
   const lane = await prisma.lane.create({
-    data: { ...parsed.data, sortOrder: 0, userId, startsOn },
+    data: { ...parsed.data, sortOrder: 0, userId, playerId, startsOn },
   });
 
   revalidatePath("/lanes");

--- a/src/app/actions/createPlayer.test.ts
+++ b/src/app/actions/createPlayer.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPlayer } from './createPlayer'
+import { prisma } from '@/lib/db'
+import { requireUserId } from '@/lib/tenancy'
+
+vi.mock('@/lib/db', () => ({
+  prisma: { player: { create: vi.fn(), count: vi.fn().mockResolvedValue(0) } },
+}))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
+
+describe('createPlayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(prisma.player.count).mockResolvedValue(0)
+  })
+
+  it('returns ok:false for empty and whitespace-only names', async () => {
+    await expect(createPlayer('')).resolves.toEqual({ ok: false, error: 'validation' })
+    await expect(createPlayer('   ')).resolves.toEqual({ ok: false, error: 'validation' })
+    expect(prisma.player.create).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:false error cap when the account already has 6 players', async () => {
+    vi.mocked(prisma.player.count).mockResolvedValue(6)
+    await expect(createPlayer('Eddie')).resolves.toEqual({ ok: false, error: 'cap' })
+    expect(prisma.player.create).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:true with row id for valid input', async () => {
+    vi.mocked(prisma.player.create).mockResolvedValue({ id: 'p9' } as never)
+    await expect(createPlayer('  Eddie ')).resolves.toEqual({ ok: true, id: 'p9' })
+    expect(prisma.player.create).toHaveBeenCalledOnce()
+    const arg = vi.mocked(prisma.player.create).mock.calls[0][0]
+    expect(arg.data).toEqual({ userId: 'u1', name: 'Eddie', isDefault: false })
+  })
+})

--- a/src/app/actions/createPlayer.ts
+++ b/src/app/actions/createPlayer.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { prisma } from '@/lib/db';
+import { requireUserId } from '@/lib/tenancy';
+import { z } from 'zod';
+
+const nameSchema = z.string().trim().min(1).max(40);
+
+export async function createPlayer(
+  name: string
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  const userId = await requireUserId();
+  const parsed = nameSchema.safeParse(name);
+  if (!parsed.success) {
+    return { ok: false, error: 'validation' };
+  }
+  // Hard per-account cap of 6 players (Thomas, 2026-08-27).
+  const count = await prisma.player.count({ where: { userId } });
+  if (count >= 6) {
+    return { ok: false, error: 'cap' };
+  }
+  const row = await prisma.player.create({
+    data: { userId, name: parsed.data, isDefault: false },
+  });
+  return { ok: true, id: row.id };
+}

--- a/src/app/boss-battles/page.test.tsx
+++ b/src/app/boss-battles/page.test.tsx
@@ -32,7 +32,7 @@ vi.mock('next/font/google', () => new Proxy({}, {
 describe('Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
     // Persistent default: any call not overridden by a test's Once
     // (i.e. the second, inactive-lanes call) resolves empty. A Once here
     // would be consumed FIFO by the FIRST (active) call instead.
@@ -42,7 +42,7 @@ describe('Page', () => {
 
   it('both lane queries are scoped to the signed-in user', async () => {
     const userId = 'u1'
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId, playerId: 'p1' })
 
     const lane = {
       id: 'l1',

--- a/src/app/history/page.test.tsx
+++ b/src/app/history/page.test.tsx
@@ -28,13 +28,13 @@ describe('Page', () => {
     const { prisma } = await import('@/lib/db')
     vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
     vi.mocked(prisma.lane.findMany).mockResolvedValue([])
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
   })
 
   it('the history queries are scoped to the signed-in user', async () => {
     const { prisma } = await import('@/lib/db')
     const userId = 'u1'
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId, playerId: 'p1' })
     
     vi.mocked(prisma.prize.findUnique).mockResolvedValue({ id: 'prize', userId } as any)
     vi.mocked(prisma.lane.findMany).mockResolvedValue([])

--- a/src/app/lanes/page.test.tsx
+++ b/src/app/lanes/page.test.tsx
@@ -34,7 +34,7 @@ describe('Page', () => {
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
     vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
   })
 
   it('the lane list is scoped to the signed-in user', async () => {
@@ -52,7 +52,7 @@ describe('Page', () => {
 
     expect(getViewer).toHaveBeenCalled()
     expect(prisma.lane.findMany).toHaveBeenCalledWith({
-      where: { userId: 'u1' },
+      where: { playerId: 'p1' },
       orderBy: [{ isActive: 'desc' }, { sortOrder: 'asc' }],
       include: { targetChanges: true },
     })

--- a/src/app/lanes/page.tsx
+++ b/src/app/lanes/page.tsx
@@ -28,18 +28,18 @@ async function loadLanes(viewer: Viewer, today: Date) {
     return { lanes, seasonRunning: true, defeats: demo.defeats }
   }
 
-  const { userId } = viewer
+  const { playerId } = viewer
   const [lanes, prize, defeats] = await Promise.all([
     prisma.lane.findMany({
-      where: { userId },
+      where: { playerId },
       orderBy: [{ isActive: "desc" }, { sortOrder: "asc" }],
       include: { targetChanges: true },
     }),
     // A running season refuses lane deletes, so the page says so up front
     // rather than letting the confirm button do nothing.
-    prisma.prize.findUnique({ where: { userId } }),
+    prisma.prize.findUnique({ where: { playerId } }),
     prisma.bossBattle.count({
-      where: { completedAt: { not: null }, lane: { userId } },
+      where: { completedAt: { not: null }, lane: { playerId } },
     }),
   ])
 

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import RootLayout from './layout'
+import { auth } from '@/auth'
+import { prisma } from '@/lib/db'
+import { ensureDefaultPlayer } from '@/app/actions/ensureDefaultPlayer'
+
+// next/font's loader only exists inside the Next build; under vitest
+// `Geist(...)` is not a function and the suite dies at module load.
+vi.mock('next/font/google', () => ({
+  Geist: () => ({ variable: 'mock-font-variable', className: 'mock-font' }),
+  Geist_Mono: () => ({ variable: 'mock-font-variable', className: 'mock-font' }),
+}))
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+vi.mock('@/lib/db', () => ({ prisma: { player: { findMany: vi.fn() } } }))
+vi.mock('next/headers', () => ({ cookies: vi.fn() }))
+vi.mock('@/app/actions/ensureDefaultPlayer', () => ({ ensureDefaultPlayer: vi.fn() }))
+vi.mock('@/app/actions/switchPlayer', () => ({ switchPlayer: vi.fn() }))
+
+import { cookies } from 'next/headers'
+
+describe('RootLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.player.findMany).mockResolvedValue(
+      [{ id: 'p1', name: 'Eddie' }] as never)
+    vi.mocked(cookies).mockResolvedValue(
+      { get: vi.fn().mockReturnValue(undefined) } as unknown as Awaited<ReturnType<typeof cookies>>)
+  })
+
+  it('renders AppShell without player switcher and without ensureDefaultPlayer when no session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+
+    render(await RootLayout({ children: <div>content</div> }))
+
+    expect(ensureDefaultPlayer).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('player-switcher')).not.toBeInTheDocument()
+  })
+
+  it('calls ensureDefaultPlayer and renders the player switcher when session exists', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'u1' } } as never)
+
+    render(await RootLayout({ children: <div>content</div> }))
+
+    expect(ensureDefaultPlayer).toHaveBeenCalledOnce()
+    expect(prisma.player.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'u1' } }))
+  })
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import AppShell from "@/components/AppShell";
 import AccountControl from "@/components/AccountControl";
+import PlayerSwitcher from "@/components/PlayerSwitcher";
 import { auth } from "@/auth";
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/db";
+import { ensureDefaultPlayer } from "@/app/actions/ensureDefaultPlayer";
+import { switchPlayer } from "@/app/actions/switchPlayer";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,12 +29,37 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// The layout reads the session and the active-player cookie on every request.
+export const dynamic = "force-dynamic";
+
 export default async function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   // Resolved here, in a server component, so the header knows who you are
   // without every page having to tell it.
   const session = await auth();
+
+  // Epic 6: signed-in accounts always have a player before any page renders —
+  // ensureDefaultPlayer migrates pre-multiplayer rows on first sight — and the
+  // header gets the switcher, fed by the active-player cookie.
+  let playerSwitcher: React.ReactNode | undefined;
+  if (session?.user) {
+    await ensureDefaultPlayer();
+    const players = await prisma.player.findMany({
+      where: { userId: session.user.id },
+      orderBy: { createdAt: "asc" },
+      select: { id: true, name: true },
+    });
+    const activePlayerId =
+      (await cookies()).get("x-active-player-id")?.value ?? players[0]?.id ?? "";
+    playerSwitcher = (
+      <PlayerSwitcher
+        players={players}
+        activePlayerId={activePlayerId}
+        switchPlayer={switchPlayer}
+      />
+    );
+  }
 
   return (
     <html
@@ -40,6 +70,7 @@ export default async function RootLayout({
         <AppShell
           signedIn={Boolean(session?.user)}
           account={<AccountControl signedIn={Boolean(session?.user)} />}
+          playerSwitcher={playerSwitcher}
         >
           {children}
         </AppShell>

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -58,7 +58,7 @@ vi.mock('next/font/google', () => new Proxy({}, {
 describe('Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
     // Default mock for lanes to prevent crashes in the loop
     vi.mocked(prisma.lane.findMany).mockResolvedValue([])
     vi.mocked(prisma.lane.count).mockResolvedValue(0)
@@ -69,7 +69,7 @@ describe('Page', () => {
 
   it('every query is scoped to the signed-in user', async () => {
     const userId = 'u1'
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId, playerId: 'p1' })
     
     // Setup mocks to verify the 'where' clause
     vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
@@ -79,13 +79,13 @@ describe('Page', () => {
     await Page()
 
     expect(prisma.prize.findUnique).toHaveBeenCalledWith({
-      where: { userId }
+      where: { playerId: 'p1' }
     })
     expect(prisma.lane.count).toHaveBeenCalledWith({
-      where: { isActive: true, userId: userId }
+      where: { isActive: true, playerId: 'p1' }
     })
     expect(prisma.lane.findMany).toHaveBeenCalledWith({
-      where: { isActive: true, userId: userId },
+      where: { isActive: true, playerId: 'p1' },
       orderBy: { sortOrder: "asc" },
       include: expect.anything()
     })
@@ -195,7 +195,7 @@ describe('Page — the freeze offer', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date(TODAY + 'T18:00:00.000Z'))
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
     vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)
@@ -306,7 +306,7 @@ describe('Page — the bar counts what the season counts', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date(TODAY + 'T18:00:00.000Z'))
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
     vi.mocked(prisma.lane.count).mockResolvedValue(3)
     vi.mocked(prisma.prize.findUnique).mockResolvedValue(null)
     vi.mocked(prisma.bossBattle.count).mockResolvedValue(0)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,19 +54,19 @@ async function loadDashboard(viewer: Viewer, today: Date) {
     }
   }
 
-  const { userId } = viewer
+  const { playerId } = viewer
   const streakWindowStart = new Date(
     today.getTime() - STREAK_WINDOW_DAYS * 24 * 60 * 60 * 1000
   )
 
   const [prize, activeLaneCount, defeats, lanes] = await Promise.all([
-    prisma.prize.findUnique({ where: { userId } }),
-    prisma.lane.count({ where: { isActive: true, userId } }),
+    prisma.prize.findUnique({ where: { playerId } }),
+    prisma.lane.count({ where: { isActive: true, playerId } }),
     prisma.bossBattle.count({
-      where: { completedAt: { not: null }, lane: { userId } },
+      where: { completedAt: { not: null }, lane: { playerId } },
     }),
     prisma.lane.findMany({
-      where: { isActive: true, userId },
+      where: { isActive: true, playerId },
       orderBy: { sortOrder: "asc" },
       include: {
         checkIns: {

--- a/src/app/prize/page.test.tsx
+++ b/src/app/prize/page.test.tsx
@@ -34,7 +34,7 @@ const PRIZE = {
 describe('Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1' })
+    vi.mocked(getViewer).mockResolvedValue({ kind: 'user', userId: 'u1', playerId: 'p1' })
     vi.mocked(prisma.lane.findMany).mockResolvedValue([] as never)
   })
 
@@ -47,11 +47,11 @@ describe('Page', () => {
     render(await PrizePage())
 
     expect(vi.mocked(prisma.prize.findUnique)).toHaveBeenCalledWith({
-      where: { userId: 'u1' },
+      where: { playerId: 'p1' },
     })
     expect(vi.mocked(prisma.lane.findMany)).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ userId: 'u1' }),
+        where: expect.objectContaining({ playerId: 'p1' }),
       }),
     )
   })

--- a/src/app/prize/page.tsx
+++ b/src/app/prize/page.tsx
@@ -39,8 +39,8 @@ async function loadPrize(viewer: Viewer, today: Date) {
     return { prize: demo.prize, lanes: demo.lanes }
   }
 
-  const { userId } = viewer
-  const prize = await prisma.prize.findUnique({ where: { userId } })
+  const { playerId } = viewer
+  const prize = await prisma.prize.findUnique({ where: { playerId } })
   const seasonStart = prize?.seasonStart ?? null
 
   // Before START there is no window to filter on — the season hasn't begun,
@@ -58,7 +58,7 @@ async function loadPrize(viewer: Viewer, today: Date) {
     : {}
 
   const lanes = await prisma.lane.findMany({
-    where: { userId },
+    where: { playerId },
     select: {
       targetPerWeek: true,
       // Each week is scored against the target that was in force THAT week, so

--- a/src/components/AppShell.test.tsx
+++ b/src/components/AppShell.test.tsx
@@ -82,4 +82,23 @@ describe('AppShell', () => {
     expect(wrapper.className).toContain('flex-col')
     expect(wrapper.className).toContain('md:flex-row')
   })
+
+  it('playerSwitcher node is rendered in the header when provided', () => {
+    render(
+      <AppShell signedIn account={<span>acct</span>}
+        playerSwitcher={<span data-testid="switcher-slot">SW</span>}>
+        <div>content</div>
+      </AppShell>
+    )
+    expect(screen.getByTestId('switcher-slot')).toBeInTheDocument()
+  })
+
+  it('header renders without error when playerSwitcher is undefined', () => {
+    render(
+      <AppShell signedIn account={<span>acct</span>}>
+        <div>content</div>
+      </AppShell>
+    )
+    expect(screen.getByTestId('mobile-topbar')).toBeInTheDocument()
+  })
 })

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,9 +11,11 @@ interface AppShellProps {
   account?: React.ReactNode
   /** Whether there is an account to manage — the nav hides what there is not. */
   signedIn?: boolean
+  /** Active-player switcher (epic 6) — sits left of the account control. */
+  playerSwitcher?: React.ReactNode
 }
 
-export default function AppShell({ children, account, signedIn = false }: AppShellProps) {
+export default function AppShell({ children, account, signedIn = false, playerSwitcher }: AppShellProps) {
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
   
@@ -53,7 +55,7 @@ export default function AppShell({ children, account, signedIn = false }: AppShe
           isOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
-        <SidebarNav signedIn={signedIn} />
+        <SidebarNav signedIn={signedIn} playerSwitcher={playerSwitcher} />
       </aside>
 
       {/* min-w-0 keeps a wide child (the history heatmap, a long coach note)
@@ -85,7 +87,7 @@ export default function AppShell({ children, account, signedIn = false }: AppShe
             </button>
             <span className="text-lg font-bold text-zinc-100">Lacrosse Grind</span>
           </div>
-          {account}
+          <div className="flex items-center gap-2">{playerSwitcher}{account}</div>
         </header>
 
         <main className="min-w-0 flex-1 overflow-y-auto">{children}</main>

--- a/src/lib/tenancy.test.ts
+++ b/src/lib/tenancy.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi } from 'vitest'
-import { requireUserId } from './tenancy'
+import { requireUserId, requirePlayerId } from './tenancy'
 
 import { auth } from '@/auth'
 import { redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
 import { prisma } from '@/lib/db'
 
 vi.mock('@/auth', () => ({
   auth: vi.fn(),
 }))
 
-vi.mock('@/lib/db', () => ({ prisma: { user: { count: vi.fn() } } }))
+vi.mock('@/lib/db', () => ({ prisma: { user: { count: vi.fn() }, player: { findFirst: vi.fn() } } }))
 
+vi.mock('next/headers', () => ({ cookies: vi.fn() }))
 vi.mock('next/navigation', () => ({
   redirect: vi.fn(() => { throw new Error('REDIRECT') }),
 }))
@@ -60,5 +62,28 @@ describe('requireUserId — a cookie is not proof the account exists', () => {
 
     await expect(requireUserId()).rejects.toThrow()
     expect(redirect).toHaveBeenCalledWith('/signin')
+  })
+
+  it('returns cookie player id when cookie names an owned player', async () => {
+    vi.mocked(cookies).mockResolvedValue(
+      { get: () => ({ value: 'player-1' }) } as unknown as Awaited<ReturnType<typeof cookies>>)
+    vi.mocked(prisma.player.findFirst).mockResolvedValueOnce({ id: 'player-1' } as never)
+    await expect(requirePlayerId('user-1')).resolves.toBe('player-1')
+  })
+
+  it('falls back to oldest player when cookie is absent', async () => {
+    vi.mocked(cookies).mockResolvedValue(
+      { get: () => undefined } as unknown as Awaited<ReturnType<typeof cookies>>)
+    vi.mocked(prisma.player.findFirst).mockResolvedValueOnce({ id: 'player-2' } as never)
+    await expect(requirePlayerId('user-1')).resolves.toBe('player-2')
+  })
+
+  it('redirects when no player rows exist for userId', async () => {
+    vi.mocked(cookies).mockResolvedValue(
+      { get: () => undefined } as unknown as Awaited<ReturnType<typeof cookies>>)
+    vi.mocked(prisma.player.findFirst).mockResolvedValueOnce(null as never)
+    vi.mocked(prisma.player.findFirst).mockResolvedValueOnce(null as never)
+    await requirePlayerId('user-1').catch(() => undefined)
+    expect(redirect).toHaveBeenCalledWith('/')
   })
 })

--- a/src/lib/tenancy.ts
+++ b/src/lib/tenancy.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db";
 
@@ -21,5 +22,29 @@ export async function requireUserId(): Promise<string> {
 
   redirect("/signin");
   // The redirect function throws, so this line is unreachable.
+  throw new Error("Redirected");
+}
+/**
+ * The active player for this account, or a redirect home if none exist.
+ *
+ * Cookie first (`x-active-player-id`), validated against ownership so a stale
+ * or foreign cookie can never leak another account's player; falls back to
+ * the oldest player. Redirects only when the account has no players at all
+ * (pre-`ensureDefaultPlayer` state).
+ */
+export async function requirePlayerId(userId: string): Promise<string> {
+  const cookieValue = (await cookies()).get("x-active-player-id")?.value;
+  if (cookieValue) {
+    const owned = await prisma.player.findFirst({
+      where: { id: cookieValue, userId },
+    });
+    if (owned) return owned.id;
+  }
+  const oldest = await prisma.player.findFirst({
+    where: { userId },
+    orderBy: { createdAt: "asc" },
+  });
+  if (oldest) return oldest.id;
+  redirect("/");
   throw new Error("Redirected");
 }

--- a/src/lib/viewer.test.ts
+++ b/src/lib/viewer.test.ts
@@ -2,23 +2,29 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db";
-import { getViewer } from "@/lib/viewer";
+import { getViewer, getActivePlayerId } from "@/lib/viewer";
+import { cookies } from "next/headers";
 
 vi.mock("@/auth", () => ({ auth: vi.fn() }));
 vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
-vi.mock("@/lib/db", () => ({ prisma: { user: { count: vi.fn() } } }));
+vi.mock("@/lib/db", () => ({ prisma: { user: { count: vi.fn() }, player: { findFirst: vi.fn() } } }));
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
 
 describe("getViewer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: the account named by the cookie still exists.
     vi.mocked(prisma.user.count).mockResolvedValue(1);
+    // Default: no active-player cookie; oldest-player fallback finds p1.
+    vi.mocked(cookies).mockResolvedValue(
+      { get: vi.fn().mockReturnValue(undefined) } as unknown as Awaited<ReturnType<typeof cookies>>);
+    vi.mocked(prisma.player.findFirst).mockResolvedValue({ id: "p1" } as never);
   });
 
   it("reports the signed-in user", async () => {
     vi.mocked(auth).mockResolvedValue({ user: { id: "u1" } } as never);
 
-    expect(await getViewer()).toEqual({ kind: "user", userId: "u1" });
+    expect(await getViewer()).toEqual({ kind: "user", userId: "u1", playerId: "p1" });
   });
 
   it("reports a demo viewer when there is no session", async () => {
@@ -64,5 +70,29 @@ describe("getViewer — a cookie is not proof the account exists", () => {
     await getViewer();
 
     expect(prisma.user.count).not.toHaveBeenCalled();
+  });
+
+  it("getActivePlayerId returns null when cookie absent", async () => {
+    vi.mocked(cookies).mockResolvedValue(
+      { get: vi.fn().mockReturnValue(undefined) } as unknown as Awaited<ReturnType<typeof cookies>>);
+    vi.mocked(prisma.player.findFirst).mockClear();
+
+    expect(await getActivePlayerId("user-1")).toBeNull();
+    expect(prisma.player.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("getActivePlayerId returns playerId when cookie matches owner", async () => {
+    vi.mocked(cookies).mockResolvedValue(
+      { get: vi.fn().mockReturnValue({ value: "player-abc" }) } as unknown as Awaited<ReturnType<typeof cookies>>);
+    vi.mocked(prisma.player.findFirst).mockResolvedValue(
+      { id: "player-abc", userId: "user-1", createdAt: new Date() } as never);
+
+    expect(await getActivePlayerId("user-1")).toBe("player-abc");
+  });
+
+  it("getViewer returns demo when session has no user", async () => {
+    vi.mocked(auth).mockResolvedValue(null as never);
+
+    expect(await getViewer()).toEqual({ kind: "demo" });
   });
 });

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -1,7 +1,10 @@
 import { auth } from "@/auth";
+import { cookies } from "next/headers";
 import { prisma } from "@/lib/db";
 
-export type Viewer = { kind: "user"; userId: string } | { kind: "demo" };
+export type Viewer =
+  | { kind: "user"; userId: string; playerId: string }
+  | { kind: "demo" };
 
 /**
  * Who is looking at this page — a signed-in user, or nobody?
@@ -26,6 +29,32 @@ export async function getViewer(): Promise<Viewer> {
   if (!userId) return { kind: "demo" };
 
   const stillExists = await prisma.user.count({ where: { id: userId } });
+  if (stillExists !== 1) return { kind: "demo" };
 
-  return stillExists === 1 ? { kind: "user", userId } : { kind: "demo" };
+  // Active player: cookie-validated first, oldest player as the fallback.
+  // '' means "no players yet" — the layout's ensureDefaultPlayer closes that
+  // window on the next request.
+  let playerId = await getActivePlayerId(userId);
+  if (playerId === null) {
+    const oldest = await prisma.player.findFirst({
+      where: { userId },
+      orderBy: { createdAt: "asc" },
+    });
+    playerId = oldest?.id ?? "";
+  }
+  return { kind: "user", userId, playerId };
+}
+
+/**
+ * The player named by the `x-active-player-id` cookie, IF this user owns it.
+ * Ownership is validated so a stale or foreign cookie can never select
+ * another account's player. Null when the cookie is absent or invalid.
+ */
+export async function getActivePlayerId(userId: string): Promise<string | null> {
+  const cookieValue = (await cookies()).get("x-active-player-id")?.value;
+  if (!cookieValue) return null;
+  const row = await prisma.player.findFirst({
+    where: { id: cookieValue, userId },
+  });
+  return row?.id ?? null;
 }


### PR DESCRIPTION
Completes the multi-player epic on top of the machine-landed stories (#481/#491/#492/#494 via PRs #498–#501). All 11 remaining stories hand-written red-green on this branch, one commit per story (or per tight pair).

## Stories
- Closes #483 — requirePlayerId tenancy helper (cookie → ownership check → oldest-player fallback → redirect)
- Closes #484 — createPlayer server action, zod name validation, 6-player cap
- Closes #485 — getActivePlayerId + Viewer gains playerId
- Closes #486 — createLane scoped to active player
- Closes #487 — createCheckIn lane lookup scoped to active player
- Closes #488 — dashboard queries by playerId
- Closes #489 — lanes page queries by playerId
- Closes #490 — prize page queries by playerId (+ Prize.playerId @unique schema amendment the ACs' findUnique requires)
- Closes #493 — AppShell playerSwitcher slot, forwarded to SidebarNav
- Closes #482 — layout force-dynamic + ensureDefaultPlayer for signed-in requests
- Closes #495 — layout fetches players, resolves active from cookie, wires PlayerSwitcher

Also includes the planner's epic spec (docs/epics/epic-6-multi-player.md), previously untracked.

## Gates
- tsc clean, eslint 0 errors (130 pre-existing warnings)
- vitest TZ=UTC: 598/598 across 88 files (incl. new layout.test.tsx)
- next build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn