### PR TITLE
Hotfix: vercel-build must not run prisma db push

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",
-    "vercel-build": "prisma generate && prisma db push && next build",
+    "vercel-build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "TZ=Pacific/Kiritimati vitest",


### PR DESCRIPTION
CD's schema-sync step succeeded on the last run — prod DB has the epic-6 schema. The Build step then failed because the legacy `vercel-build` script still ran `prisma db push` at build time (the old git-integration-era sync hack), and CI's build env only has the placeholder DATABASE_URL → P1001. Builds must never mutate a database; the script is now `prisma generate && next build`. Merging re-triggers CD, which should complete: sync (no-op now) → build → deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn