### PR TITLE
feat(#516): Story 7.6: HeaderPlayerChip — chip in header (consumed by 7.7)

### DIFF
--- a/src/components/HeaderPlayerChip.test.tsx
+++ b/src/components/HeaderPlayerChip.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import HeaderPlayerChip from './HeaderPlayerChip'
+
+// Do NOT vi.mock @/lib/playerLevel — pure module(s), no I/O.
+// Render them for real; mocking a collaborator makes the test assert against
+// its own mock and pass whatever the component does.
+
+describe('HeaderPlayerChip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders avatar and name: pass `{ playerId: \'p1\', playerName: \'Alice\', defeats: 15 }`, assert avatar and name text present', async () => {
+    render(<HeaderPlayerChip playerId="p1" playerName="Alice" defeats={15} />)
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    // PlayerAvatar is a child component; we check for its presence via the name prop passed to it
+    // Since we are rendering the real component, we look for the text it renders
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+  })
+
+  it('link destination: render chip, assert wrapper links to `/choose-player`', async () => {
+    render(<HeaderPlayerChip playerId="p1" playerName="Alice" defeats={15} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/choose-player')
+  })
+
+  it('name hidden on mobile: assert name element has class `hidden sm:inline`', async () => {
+    render(<HeaderPlayerChip playerId="p1" playerName="Alice" defeats={15} />)
+    const nameSpan = screen.getByText('Alice')
+    expect(nameSpan).toHaveClass('hidden', 'sm:inline')
+  })
+})

--- a/src/components/HeaderPlayerChip.tsx
+++ b/src/components/HeaderPlayerChip.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import PlayerAvatar from '@/components/PlayerAvatar'
+import { playerLevel } from '@/lib/playerLevel'
+
+interface HeaderPlayerChipProps {
+  playerId: string
+  playerName: string
+  defeats: number
+}
+
+export default function HeaderPlayerChip({
+  playerId,
+  playerName,
+  defeats,
+}: HeaderPlayerChipProps) {
+  const levelData = playerLevel(defeats)
+
+  return (
+    <Link
+      href="/choose-player"
+      className="flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 hover:bg-slate-200 transition-colors"
+    >
+      <PlayerAvatar size={32} level={levelData.level} name={playerName} />
+      <span className="hidden sm:inline text-sm font-medium text-slate-900">
+        {playerName}
+      </span>
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary

Implements story #516: Story 7.6: HeaderPlayerChip — chip in header (consumed by 7.7)

## Verified gates (auto-captured by dag-poc)

- `typecheck` exit 0
- `lint` exit 0
- `build` exit 0

## Implementation provenance

- Model: `spike-coder-v3:latest` (local Ollama)
- LLM calls: 3
- Prompt tokens: 33102
- Output tokens: 1218

Closes #516