### PR TITLE
Epic 7: final three — ManagePanel, tile grid, gate page

### DIFF
--- a/src/app/choose-player/PlayerChooserClient.test.tsx
+++ b/src/app/choose-player/PlayerChooserClient.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PlayerChooserClient from './PlayerChooserClient'
+import { switchPlayer } from '@/app/actions/switchPlayer'
+
+vi.mock('@/app/actions/switchPlayer', () => ({ switchPlayer: vi.fn() }))
+const push = vi.fn()
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push, refresh: vi.fn() }) }))
+
+const players = [
+  { id: 'p1', name: 'Alice', defeats: 0 },
+  { id: 'p2', name: 'Bob', defeats: 9 },
+  { id: 'p3', name: 'Cleo', defeats: 40 },
+]
+
+describe('PlayerChooserClient', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders a tile per player with their name', () => {
+    render(<PlayerChooserClient players={players} manage={false} />)
+    for (const p of players) {
+      expect(screen.getAllByText(p.name).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('switches player and navigates home on tile tap', async () => {
+    vi.mocked(switchPlayer).mockResolvedValue(undefined)
+    render(<PlayerChooserClient players={players} manage={false} />)
+    await userEvent.click(screen.getByRole('button', { name: /Bob/ }))
+    await waitFor(() => expect(switchPlayer).toHaveBeenCalledWith('p2'))
+    expect(push).toHaveBeenCalledWith('/')
+  })
+
+  it('opens the add modal from the plus tile', async () => {
+    render(<PlayerChooserClient players={players} manage={false} />)
+    await userEvent.click(screen.getByRole('button', { name: /add player/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('renders the manage panel instead of the grid in manage mode', () => {
+    render(<PlayerChooserClient players={players} manage={true} />)
+    expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add player/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/app/choose-player/PlayerChooserClient.tsx
+++ b/src/app/choose-player/PlayerChooserClient.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { switchPlayer } from '@/app/actions/switchPlayer'
+import { playerLevel } from '@/lib/playerLevel'
+import PlayerAvatar from '@/components/PlayerAvatar'
+import ChoosePlayerAddModal from '@/components/ChoosePlayerAddModal'
+import ChoosePlayerManagePanel from '@/components/ChoosePlayerManagePanel'
+
+interface PlayerChooserClientProps {
+  players: { id: string; name: string; defeats: number }[]
+  manage: boolean
+}
+
+const PLAYER_CAP = 6
+
+export default function PlayerChooserClient({ players, manage }: PlayerChooserClientProps) {
+  const router = useRouter()
+  const [addOpen, setAddOpen] = useState(false)
+  const [switching, setSwitching] = useState(false)
+
+  if (manage) {
+    return (
+      <ChoosePlayerManagePanel
+        players={players}
+        onManageDone={() => router.push('/choose-player')}
+      />
+    )
+  }
+
+  const pick = async (id: string) => {
+    if (switching) return
+    setSwitching(true)
+    await switchPlayer(id)
+    router.push('/')
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-lg">
+      <h1 className="text-center text-2xl font-semibold text-zinc-100">
+        Who&apos;s grinding today?
+      </h1>
+      <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {players.map((player) => (
+          <button
+            key={player.id}
+            type="button"
+            onClick={() => pick(player.id)}
+            className="flex flex-col items-center gap-2 rounded-2xl border border-zinc-700 bg-zinc-900 p-4 hover:border-emerald-500 transition-colors"
+          >
+            <PlayerAvatar
+              size={96}
+              level={playerLevel(player.defeats).level}
+              name={player.name}
+            />
+            <span className="text-sm font-medium text-zinc-100">{player.name}</span>
+          </button>
+        ))}
+        {players.length < PLAYER_CAP && (
+          <button
+            type="button"
+            onClick={() => setAddOpen(true)}
+            className="flex min-h-[120px] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-zinc-600 p-4 text-zinc-400 hover:border-emerald-500 hover:text-emerald-400 transition-colors"
+          >
+            <span className="text-3xl" aria-hidden>
+              ＋
+            </span>
+            <span className="text-sm">Add player</span>
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => router.push('/choose-player?mode=manage')}
+          className="flex min-h-[120px] flex-col items-center justify-center gap-2 rounded-2xl border border-zinc-700 p-4 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200 transition-colors"
+        >
+          <span className="text-3xl" aria-hidden>
+            ✎
+          </span>
+          <span className="text-sm">Edit</span>
+        </button>
+      </div>
+      <ChoosePlayerAddModal open={addOpen} onClose={() => setAddOpen(false)} />
+    </div>
+  )
+}

--- a/src/app/choose-player/page.test.tsx
+++ b/src/app/choose-player/page.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ChoosePlayerPage from './page'
+import { prisma } from '@/lib/db'
+import { requireUserId } from '@/lib/tenancy'
+
+vi.mock('@/lib/db', () => ({
+  prisma: { player: { findMany: vi.fn() }, bossBattle: { count: vi.fn() } },
+}))
+vi.mock('@/lib/tenancy', () => ({ requireUserId: vi.fn() }))
+vi.mock('@/app/actions/switchPlayer', () => ({ switchPlayer: vi.fn() }))
+vi.mock('@/app/actions/renamePlayer', () => ({ renamePlayer: vi.fn() }))
+vi.mock('@/app/actions/deletePlayer', () => ({ deletePlayer: vi.fn() }))
+vi.mock('@/app/actions/createPlayer', () => ({ createPlayer: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+describe('ChoosePlayerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireUserId).mockResolvedValue('u1')
+    vi.mocked(prisma.player.findMany).mockResolvedValue(
+      [{ id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }] as never)
+    vi.mocked(prisma.bossBattle.count).mockResolvedValue(2 as never)
+  })
+
+  it('renders a tile per fetched player', async () => {
+    render(await ChoosePlayerPage({ searchParams: Promise.resolve({}) }))
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0)
+    expect(prisma.bossBattle.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ lane: { playerId: 'p1' } }) }))
+  })
+
+  it('renders the manage panel when mode=manage', async () => {
+    render(await ChoosePlayerPage({ searchParams: Promise.resolve({ mode: 'manage' }) }))
+    expect(screen.getByRole('button', { name: /done/i })).toBeInTheDocument()
+  })
+})

--- a/src/app/choose-player/page.tsx
+++ b/src/app/choose-player/page.tsx
@@ -1,0 +1,33 @@
+import { prisma } from '@/lib/db';
+import { requireUserId } from '@/lib/tenancy';
+import PlayerChooserClient from './PlayerChooserClient';
+
+// Reads cookies (via requireUserId's session) and the DB on every request.
+export const dynamic = 'force-dynamic';
+
+export default async function ChoosePlayerPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ mode?: string }>;
+}) {
+  const userId = await requireUserId();
+  const players = await prisma.player.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'asc' },
+    select: { id: true, name: true },
+  });
+  // Level = defeated bosses across each player's lanes. Fan-out is fine — the
+  // account cap is 6 players.
+  const playersWithDefeats = await Promise.all(
+    players.map(async (player) => ({
+      ...player,
+      defeats: await prisma.bossBattle.count({
+        where: { completedAt: { not: null }, lane: { playerId: player.id } },
+      }),
+    }))
+  );
+  const { mode } = await searchParams;
+  return (
+    <PlayerChooserClient players={playersWithDefeats} manage={mode === 'manage'} />
+  );
+}

--- a/src/components/ChoosePlayerManagePanel.test.tsx
+++ b/src/components/ChoosePlayerManagePanel.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ChoosePlayerManagePanel from './ChoosePlayerManagePanel'
+import { renamePlayer } from '@/app/actions/renamePlayer'
+import { deletePlayer } from '@/app/actions/deletePlayer'
+
+vi.mock('@/app/actions/renamePlayer', () => ({ renamePlayer: vi.fn() }))
+vi.mock('@/app/actions/deletePlayer', () => ({ deletePlayer: vi.fn() }))
+const refresh = vi.fn()
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh, push: vi.fn() }) }))
+
+const twoPlayers = [
+  { id: 'p1', name: 'Alice' },
+  { id: 'p2', name: 'Bob' },
+]
+
+describe('ChoosePlayerManagePanel', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders a rename and a delete control per player', () => {
+    render(<ChoosePlayerManagePanel players={twoPlayers} onManageDone={vi.fn()} />)
+    expect(screen.getAllByRole('button', { name: /rename/i })).toHaveLength(2)
+    expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(2)
+  })
+
+  it('renames via the action with the typed name', async () => {
+    vi.mocked(renamePlayer).mockResolvedValue({ ok: true })
+    render(<ChoosePlayerManagePanel players={twoPlayers} onManageDone={vi.fn()} />)
+    await userEvent.click(screen.getAllByRole('button', { name: /rename/i })[0])
+    const input = screen.getByDisplayValue('Alice')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Ally')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() => expect(renamePlayer).toHaveBeenCalledWith('p1', 'Ally'))
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('shows the duplicate error inline on rename', async () => {
+    vi.mocked(renamePlayer).mockResolvedValue({ ok: false, error: 'duplicate' })
+    render(<ChoosePlayerManagePanel players={twoPlayers} onManageDone={vi.fn()} />)
+    await userEvent.click(screen.getAllByRole('button', { name: /rename/i })[0])
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(await screen.findByText(/already used/i)).toBeInTheDocument()
+  })
+
+  it('deletes via the action with the typed confirmation', async () => {
+    vi.mocked(deletePlayer).mockResolvedValue({ ok: true })
+    render(<ChoosePlayerManagePanel players={twoPlayers} onManageDone={vi.fn()} />)
+    await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0])
+    await userEvent.type(screen.getByLabelText(/type .* name/i), 'Alice')
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+    await waitFor(() => expect(deletePlayer).toHaveBeenCalledWith('p1', 'Alice'))
+  })
+
+  it('disables delete for the last remaining player', () => {
+    render(<ChoosePlayerManagePanel players={[twoPlayers[0]]} onManageDone={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /delete/i })).toBeDisabled()
+  })
+})

--- a/src/components/ChoosePlayerManagePanel.tsx
+++ b/src/components/ChoosePlayerManagePanel.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { renamePlayer } from '@/app/actions/renamePlayer'
+import { deletePlayer } from '@/app/actions/deletePlayer'
+
+interface ChoosePlayerManagePanelProps {
+  players: { id: string; name: string }[]
+  onManageDone: () => void
+}
+
+const RENAME_ERROR: Record<string, string> = {
+  validation: 'Name is required',
+  duplicate: 'This name is already used',
+  'not-found': 'Player not found',
+}
+
+const DELETE_ERROR: Record<string, string> = {
+  'confirmation-mismatch': "Name doesn't match",
+  'last-player': 'You must have at least one player',
+  'not-found': 'Player not found',
+}
+
+export default function ChoosePlayerManagePanel({
+  players,
+  onManageDone,
+}: ChoosePlayerManagePanelProps) {
+  const router = useRouter()
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [confirmValue, setConfirmValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const lastPlayer = players.length === 1
+  const deleting = players.find((p) => p.id === deletingId)
+
+  const startRename = (id: string, name: string) => {
+    setRenamingId(id)
+    setRenameValue(name)
+    setError(null)
+  }
+
+  const saveRename = async () => {
+    if (!renamingId) return
+    const result = await renamePlayer(renamingId, renameValue)
+    if (result.ok) {
+      setRenamingId(null)
+      setError(null)
+      router.refresh()
+      return
+    }
+    setError(RENAME_ERROR[result.error] ?? 'Something went wrong')
+  }
+
+  const confirmDelete = async () => {
+    if (!deletingId) return
+    const result = await deletePlayer(deletingId, confirmValue)
+    if (result.ok) {
+      setDeletingId(null)
+      setConfirmValue('')
+      setError(null)
+      router.refresh()
+      return
+    }
+    setError(DELETE_ERROR[result.error] ?? 'Something went wrong')
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-md">
+      <h2 className="text-lg font-semibold text-zinc-100">Manage players</h2>
+      <ul className="mt-4 space-y-2">
+        {players.map((player) => (
+          <li
+            key={player.id}
+            className="flex items-center gap-2 rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-3"
+          >
+            {renamingId === player.id ? (
+              <>
+                <input
+                  type="text"
+                  value={renameValue}
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  maxLength={40}
+                  autoFocus
+                  className="w-full rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-zinc-100 focus:border-emerald-500 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={saveRename}
+                  className="rounded bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-500"
+                >
+                  Save
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="flex-1 text-zinc-100">{player.name}</span>
+                <button
+                  type="button"
+                  onClick={() => startRename(player.id, player.name)}
+                  className="rounded px-3 py-1 text-sm text-zinc-300 hover:bg-zinc-800"
+                >
+                  Rename
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDeletingId(player.id)
+                    setConfirmValue('')
+                    setError(null)
+                  }}
+                  disabled={lastPlayer}
+                  title={lastPlayer ? 'You must have at least one player' : undefined}
+                  className="rounded px-3 py-1 text-sm text-red-400 disabled:opacity-40 hover:bg-zinc-800"
+                >
+                  Delete
+                </button>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+      <button
+        type="button"
+        onClick={onManageDone}
+        className="mt-6 rounded px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
+      >
+        Done
+      </button>
+
+      {deleting && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+            onClick={() => setDeletingId(null)}
+          />
+          <div className="relative w-full max-w-sm rounded-2xl border border-zinc-700 bg-zinc-900 p-6">
+            <h3 className="text-lg font-semibold text-zinc-100">
+              Delete {deleting.name}?
+            </h3>
+            <p className="mt-2 text-sm text-zinc-400">
+              This removes all of their lanes and season progress. It cannot be undone.
+            </p>
+            <label htmlFor="confirm-delete" className="mt-4 block text-sm text-zinc-300">
+              Type this player&apos;s name to confirm
+            </label>
+            <input
+              id="confirm-delete"
+              type="text"
+              value={confirmValue}
+              onChange={(e) => setConfirmValue(e.target.value)}
+              className="mt-1 w-full rounded border border-zinc-600 bg-zinc-800 px-3 py-2 text-zinc-100 focus:border-red-500 focus:outline-none"
+            />
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setDeletingId(null)}
+                className="rounded px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmDelete}
+                disabled={confirmValue.length === 0}
+                className="rounded bg-red-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50 hover:bg-red-500"
+              >
+                Confirm delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
The last three stories, hand-written red-green after #515 burned both machine rounds on the stray-slash corruption (a 0-error, 0-warning story — pure decoding noise), blocking the other two behind it.

- Closes #515 — ChoosePlayerManagePanel: inline rename, delete with typed name confirm, last-player guard
- Closes #524 — PlayerChooserClient: "Who's grinding today?" tile grid (earned monster avatars via playerLevel), + tile (hidden at cap 6), Edit tile
- Closes #513 — /choose-player server page: players + defeats fan-out, ?mode=manage toggle, force-dynamic

Gates: tsc clean · eslint 0 errors · vitest TZ=UTC 632/632 · next build green (route ƒ /choose-player present).

This completes epic 7 — every story landed (5 machine + 8 hand-written across the epic). After merge: release to main via CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18cq3QmWBHN6VZowba7Zn