### PR TITLE
CD fix: schema-sync must survive Vercel Sensitive-flagged DATABASE_URL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,9 +38,20 @@ jobs:
         # a column prod's DB never got. Push the schema BEFORE deploying so
         # code and database always move together. Uses the real DATABASE_URL
         # from the pulled Vercel production env, not the placeholder above.
+        env:
+          PROD_DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           pnpm install --frozen-lockfile
           set -a && source .vercel/.env.production.local && set +a
+          # Vercel env vars flagged Sensitive (Neon integration default) pull
+          # as the literal string "[SENSITIVE]" — a repo secret DATABASE_URL
+          # is the source of truth then. Fail loudly rather than hand prisma
+          # a placeholder.
+          if [ -n "$PROD_DATABASE_URL" ]; then export DATABASE_URL="$PROD_DATABASE_URL"; fi
+          if [ "$DATABASE_URL" = "[SENSITIVE]" ]; then
+            echo "DATABASE_URL is Sensitive in Vercel and no DATABASE_URL repo secret is set" >&2
+            exit 1
+          fi
           # NO --skip-generate: Prisma 7 rejects it by printing help and
           # exiting 0 — a silent no-op that would re-plant the outage on the
           # next Prisma upgrade (brownfield-readiness-checklist §4).


### PR DESCRIPTION
Pre-merge validation of the CD pipeline caught this: `vercel pull` writes Sensitive-flagged env vars as the literal string `[SENSITIVE]` — and this repo's DATABASE_URL is Sensitive (Neon integration default). The schema-sync step would have failed with P1013 on the first main deploy. (partner-coach-bot never hit this; its var is non-sensitive.)

Fix: the sync step prefers a `DATABASE_URL` Actions repo secret when present, and exits loudly if it ends up holding the `[SENSITIVE]` placeholder. Verified read-only against prod: `prisma migrate diff` shows exactly the epic's additive DDL (Player table + nullable playerId columns + indexes), so the push is safe.

Requires the `DATABASE_URL` repo secret before release (command in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn