### PR TITLE
Hotfix: Prisma binaryTargets for prebuilt CD deploys

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,8 @@
 generator client {
   provider = "prisma-client-js"
+  // CD builds on the GitHub Ubuntu runner (debian engine) but the app runs
+  // on Vercel's Amazon Linux Lambdas — ship the rhel engine alongside.
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Prod outage: every DB-touching request crashes with PrismaClientInitializationError — the client engine was generated on the GitHub Ubuntu runner (debian-openssl-3.0.x) but Vercel Lambdas require rhel-openssl-3.0.x. The old git-integration flow built ON Vercel so "native" matched; the prebuilt CD flow must pin binaryTargets = ["native", "rhel-openssl-3.0.x"]. Merging re-runs CD and redeploys with the correct engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn